### PR TITLE
ci: add pnpm and node setup to Vercel deploy workflow

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -18,6 +18,14 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_MOSS_SAMPLES_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
       - name: Pull Vercel Environment
@@ -50,6 +58,14 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_MOSS_VITEPRESS_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
       - name: Pull Vercel Environment


### PR DESCRIPTION
## Summary
- Adds pnpm and Node.js 22 setup steps to the Vercel deploy workflow
- Fixes `pnpm: not found` error in GitHub Actions runner

Syncing fix from `deploy` branch where this was already verified and deployed successfully.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usemoss/moss/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
