### PR TITLE
feat(moss-cli): add interactive mode for query (#127)

### DIFF
--- a/packages/moss-cli/README.md
+++ b/packages/moss-cli/README.md
@@ -121,6 +121,7 @@ moss query my-index --interactive
 moss query my-index --interactive --top-k 20 --alpha 0.4
 
 # Note: interactive mode is local-only (no --cloud) and not supported with --json
+# Note: with redirected/piped stdin, interactive mode runs the piped query (if provided) and exits
 
 # In interactive prompt:
 #   /set alpha 0.5

--- a/packages/moss-cli/README.md
+++ b/packages/moss-cli/README.md
@@ -120,6 +120,8 @@ moss query my-index --interactive
 # Interactive mode with session defaults
 moss query my-index --interactive --top-k 20 --alpha 0.4
 
+# Note: interactive mode is local-only (no --cloud) and not supported with --json
+
 # In interactive prompt:
 #   /set alpha 0.5
 #   /set top-k 10

--- a/packages/moss-cli/README.md
+++ b/packages/moss-cli/README.md
@@ -114,6 +114,17 @@ moss query my-index "neural networks" --top-k 20 --alpha 0.3
 # Cloud mode (skip download, query via cloud API)
 moss query my-index "transformers" --cloud
 
+# Interactive mode (keeps one loaded index for multiple queries)
+moss query my-index --interactive
+
+# Interactive mode with session defaults
+moss query my-index --interactive --top-k 20 --alpha 0.4
+
+# In interactive prompt:
+#   /set alpha 0.5
+#   /set top-k 10
+#   /exit
+
 # With metadata filter (local only)
 moss query my-index "shoes" --filter '{"field": "category", "condition": {"$eq": "footwear"}}'
 

--- a/packages/moss-cli/src/moss_cli/commands/search.py
+++ b/packages/moss-cli/src/moss_cli/commands/search.py
@@ -63,15 +63,18 @@ def query_command(
     """Query an index. Downloads the index and queries on-device by default. Use --cloud to skip the download and query via the cloud API."""
     json_mode = ctx.obj.get("json_output", False)
 
-    # Resolve query text for non-interactive mode
-    if not interactive and query_text is None:
-        if sys.stdin.isatty():
-            output.print_error("No query provided. Pass as argument or pipe via stdin.", json_mode)
-            raise typer.Exit(1)
+    # Resolve query text from stdin when piped.
+    # In interactive mode this becomes the initial query before entering the prompt loop.
+    if query_text is None and not sys.stdin.isatty():
         query_text = sys.stdin.read().strip()
         if not query_text:
             output.print_error("Empty query from stdin.", json_mode)
             raise typer.Exit(1)
+
+    # Non-interactive mode still requires either arg query or piped stdin input.
+    if not interactive and query_text is None:
+        output.print_error("No query provided. Pass as argument or pipe via stdin.", json_mode)
+        raise typer.Exit(1)
 
     # Parse filter
     parsed_filter = None
@@ -144,7 +147,7 @@ def query_command(
                     continue
                 if line == "/exit":
                     break
-                if line.startswith("/set"):
+                if line == "/set" or line.startswith("/set "):
                     parsed, err = _parse_set_command(line)
                     if err:
                         output.print_error(err, json_mode)

--- a/packages/moss-cli/src/moss_cli/commands/search.py
+++ b/packages/moss-cli/src/moss_cli/commands/search.py
@@ -91,6 +91,18 @@ def query_command(
             json_mode,
         )
         raise typer.Exit(1)
+    if interactive and json_mode:
+        output.print_error(
+            "Interactive mode is not supported with --json. Remove --interactive or --json.",
+            json_mode,
+        )
+        raise typer.Exit(1)
+    if interactive and cloud:
+        output.print_error(
+            "Interactive mode currently supports local queries only. Remove --cloud.",
+            json_mode,
+        )
+        raise typer.Exit(1)
 
     client = MossClient(pid, pkey)
 
@@ -107,7 +119,8 @@ def query_command(
             if not json_mode:
                 console.print(
                     "Interactive mode started. Type queries, [/set alpha <value>], "
-                    "[/set top-k <value>], or [/exit]."
+                    "[/set top-k <value>], or [/exit].",
+                    markup=False,
                 )
                 console.print(
                     f"Session defaults: top-k={current_top_k}, alpha={current_alpha}"
@@ -123,8 +136,8 @@ def query_command(
 
             while True:
                 try:
-                    line = input("moss> ").strip()
-                except EOFError:
+                    line = (await asyncio.to_thread(input, "moss> ")).strip()
+                except (EOFError, KeyboardInterrupt):
                     break
 
                 if not line:

--- a/packages/moss-cli/src/moss_cli/commands/search.py
+++ b/packages/moss-cli/src/moss_cli/commands/search.py
@@ -18,6 +18,33 @@ from ..config import resolve_credentials
 console = Console()
 
 
+def _parse_set_command(line: str) -> tuple[Optional[str], Optional[str]]:
+    parts = line.strip().split()
+    if len(parts) != 3 or parts[0] != "/set":
+        return None, "Usage: /set <alpha|top-k> <value>"
+
+    key = parts[1].lower()
+    if key not in {"alpha", "top-k", "topk"}:
+        return None, "Unknown setting. Supported: alpha, top-k"
+
+    if key == "alpha":
+        try:
+            alpha = float(parts[2])
+        except ValueError:
+            return None, "Invalid alpha. Must be a number between 0.0 and 1.0."
+        if not 0.0 <= alpha <= 1.0:
+            return None, "Invalid alpha. Must be between 0.0 and 1.0."
+        return f"alpha={alpha}", None
+
+    try:
+        top_k = int(parts[2])
+    except ValueError:
+        return None, "Invalid top-k. Must be a positive integer."
+    if top_k < 1:
+        return None, "Invalid top-k. Must be >= 1."
+    return f"top_k={top_k}", None
+
+
 def query_command(
     ctx: typer.Context,
     index_name: str = typer.Argument(..., help="Index name"),
@@ -26,12 +53,18 @@ def query_command(
     alpha: float = typer.Option(0.8, "--alpha", "-a", help="Semantic weight (0.0=keyword, 1.0=semantic)"),
     filter_json: Optional[str] = typer.Option(None, "--filter", help="Metadata filter as JSON string"),
     cloud: bool = typer.Option(False, "--cloud", "-c", help="Query via cloud API instead of downloading the index"),
+    interactive: bool = typer.Option(
+        False,
+        "--interactive",
+        "-i",
+        help="Start interactive query session for multiple queries against one loaded index",
+    ),
 ) -> None:
     """Query an index. Downloads the index and queries on-device by default. Use --cloud to skip the download and query via the cloud API."""
     json_mode = ctx.obj.get("json_output", False)
 
-    # Resolve query text
-    if query_text is None:
+    # Resolve query text for non-interactive mode
+    if not interactive and query_text is None:
         if sys.stdin.isatty():
             output.print_error("No query provided. Pass as argument or pipe via stdin.", json_mode)
             raise typer.Exit(1)
@@ -66,6 +99,61 @@ def query_command(
             if not json_mode:
                 console.print(f"Loading index [cyan]{index_name}[/cyan] locally...")
             await client.load_index(index_name)
+
+        if interactive:
+            current_top_k = top_k
+            current_alpha = alpha
+
+            if not json_mode:
+                console.print(
+                    "Interactive mode started. Type queries, [/set alpha <value>], "
+                    "[/set top-k <value>], or [/exit]."
+                )
+                console.print(
+                    f"Session defaults: top-k={current_top_k}, alpha={current_alpha}"
+                )
+
+            async def run_query(text: str) -> None:
+                options = QueryOptions(top_k=current_top_k, alpha=current_alpha, filter=parsed_filter)
+                result = await client.query(index_name, text, options)
+                output.print_search_results(result, json_mode=json_mode)
+
+            if query_text:
+                await run_query(query_text)
+
+            while True:
+                try:
+                    line = input("moss> ").strip()
+                except EOFError:
+                    break
+
+                if not line:
+                    continue
+                if line == "/exit":
+                    break
+                if line.startswith("/set"):
+                    parsed, err = _parse_set_command(line)
+                    if err:
+                        output.print_error(err, json_mode)
+                        continue
+                    if parsed is None:
+                        output.print_error("Invalid /set command.", json_mode)
+                        continue
+                    if parsed.startswith("alpha="):
+                        current_alpha = float(parsed.split("=", 1)[1])
+                    else:
+                        current_top_k = int(parsed.split("=", 1)[1])
+                    if not json_mode:
+                        console.print(
+                            f"Session defaults updated: top-k={current_top_k}, alpha={current_alpha}"
+                        )
+                    continue
+
+                await run_query(line)
+
+            if not json_mode:
+                console.print("Exiting interactive session.")
+            return
 
         options = QueryOptions(top_k=top_k, alpha=alpha, filter=parsed_filter)
         result = await client.query(index_name, query_text, options)

--- a/packages/moss-cli/src/moss_cli/commands/search.py
+++ b/packages/moss-cli/src/moss_cli/commands/search.py
@@ -139,6 +139,16 @@ def query_command(
             if query_text:
                 await run_query(query_text)
 
+            # When stdin is redirected (non-TTY), an interactive prompt cannot be sustained.
+            # In that case, run any piped initial query and exit with an explicit message.
+            if not sys.stdin.isatty():
+                if not json_mode:
+                    console.print(
+                        "Interactive stdin is not a TTY; exiting after piped input.",
+                        style="yellow",
+                    )
+                return
+
             while True:
                 try:
                     line = (await asyncio.to_thread(input, "moss> ")).strip()

--- a/packages/moss-cli/src/moss_cli/commands/search.py
+++ b/packages/moss-cli/src/moss_cli/commands/search.py
@@ -66,8 +66,10 @@ def query_command(
     # Resolve query text from stdin when piped.
     # In interactive mode this becomes the initial query before entering the prompt loop.
     if query_text is None and not sys.stdin.isatty():
-        query_text = sys.stdin.read().strip()
-        if not query_text:
+        piped_query = sys.stdin.read().strip()
+        if piped_query:
+            query_text = piped_query
+        elif not interactive:
             output.print_error("Empty query from stdin.", json_mode)
             raise typer.Exit(1)
 
@@ -165,7 +167,11 @@ def query_command(
                         )
                     continue
 
-                await run_query(line)
+                try:
+                    await run_query(line)
+                except Exception as e:
+                    output.print_error(f"Query failed: {e}", json_mode)
+                    continue
 
             if not json_mode:
                 console.print("Exiting interactive session.")

--- a/packages/moss-cli/tests/test_search_set_command.py
+++ b/packages/moss-cli/tests/test_search_set_command.py
@@ -1,0 +1,55 @@
+from moss_cli.commands.search import _parse_set_command
+
+
+def test_parse_set_alpha_valid() -> None:
+    parsed, err = _parse_set_command("/set alpha 0.5")
+    assert err is None
+    assert parsed == "alpha=0.5"
+
+
+def test_parse_set_top_k_valid_dash_name() -> None:
+    parsed, err = _parse_set_command("/set top-k 12")
+    assert err is None
+    assert parsed == "top_k=12"
+
+
+def test_parse_set_top_k_valid_compact_name() -> None:
+    parsed, err = _parse_set_command("/set topk 4")
+    assert err is None
+    assert parsed == "top_k=4"
+
+
+def test_parse_set_usage_error_for_wrong_arity() -> None:
+    parsed, err = _parse_set_command("/set alpha")
+    assert parsed is None
+    assert err == "Usage: /set <alpha|top-k> <value>"
+
+
+def test_parse_set_unknown_key_error() -> None:
+    parsed, err = _parse_set_command("/set beta 0.2")
+    assert parsed is None
+    assert err == "Unknown setting. Supported: alpha, top-k"
+
+
+def test_parse_set_alpha_non_numeric_error() -> None:
+    parsed, err = _parse_set_command("/set alpha abc")
+    assert parsed is None
+    assert err == "Invalid alpha. Must be a number between 0.0 and 1.0."
+
+
+def test_parse_set_alpha_out_of_range_error() -> None:
+    parsed, err = _parse_set_command("/set alpha 1.2")
+    assert parsed is None
+    assert err == "Invalid alpha. Must be between 0.0 and 1.0."
+
+
+def test_parse_set_top_k_non_numeric_error() -> None:
+    parsed, err = _parse_set_command("/set top-k abc")
+    assert parsed is None
+    assert err == "Invalid top-k. Must be a positive integer."
+
+
+def test_parse_set_top_k_non_positive_error() -> None:
+    parsed, err = _parse_set_command("/set top-k 0")
+    assert parsed is None
+    assert err == "Invalid top-k. Must be >= 1."


### PR DESCRIPTION
## Pull Request Checklist

-  I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
-  I have updated the documentation (if applicable).
-  My code follows the style guidelines of this project.
-  I have performed a self-review of my own code.


## Description

This PR adds an interactive mode to moss query using a new --interactive flag.

Summary of changes:

Added --interactive support to moss query.
Added a REPL-style prompt loop (moss>) so users can run multiple queries in one session.
Ensured the index is loaded once per interactive session (no repeated download/init for each query).
Added session default controls with:
/set alpha <value>
/set top-k <value>
Added /exit and Ctrl+D handling to end the session cleanly.
Preserved existing non-interactive query behavior.
Updated moss-cli README with interactive usage examples.
Motivation and context:
This improves CLI usability and performance for iterative querying workflows by avoiding repeated setup between queries.


Fixes #127

## Type of Change


-  New feature (non-breaking change which adds functionality)

-  This change requires a documentation update

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usemoss/moss/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
