### PR TITLE
inferedge-moss==1.0.0b18

### DIFF
--- a/examples/python/requirements.txt
+++ b/examples/python/requirements.txt
@@ -1,3 +1,3 @@
-inferedge-moss>=1.0.0b17
+inferedge-moss==1.0.0b18
 python-dotenv
 openai


### PR DESCRIPTION
Updated the `inferedge-moss` package version from `>=1.0.0b17` to `==1.0.0b18`