### PR TITLE
Potential fix for code scanning alert no. 6: Improper code sanitization

### DIFF
--- a/packages/vitepress-plugin-moss/index.ts
+++ b/packages/vitepress-plugin-moss/index.ts
@@ -10,6 +10,25 @@ export type { MossSearchOptions } from './types.js'
 const debug = createDebug('vitepress:moss-indexer')
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
+const charMap: Record<string, string> = {
+  '<': '\\u003C',
+  '>': '\\u003E',
+  '/': '\\u002F',
+  '\\': '\\\\',
+  '\b': '\\b',
+  '\f': '\\f',
+  '\n': '\\n',
+  '\r': '\\r',
+  '\t': '\\t',
+  '\0': '\\0',
+  '\u2028': '\\u2028',
+  '\u2029': '\\u2029'
+}
+
+function escapeUnsafeChars(str: string): string {
+  return str.replace(/[<>/\\\b\f\n\r\t\0\u2028\u2029]/g, x => charMap[x] ?? x)
+}
+
 export function mossIndexerPlugin(): Plugin {
   const virtualModuleId = 'virtual:moss-config'
   const resolvedVirtualModuleId = '\0' + virtualModuleId
@@ -48,7 +67,7 @@ export function mossIndexerPlugin(): Plugin {
           return 'export default () => ({})'
         }
         const searchOptions = searchConfig.options || {}
-        return `export default () => (${JSON.stringify(searchOptions)})`
+        return `export default () => (${escapeUnsafeChars(JSON.stringify(searchOptions))})`
       }
     },
     async buildEnd() {


### PR DESCRIPTION
Potential fix for [https://github.com/usemoss/moss/security/code-scanning/6](https://github.com/usemoss/moss/security/code-scanning/6)

In general, to fix this type of issue you should avoid directly interpolating raw or only-JSON-stringified values into constructed JavaScript source. Instead, encode them such that any problematic characters (`<`, `>`, `/`, backslashes, control characters, Unicode line separators, etc.) are converted into safe escape sequences, while still yielding a valid JavaScript value when evaluated/imported.

For this specific code, the simplest robust fix is:

1. Add a small helper (e.g., `escapeUnsafeChars`) that applies an extra escaping layer to the string output of `JSON.stringify`, replacing characters that can break out of `<script>` contexts or cause parsing ambiguities, following the pattern from the background example.
2. Use this helper when embedding `JSON.stringify(searchOptions)` into the template literal, so the virtual module source becomes:
   ```ts
   return `export default () => (${escapeUnsafeChars(JSON.stringify(searchOptions))})`
   ```
   This keeps the runtime behavior the same (the exported function still returns the same object) while ensuring the generated module source string never contains raw unsafe characters.
3. Implement `escapeUnsafeChars` and its `charMap` near the top of `packages/vitepress-plugin-moss/index.ts` (after imports), without changing any other logic.

No changes are needed elsewhere; we are only strengthening the sanitization of the string used to construct the virtual module.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
