### PR TITLE
feat(vercel-sdk): add mossLoadIndexTool + update integration status

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ const results = await client.query(name, "your query", { topK: 5 });
 | [LiveKit](https://github.com/livekit/livekit) | Available | [`apps/livekit-moss-vercel/`](apps/livekit-moss-vercel/) |
 | [Next.js](https://nextjs.org) | Available | [`apps/next-js/`](apps/next-js/) |
 | [VitePress](https://vitepress.dev) | Available | [`packages/vitepress-plugin-moss/`](packages/vitepress-plugin-moss/) |
-| [Vercel AI SDK](https://sdk.vercel.ai) | Coming soon | — |
+| [Vercel AI SDK](https://sdk.vercel.ai) | Available | [`packages/vercel-sdk/`](packages/vercel-sdk/) |
 | [CrewAI](https://github.com/crewAIInc/crewAI) | Coming soon | — |
 
 ## Architecture
@@ -280,7 +280,7 @@ Full Python SDK source code is available at [`sdks/python/`](sdks/python/).
 We welcome contributions! Here's where the community can have the most impact:
 
 - **New SDK bindings** — Swift, Go, Elixir,...
-- **Framework integrations** — Vercel AI SDK, CrewAI, Haystack, AutoGen
+- **Framework integrations** — CrewAI, Haystack, AutoGen
 - **Reranking support** — plug in cross-encoder rerankers
 - **Doc-parsing connectors** — PDF, DOCX, HTML, Markdown ingestion
 - **Examples and tutorials** — if you build something with Moss, we'd love to feature it

--- a/packages/vercel-sdk/README.md
+++ b/packages/vercel-sdk/README.md
@@ -39,6 +39,7 @@ const result = await generateText({
 | `mossAddDocsTool` | Add documents to an index | Yes |
 | `mossDeleteDocsTool` | Delete documents by ID | Yes |
 | `mossCreateIndexTool` | Create a new index with documents | Yes |
+| `mossLoadIndexTool` | Load an index into memory for fast local queries | No |
 | `mossListIndexesTool` | List all indexes | No |
 
 Mutating tools set `needsApproval: true` so the AI SDK can prompt for user confirmation.
@@ -50,7 +51,7 @@ All tool factories accept:
 - `client` — a `MossClient` instance (required)
 - `description` — override the default tool description
 
-Search, addDocs, and deleteDocs also accept:
+Search, loadIndex, addDocs, and deleteDocs also accept:
 
 - `indexName` — prebind to a specific index. When omitted, the LLM must specify the index name as part of the tool input.
 
@@ -75,6 +76,7 @@ const search = mossSearchTool({ client });
 ```typescript
 import {
   mossSearchTool,
+  mossLoadIndexTool,
   mossAddDocsTool,
   mossDeleteDocsTool,
   mossCreateIndexTool,
@@ -83,6 +85,7 @@ import {
 
 const tools = {
   search: mossSearchTool({ client, indexName: 'docs' }),
+  loadIndex: mossLoadIndexTool({ client, indexName: 'docs' }),
   addDocs: mossAddDocsTool({ client, indexName: 'docs' }),
   deleteDocs: mossDeleteDocsTool({ client, indexName: 'docs' }),
   createIndex: mossCreateIndexTool({ client }),

--- a/packages/vercel-sdk/src/index.ts
+++ b/packages/vercel-sdk/src/index.ts
@@ -8,6 +8,8 @@ export {
 export {
   mossCreateIndexTool,
   mossListIndexesTool,
+  mossLoadIndexTool,
   type MossCreateIndexToolOptions,
   type MossListIndexesToolOptions,
+  type MossLoadIndexToolOptions,
 } from './tools/indexes.js';

--- a/packages/vercel-sdk/src/tools/indexes.ts
+++ b/packages/vercel-sdk/src/tools/indexes.ts
@@ -60,33 +60,26 @@ export function mossCreateIndexTool(options: MossCreateIndexToolOptions) {
 export function mossLoadIndexTool(options: MossLoadIndexToolOptions) {
   const { client, indexName: boundIndexName, description } = options;
 
+  const baseFields = {
+    autoRefresh: z
+      .boolean()
+      .default(false)
+      .describe('Enable auto-refresh polling to keep the index up-to-date.'),
+    pollingIntervalInSeconds: z
+      .number()
+      .int()
+      .min(60)
+      .optional()
+      .describe('Polling interval in seconds when autoRefresh is enabled (min 60).'),
+  };
+
   const inputSchema = boundIndexName != null
-    ? z.object({
-        autoRefresh: z
-          .boolean()
-          .default(false)
-          .describe('Enable auto-refresh polling to keep the index up-to-date.'),
-        pollingIntervalInSeconds: z
-          .number()
-          .int()
-          .min(60)
-          .optional()
-          .describe('Polling interval in seconds when autoRefresh is enabled (min 60).'),
-      })
+    ? z.object(baseFields)
     : z.object({
         indexName: z
           .string()
           .describe('Name of the index to load into memory.'),
-        autoRefresh: z
-          .boolean()
-          .default(false)
-          .describe('Enable auto-refresh polling to keep the index up-to-date.'),
-        pollingIntervalInSeconds: z
-          .number()
-          .int()
-          .min(60)
-          .optional()
-          .describe('Polling interval in seconds when autoRefresh is enabled (min 60).'),
+        ...baseFields,
       });
 
   return tool({

--- a/packages/vercel-sdk/src/tools/indexes.ts
+++ b/packages/vercel-sdk/src/tools/indexes.ts
@@ -12,6 +12,12 @@ export interface MossListIndexesToolOptions {
   description?: string;
 }
 
+export interface MossLoadIndexToolOptions {
+  client: MossClient;
+  indexName?: string;
+  description?: string;
+}
+
 const docSchema = z.object({
   id: z.string().describe('Unique identifier for the document.'),
   text: z.string().describe('Text content to embed and index.'),
@@ -47,6 +53,59 @@ export function mossCreateIndexTool(options: MossCreateIndexToolOptions) {
       return client.createIndex(input.indexName, input.docs, {
         modelId: input.modelId,
       });
+    },
+  });
+}
+
+export function mossLoadIndexTool(options: MossLoadIndexToolOptions) {
+  const { client, indexName: boundIndexName, description } = options;
+
+  const inputSchema = boundIndexName != null
+    ? z.object({
+        autoRefresh: z
+          .boolean()
+          .default(false)
+          .describe('Enable auto-refresh polling to keep the index up-to-date.'),
+        pollingIntervalInSeconds: z
+          .number()
+          .int()
+          .min(60)
+          .optional()
+          .describe('Polling interval in seconds when autoRefresh is enabled (min 60).'),
+      })
+    : z.object({
+        indexName: z
+          .string()
+          .describe('Name of the index to load into memory.'),
+        autoRefresh: z
+          .boolean()
+          .default(false)
+          .describe('Enable auto-refresh polling to keep the index up-to-date.'),
+        pollingIntervalInSeconds: z
+          .number()
+          .int()
+          .min(60)
+          .optional()
+          .describe('Polling interval in seconds when autoRefresh is enabled (min 60).'),
+      });
+
+  return tool({
+    description:
+      description ??
+      'Load a MOSS index into memory for fast local querying. Without loading, queries go to the cloud API. After loading, queries run in-memory.',
+    inputSchema,
+    execute: async (input) => {
+      const resolvedIndexName =
+        boundIndexName ?? (input as unknown as { indexName: string }).indexName;
+      const opts: Record<string, unknown> = {};
+      if (input.autoRefresh) {
+        opts.autoRefresh = true;
+        if (input.pollingIntervalInSeconds != null) {
+          opts.pollingIntervalInSeconds = input.pollingIntervalInSeconds;
+        }
+      }
+      const loaded = await client.loadIndex(resolvedIndexName, opts);
+      return { indexName: loaded, status: 'loaded' };
     },
   });
 }

--- a/packages/vercel-sdk/test/indexes.test.ts
+++ b/packages/vercel-sdk/test/indexes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { mossCreateIndexTool, mossListIndexesTool } from '../src/tools/indexes.js';
+import { mossCreateIndexTool, mossListIndexesTool, mossLoadIndexTool } from '../src/tools/indexes.js';
 
 function createMockClient() {
   return {
@@ -85,5 +85,66 @@ describe('mossListIndexesTool', () => {
     const tool = mossListIndexesTool({ client, description: 'Custom list' });
 
     expect(tool.description).toBe('Custom list');
+  });
+});
+
+describe('mossLoadIndexTool', () => {
+  it('creates a tool with correct description', () => {
+    const client = createMockClient();
+    const tool = mossLoadIndexTool({ client });
+
+    expect(tool.description).toContain('Load a MOSS index');
+    expect(tool.inputSchema).toBeDefined();
+  });
+
+  it('executes with indexName from input', async () => {
+    const client = createMockClient();
+    client.loadIndex.mockResolvedValue('my-index');
+    const tool = mossLoadIndexTool({ client });
+
+    const result = await tool.execute!(
+      { indexName: 'my-index', autoRefresh: false },
+      toolCallContext,
+    );
+
+    expect(client.loadIndex).toHaveBeenCalledWith('my-index', {});
+    expect(result).toEqual({ indexName: 'my-index', status: 'loaded' });
+  });
+
+  it('uses bound indexName when provided', async () => {
+    const client = createMockClient();
+    client.loadIndex.mockResolvedValue('bound-index');
+    const tool = mossLoadIndexTool({ client, indexName: 'bound-index' });
+
+    const result = await tool.execute!(
+      { autoRefresh: false },
+      toolCallContext,
+    );
+
+    expect(client.loadIndex).toHaveBeenCalledWith('bound-index', {});
+    expect(result).toEqual({ indexName: 'bound-index', status: 'loaded' });
+  });
+
+  it('passes autoRefresh and pollingIntervalInSeconds', async () => {
+    const client = createMockClient();
+    client.loadIndex.mockResolvedValue('my-index');
+    const tool = mossLoadIndexTool({ client });
+
+    await tool.execute!(
+      { indexName: 'my-index', autoRefresh: true, pollingIntervalInSeconds: 120 },
+      toolCallContext,
+    );
+
+    expect(client.loadIndex).toHaveBeenCalledWith('my-index', {
+      autoRefresh: true,
+      pollingIntervalInSeconds: 120,
+    });
+  });
+
+  it('accepts a custom description', () => {
+    const client = createMockClient();
+    const tool = mossLoadIndexTool({ client, description: 'Custom load' });
+
+    expect(tool.description).toBe('Custom load');
   });
 });


### PR DESCRIPTION
## Summary
- Adds `mossLoadIndexTool` to `@moss-tools/vercel-sdk` enabling AI agents to load indexes into memory for fast local querying (sub-10ms) instead of cloud API round-trips
- Supports optional `indexName` binding, `autoRefresh`, and `pollingIntervalInSeconds` options
- Updates README integrations table to mark Vercel AI SDK as Available

## Test plan
- [x] Unit tests added (5 new tests covering description, input/bound indexName, autoRefresh options, custom description)
- [x] All 26 existing tests pass
- [x] Verified end-to-end against live Moss API with `demo-customer_faqs` index — confirmed 0ms local query after load
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usemoss/moss/pull/133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
