### PR TITLE
Fix pnpm lockfile specifier for @inferedge/moss

### DIFF
--- a/packages/vitepress-plugin-moss/pnpm-lock.yaml
+++ b/packages/vitepress-plugin-moss/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@inferedge/moss':
-        specifier: ^1.0.0-beta.5
+        specifier: ^1.0.0-beta.7
         version: 1.0.0-beta.7
       '@moss-tools/md-indexer':
         specifier: ^1.0.0-beta.3


### PR DESCRIPTION
## Summary

- Regenerated `packages/vitepress-plugin-moss/pnpm-lock.yaml` so the `@inferedge/moss` specifier matches `package.json` (`^1.0.0-beta.7`)
- The lockfile was stale after #49 bumped the version, causing `pnpm install --frozen-lockfile` to fail in the new `vitepress-plugin-test` CI job
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usemoss/moss/pull/51" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
