### PR TITLE
ci: add Vercel deploy gate script

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [deploy]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   deploy-moss-samples:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `scripts/should-deploy.sh` used by Vercel's Ignored Build Step
- Only allows Vercel builds for direct pushes to `deploy` branch or PRs targeting `deploy`
- Skips all builds on `main` to avoid noisy failed checks on contributor PRs

## Context
External contributor PRs were showing failed Vercel checks (fork auth errors). This script, combined with Vercel project settings, ensures Vercel only builds when deploying via the `deploy` branch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usemoss/moss/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
