### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/langchain-release.yml
+++ b/.github/workflows/langchain-release.yml
@@ -10,6 +10,8 @@ concurrency:
 jobs:
   determine-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.compute.outputs.version }}
       major_minor: ${{ steps.compute.outputs.major_minor }}


### PR DESCRIPTION
Potential fix for [https://github.com/usemoss/moss/security/code-scanning/3](https://github.com/usemoss/moss/security/code-scanning/3)

Generally, the problem is fixed by explicitly adding a `permissions` block to the workflow (root-level or per-job) that restricts the GITHUB_TOKEN to the minimum required scopes. Jobs that only need to read the repository (e.g., to check out code, read config files) should usually have `permissions: contents: read`. Jobs that must push tags or otherwise write need `contents: write` (or more granular write scopes) as already done in `build-and-publish`.

For this workflow, the best minimal change is to add a `permissions` block to the `determine-version` job setting `contents: read`, since the job only checks out the repository and reads `pyproject.toml`. We should not change `build-and-publish`, which already has `permissions: contents: write` and needs it to `git push` tags. Concretely, in `.github/workflows/langchain-release.yml`, under `jobs: determine-version: runs-on: ubuntu-latest`, add:

```yaml
    permissions:
      contents: read
```

with indentation matching the existing YAML structure. No new methods, imports, or definitions are required; this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
