### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/usemoss/moss/security/code-scanning/1](https://github.com/usemoss/moss/security/code-scanning/1)

In general, the fix is to explicitly set a minimal `permissions` block for the workflow or for each job, typically at the top level so it applies to all jobs. For a pure CI workflow that only checks out code and runs lint/type-check commands, `contents: read` is sufficient and aligns with CodeQL’s suggested minimal starting point.

The best fix here is to add a root-level `permissions` section after the `name` declaration in `.github/workflows/ci.yml`, before the `on:` block. This will apply to both `python-lint` and `javascript-lint` jobs, keeping `GITHUB_TOKEN` limited to read-only contents, which is enough for `actions/checkout` to read the repository. No other permissions (like `pull-requests` or `issues`) are required given the current steps. No additional imports or dependencies are needed—this is a YAML-only change.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between lines 1 and 3 (after `name: CI` and the blank line). All existing functionality will remain unchanged; the jobs will still run exactly as before, but with a more restricted token.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
