### PR TITLE
feat: add unified release script for all packages

### DIFF
--- a/.github/workflows/publish-elevenlabs-moss.yml
+++ b/.github/workflows/publish-elevenlabs-moss.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish-elevenlabs-moss.yml
+++ b/.github/workflows/publish-elevenlabs-moss.yml
@@ -1,5 +1,8 @@
 name: Publish elevenlabs-moss
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/publish-elevenlabs-moss.yml
+++ b/.github/workflows/publish-elevenlabs-moss.yml
@@ -1,0 +1,108 @@
+name: Publish elevenlabs-moss
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: elevenlabs-moss-release
+  cancel-in-progress: false
+
+jobs:
+  determine-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Read version from pyproject
+        id: compute
+        shell: python
+        run: |
+          import os, pathlib, re, sys
+
+          text = pathlib.Path("packages/elevenlabs-moss/pyproject.toml").read_text(encoding="utf-8")
+          match = re.search(r'(?m)^version\s*=\s*"([^"]+)"', text)
+          if not match:
+              print("Could not find version in pyproject", file=sys.stderr)
+              sys.exit(1)
+          version = match.group(1)
+
+          out = pathlib.Path(os.environ["GITHUB_OUTPUT"])
+          with out.open("a", encoding="utf-8") as fh:
+              fh.write(f"version={version}\n")
+
+          print(f"Publishing version: {version}")
+
+  build-and-publish:
+    needs: determine-version
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.11", "3.12", "3.13"]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.determine-version.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build distributions
+        working-directory: packages/elevenlabs-moss
+        run: |
+          rm -rf dist
+          python -m build
+
+      - name: Smoke test import
+        shell: python
+        run: |
+          import glob, subprocess, sys
+
+          wheels = glob.glob("packages/elevenlabs-moss/dist/*.whl")
+          if not wheels:
+              raise SystemExit("No wheel found in dist/")
+
+          wheel = wheels[0]
+          subprocess.check_call([sys.executable, "-m", "pip", "install", "--force-reinstall", wheel])
+
+          import importlib
+          module = importlib.import_module("elevenlabs_moss")
+          print("import ok; sample attrs:", dir(module)[:5])
+
+      - name: Publish to PyPI
+        if: matrix.python == '3.11'
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          twine upload --skip-existing packages/elevenlabs-moss/dist/*
+
+      - name: Tag release
+        if: matrix.python == '3.11'
+        env:
+          VERSION: ${{ env.VERSION }}
+        run: |
+          git fetch --tags --force
+          if git rev-parse "elevenlabs-moss-v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag elevenlabs-moss-v${VERSION} already exists"
+          else
+            git config user.name "github-actions"
+            git config user.email "github-actions@users.noreply.github.com"
+            git tag "elevenlabs-moss-v${VERSION}"
+            git push origin "elevenlabs-moss-v${VERSION}"
+          fi

--- a/.github/workflows/publish-moss-cli.yml
+++ b/.github/workflows/publish-moss-cli.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish-moss-cli.yml
+++ b/.github/workflows/publish-moss-cli.yml
@@ -1,5 +1,8 @@
 name: Publish moss-cli
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/publish-moss-cli.yml
+++ b/.github/workflows/publish-moss-cli.yml
@@ -1,0 +1,108 @@
+name: Publish moss-cli
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: moss-cli-release
+  cancel-in-progress: false
+
+jobs:
+  determine-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Read version from pyproject
+        id: compute
+        shell: python
+        run: |
+          import os, pathlib, re, sys
+
+          text = pathlib.Path("packages/moss-cli/pyproject.toml").read_text(encoding="utf-8")
+          match = re.search(r'(?m)^version\s*=\s*"([^"]+)"', text)
+          if not match:
+              print("Could not find version in pyproject", file=sys.stderr)
+              sys.exit(1)
+          version = match.group(1)
+
+          out = pathlib.Path(os.environ["GITHUB_OUTPUT"])
+          with out.open("a", encoding="utf-8") as fh:
+              fh.write(f"version={version}\n")
+
+          print(f"Publishing version: {version}")
+
+  build-and-publish:
+    needs: determine-version
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.11", "3.12", "3.13"]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.determine-version.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build distributions
+        working-directory: packages/moss-cli
+        run: |
+          rm -rf dist
+          python -m build
+
+      - name: Smoke test import
+        shell: python
+        run: |
+          import glob, subprocess, sys
+
+          wheels = glob.glob("packages/moss-cli/dist/*.whl")
+          if not wheels:
+              raise SystemExit("No wheel found in dist/")
+
+          wheel = wheels[0]
+          subprocess.check_call([sys.executable, "-m", "pip", "install", "--force-reinstall", wheel])
+
+          import importlib
+          module = importlib.import_module("moss_cli")
+          print("import ok; sample attrs:", dir(module)[:5])
+
+      - name: Publish to PyPI
+        if: matrix.python == '3.11'
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          twine upload --skip-existing packages/moss-cli/dist/*
+
+      - name: Tag release
+        if: matrix.python == '3.11'
+        env:
+          VERSION: ${{ env.VERSION }}
+        run: |
+          git fetch --tags --force
+          if git rev-parse "moss-cli-v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag moss-cli-v${VERSION} already exists"
+          else
+            git config user.name "github-actions"
+            git config user.email "github-actions@users.noreply.github.com"
+            git tag "moss-cli-v${VERSION}"
+            git push origin "moss-cli-v${VERSION}"
+          fi

--- a/.github/workflows/publish-moss-md-indexer.yml
+++ b/.github/workflows/publish-moss-md-indexer.yml
@@ -1,0 +1,88 @@
+name: Publish moss-md-indexer
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: moss-md-indexer-release
+  cancel-in-progress: false
+
+jobs:
+  determine-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Get version from package.json
+        id: compute
+        shell: bash
+        run: |
+          cd packages/moss-md-indexer
+          VERSION=$(node -p "require('./package.json').version")
+
+          if [[ -z "$VERSION" || "$VERSION" == "undefined" ]]; then
+            echo "Could not read version from package.json" >&2
+            exit 1
+          fi
+
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Publishing version: $VERSION"
+
+  build-and-publish:
+    needs: determine-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    env:
+      PKG_DIR: packages/moss-md-indexer
+      VERSION: ${{ needs.determine-version.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
+          cache-dependency-path: ${{ env.PKG_DIR }}/pnpm-lock.yaml
+
+      - name: Show version to be published
+        run: echo "Publishing version ${{ env.VERSION }}"
+
+      - name: Install dependencies
+        working-directory: ${{ env.PKG_DIR }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package
+        working-directory: ${{ env.PKG_DIR }}
+        run: pnpm build
+
+      - name: Publish to npm
+        working-directory: ${{ env.PKG_DIR }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: pnpm publish --no-git-checks --access public
+
+      - name: Tag release
+        env:
+          VERSION: ${{ env.VERSION }}
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@users.noreply.github.com"
+          git tag "moss-md-indexer-v${VERSION}"
+          git push origin "moss-md-indexer-v${VERSION}"

--- a/.github/workflows/publish-pipecat-moss.yml
+++ b/.github/workflows/publish-pipecat-moss.yml
@@ -1,5 +1,8 @@
 name: Publish pipecat-moss
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 
@@ -56,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish-strands-agents-moss.yml
+++ b/.github/workflows/publish-strands-agents-moss.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish-strands-agents-moss.yml
+++ b/.github/workflows/publish-strands-agents-moss.yml
@@ -1,0 +1,108 @@
+name: Publish strands-agents-moss
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: strands-agents-moss-release
+  cancel-in-progress: false
+
+jobs:
+  determine-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Read version from pyproject
+        id: compute
+        shell: python
+        run: |
+          import os, pathlib, re, sys
+
+          text = pathlib.Path("packages/strands-agents-moss/pyproject.toml").read_text(encoding="utf-8")
+          match = re.search(r'(?m)^version\s*=\s*"([^"]+)"', text)
+          if not match:
+              print("Could not find version in pyproject", file=sys.stderr)
+              sys.exit(1)
+          version = match.group(1)
+
+          out = pathlib.Path(os.environ["GITHUB_OUTPUT"])
+          with out.open("a", encoding="utf-8") as fh:
+              fh.write(f"version={version}\n")
+
+          print(f"Publishing version: {version}")
+
+  build-and-publish:
+    needs: determine-version
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.11", "3.12", "3.13"]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.determine-version.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build distributions
+        working-directory: packages/strands-agents-moss
+        run: |
+          rm -rf dist
+          python -m build
+
+      - name: Smoke test import
+        shell: python
+        run: |
+          import glob, subprocess, sys
+
+          wheels = glob.glob("packages/strands-agents-moss/dist/*.whl")
+          if not wheels:
+              raise SystemExit("No wheel found in dist/")
+
+          wheel = wheels[0]
+          subprocess.check_call([sys.executable, "-m", "pip", "install", "--force-reinstall", wheel])
+
+          import importlib
+          module = importlib.import_module("strands_agents_moss")
+          print("import ok; sample attrs:", dir(module)[:5])
+
+      - name: Publish to PyPI
+        if: matrix.python == '3.11'
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          twine upload --skip-existing packages/strands-agents-moss/dist/*
+
+      - name: Tag release
+        if: matrix.python == '3.11'
+        env:
+          VERSION: ${{ env.VERSION }}
+        run: |
+          git fetch --tags --force
+          if git rev-parse "strands-agents-moss-v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag strands-agents-moss-v${VERSION} already exists"
+          else
+            git config user.name "github-actions"
+            git config user.email "github-actions@users.noreply.github.com"
+            git tag "strands-agents-moss-v${VERSION}"
+            git push origin "strands-agents-moss-v${VERSION}"
+          fi

--- a/.github/workflows/publish-strands-agents-moss.yml
+++ b/.github/workflows/publish-strands-agents-moss.yml
@@ -1,5 +1,8 @@
 name: Publish strands-agents-moss
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/publish-vapi-moss.yml
+++ b/.github/workflows/publish-vapi-moss.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish-vapi-moss.yml
+++ b/.github/workflows/publish-vapi-moss.yml
@@ -1,0 +1,108 @@
+name: Publish vapi-moss
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: vapi-moss-release
+  cancel-in-progress: false
+
+jobs:
+  determine-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Read version from pyproject
+        id: compute
+        shell: python
+        run: |
+          import os, pathlib, re, sys
+
+          text = pathlib.Path("packages/vapi-moss/pyproject.toml").read_text(encoding="utf-8")
+          match = re.search(r'(?m)^version\s*=\s*"([^"]+)"', text)
+          if not match:
+              print("Could not find version in pyproject", file=sys.stderr)
+              sys.exit(1)
+          version = match.group(1)
+
+          out = pathlib.Path(os.environ["GITHUB_OUTPUT"])
+          with out.open("a", encoding="utf-8") as fh:
+              fh.write(f"version={version}\n")
+
+          print(f"Publishing version: {version}")
+
+  build-and-publish:
+    needs: determine-version
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.11", "3.12", "3.13"]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.determine-version.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build distributions
+        working-directory: packages/vapi-moss
+        run: |
+          rm -rf dist
+          python -m build
+
+      - name: Smoke test import
+        shell: python
+        run: |
+          import glob, subprocess, sys
+
+          wheels = glob.glob("packages/vapi-moss/dist/*.whl")
+          if not wheels:
+              raise SystemExit("No wheel found in dist/")
+
+          wheel = wheels[0]
+          subprocess.check_call([sys.executable, "-m", "pip", "install", "--force-reinstall", wheel])
+
+          import importlib
+          module = importlib.import_module("vapi_moss")
+          print("import ok; sample attrs:", dir(module)[:5])
+
+      - name: Publish to PyPI
+        if: matrix.python == '3.11'
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          twine upload --skip-existing packages/vapi-moss/dist/*
+
+      - name: Tag release
+        if: matrix.python == '3.11'
+        env:
+          VERSION: ${{ env.VERSION }}
+        run: |
+          git fetch --tags --force
+          if git rev-parse "vapi-moss-v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag vapi-moss-v${VERSION} already exists"
+          else
+            git config user.name "github-actions"
+            git config user.email "github-actions@users.noreply.github.com"
+            git tag "vapi-moss-v${VERSION}"
+            git push origin "vapi-moss-v${VERSION}"
+          fi

--- a/.github/workflows/publish-vapi-moss.yml
+++ b/.github/workflows/publish-vapi-moss.yml
@@ -1,5 +1,8 @@
 name: Publish vapi-moss
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -123,7 +123,7 @@ release_npm() {
   cd "$pkg_dir" || return 1
 
   # Install dependencies
-  if [[ -f "pnpm-lock.yaml" ]]; then
+  if [[ -f "pnpm-lock.yaml" ]] && command -v pnpm &>/dev/null; then
     { pnpm install --frozen-lockfile 2>/dev/null || pnpm install; } || return 1
   elif [[ -f "package-lock.json" ]]; then
     { npm ci 2>/dev/null || npm install; } || return 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -57,6 +57,12 @@ preflight() {
     ok "node $(node --version)"
   fi
 
+  if ! command -v pnpm &>/dev/null; then
+    warn "pnpm not found — packages with pnpm-lock.yaml will fall back to npm"
+  else
+    ok "pnpm $(pnpm --version)"
+  fi
+
   if ! command -v python3 &>/dev/null; then
     fail "python3 not found"; missing=1
   else
@@ -68,13 +74,21 @@ preflight() {
       fail "Neither uv nor pip found — need one for Python builds"; missing=1
     else
       ok "pip $(pip --version | awk '{print $2}')"
+
+      if python3 -m build --version &>/dev/null; then
+        ok "python3 -m build available"
+      else
+        fail "Python 'build' module not found — install with: pip install build"; missing=1
+      fi
+
+      if python3 -m twine --version &>/dev/null; then
+        ok "python3 -m twine available"
+      else
+        fail "Python 'twine' module not found — install with: pip install twine"; missing=1
+      fi
     fi
   else
     ok "uv $(uv --version 2>&1 | awk '{print $2}')"
-  fi
-
-  if ! command -v twine &>/dev/null && ! command -v uv &>/dev/null; then
-    warn "twine not found — will try 'uv publish' or 'python3 -m twine'"
   fi
 
   # Check npm auth
@@ -99,37 +113,37 @@ release_npm() {
   local pkg_name
   pkg_name=$(basename "$pkg_dir")
   local full_name
-  full_name=$(node -p "require('$pkg_dir/package.json').name")
+  full_name=$(node -p "require('$pkg_dir/package.json').name") || return 1
   local version
-  version=$(node -p "require('$pkg_dir/package.json').version")
+  version=$(node -p "require('$pkg_dir/package.json').version") || return 1
 
   hr
   log "Publishing ${full_name}@${version} to npm"
 
-  cd "$pkg_dir"
+  cd "$pkg_dir" || return 1
 
   # Install dependencies
   if [[ -f "pnpm-lock.yaml" ]]; then
-    pnpm install --frozen-lockfile 2>/dev/null || pnpm install
+    { pnpm install --frozen-lockfile 2>/dev/null || pnpm install; } || return 1
   elif [[ -f "package-lock.json" ]]; then
-    npm ci 2>/dev/null || npm install
+    { npm ci 2>/dev/null || npm install; } || return 1
   else
-    npm install
+    npm install || return 1
   fi
 
   # Build
   if node -p "require('./package.json').scripts?.build" 2>/dev/null | grep -qv "undefined"; then
     log "  Building..."
-    npm run build
+    npm run build || return 1
   fi
 
   # Publish
   if [[ "$DRY_RUN" == "true" ]]; then
     log "  [DRY RUN] Would publish ${full_name}@${version}"
-    npm pack --dry-run
+    npm pack --dry-run || return 1
     ok "Dry run complete for ${full_name}"
   else
-    npm publish --access public
+    npm publish --access public || return 1
     ok "Published ${full_name}@${version}"
   fi
 
@@ -143,23 +157,31 @@ release_pypi() {
   local pkg_dir="$1"
   local pkg_name
   pkg_name=$(python3 -c "
-import tomllib, pathlib
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+import pathlib
 p = pathlib.Path('$pkg_dir/pyproject.toml')
 d = tomllib.loads(p.read_text())
 print(d['project']['name'])
-")
+") || return 1
   local version
   version=$(python3 -c "
-import tomllib, pathlib
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+import pathlib
 p = pathlib.Path('$pkg_dir/pyproject.toml')
 d = tomllib.loads(p.read_text())
 print(d['project']['version'])
-")
+") || return 1
 
   hr
   log "Publishing ${pkg_name}==${version} to PyPI"
 
-  cd "$pkg_dir"
+  cd "$pkg_dir" || return 1
 
   # Clean previous builds
   rm -rf dist/ build/ *.egg-info src/*.egg-info
@@ -167,9 +189,9 @@ print(d['project']['version'])
   # Build
   log "  Building sdist + wheel..."
   if command -v uv &>/dev/null; then
-    uv build
+    uv build || return 1
   else
-    python3 -m build
+    python3 -m build || return 1
   fi
 
   # Publish
@@ -179,11 +201,11 @@ print(d['project']['version'])
     ok "Dry run complete for ${pkg_name}"
   else
     if command -v uv &>/dev/null; then
-      uv publish
+      uv publish || return 1
     elif command -v twine &>/dev/null; then
-      twine upload dist/*
+      twine upload dist/* || return 1
     else
-      python3 -m twine upload dist/*
+      python3 -m twine upload dist/* || return 1
     fi
     ok "Published ${pkg_name}==${version}"
   fi
@@ -248,18 +270,22 @@ do_pypi=()
 if [[ ${#SELECTED_PACKAGES[@]} -gt 0 ]]; then
   for sel in "${SELECTED_PACKAGES[@]}"; do
     matched=false
-    for np in "${NPM_PACKAGES[@]}"; do
-      if [[ "$np" == "$sel" ]]; then
-        do_npm+=("$np")
-        matched=true
-      fi
-    done
-    for pp in "${PYPI_PACKAGES[@]}"; do
-      if [[ "$pp" == "$sel" ]]; then
-        do_pypi+=("$pp")
-        matched=true
-      fi
-    done
+    if [[ "$PYPI_ONLY" != "true" ]]; then
+      for np in "${NPM_PACKAGES[@]}"; do
+        if [[ "$np" == "$sel" ]]; then
+          do_npm+=("$np")
+          matched=true
+        fi
+      done
+    fi
+    if [[ "$NPM_ONLY" != "true" ]]; then
+      for pp in "${PYPI_PACKAGES[@]}"; do
+        if [[ "$pp" == "$sel" ]]; then
+          do_pypi+=("$pp")
+          matched=true
+        fi
+      done
+    fi
     if [[ "$matched" == "false" ]]; then
       fail "Unknown package: $sel"
       exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+PACKAGES_DIR="$ROOT_DIR/packages"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+
+NPM_PACKAGES=(
+  "moss-md-indexer"
+  "vercel-sdk"
+  "vitepress-plugin-moss"
+)
+
+PYPI_PACKAGES=(
+  "elevenlabs-moss"
+  "moss-cli"
+  "pipecat-moss"
+  "strands-agents-moss"
+  "vapi-moss"
+)
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+log()   { echo -e "${BLUE}[release]${NC} $*"; }
+ok()    { echo -e "${GREEN}  ✓${NC} $*"; }
+warn()  { echo -e "${YELLOW}  ⚠${NC} $*"; }
+fail()  { echo -e "${RED}  ✗${NC} $*"; }
+hr()    { echo -e "${BLUE}─────────────────────────────────────────────────${NC}"; }
+
+FAILED=()
+SUCCEEDED=()
+
+# ── Preflight checks ──────────────────────────────────────────────────────────
+
+preflight() {
+  log "Running preflight checks..."
+  local missing=0
+
+  if ! command -v npm &>/dev/null; then
+    fail "npm not found"; missing=1
+  else
+    ok "npm $(npm --version)"
+  fi
+
+  if ! command -v node &>/dev/null; then
+    fail "node not found"; missing=1
+  else
+    ok "node $(node --version)"
+  fi
+
+  if ! command -v python3 &>/dev/null; then
+    fail "python3 not found"; missing=1
+  else
+    ok "python3 $(python3 --version 2>&1 | awk '{print $2}')"
+  fi
+
+  if ! command -v uv &>/dev/null; then
+    if ! command -v pip &>/dev/null; then
+      fail "Neither uv nor pip found — need one for Python builds"; missing=1
+    else
+      ok "pip $(pip --version | awk '{print $2}')"
+    fi
+  else
+    ok "uv $(uv --version 2>&1 | awk '{print $2}')"
+  fi
+
+  if ! command -v twine &>/dev/null && ! command -v uv &>/dev/null; then
+    warn "twine not found — will try 'uv publish' or 'python3 -m twine'"
+  fi
+
+  # Check npm auth
+  if npm whoami &>/dev/null 2>&1; then
+    ok "npm authenticated as $(npm whoami)"
+  else
+    warn "npm not authenticated — npm publish will prompt or fail"
+  fi
+
+  if [[ $missing -eq 1 ]]; then
+    fail "Missing required tools. Aborting."
+    exit 1
+  fi
+
+  echo ""
+}
+
+# ── npm package release ───────────────────────────────────────────────────────
+
+release_npm() {
+  local pkg_dir="$1"
+  local pkg_name
+  pkg_name=$(basename "$pkg_dir")
+  local full_name
+  full_name=$(node -p "require('$pkg_dir/package.json').name")
+  local version
+  version=$(node -p "require('$pkg_dir/package.json').version")
+
+  hr
+  log "Publishing ${full_name}@${version} to npm"
+
+  cd "$pkg_dir"
+
+  # Install dependencies
+  if [[ -f "pnpm-lock.yaml" ]]; then
+    pnpm install --frozen-lockfile 2>/dev/null || pnpm install
+  elif [[ -f "package-lock.json" ]]; then
+    npm ci 2>/dev/null || npm install
+  else
+    npm install
+  fi
+
+  # Build
+  if node -p "require('./package.json').scripts?.build" 2>/dev/null | grep -qv "undefined"; then
+    log "  Building..."
+    npm run build
+  fi
+
+  # Publish
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log "  [DRY RUN] Would publish ${full_name}@${version}"
+    npm pack --dry-run
+    ok "Dry run complete for ${full_name}"
+  else
+    npm publish --access public
+    ok "Published ${full_name}@${version}"
+  fi
+
+  SUCCEEDED+=("${full_name}@${version}")
+  cd "$ROOT_DIR"
+}
+
+# ── PyPI package release ──────────────────────────────────────────────────────
+
+release_pypi() {
+  local pkg_dir="$1"
+  local pkg_name
+  pkg_name=$(python3 -c "
+import tomllib, pathlib
+p = pathlib.Path('$pkg_dir/pyproject.toml')
+d = tomllib.loads(p.read_text())
+print(d['project']['name'])
+")
+  local version
+  version=$(python3 -c "
+import tomllib, pathlib
+p = pathlib.Path('$pkg_dir/pyproject.toml')
+d = tomllib.loads(p.read_text())
+print(d['project']['version'])
+")
+
+  hr
+  log "Publishing ${pkg_name}==${version} to PyPI"
+
+  cd "$pkg_dir"
+
+  # Clean previous builds
+  rm -rf dist/ build/ *.egg-info src/*.egg-info
+
+  # Build
+  log "  Building sdist + wheel..."
+  if command -v uv &>/dev/null; then
+    uv build
+  else
+    python3 -m build
+  fi
+
+  # Publish
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log "  [DRY RUN] Would publish ${pkg_name}==${version}"
+    ls -lh dist/
+    ok "Dry run complete for ${pkg_name}"
+  else
+    if command -v uv &>/dev/null; then
+      uv publish
+    elif command -v twine &>/dev/null; then
+      twine upload dist/*
+    else
+      python3 -m twine upload dist/*
+    fi
+    ok "Published ${pkg_name}==${version}"
+  fi
+
+  SUCCEEDED+=("${pkg_name}==${version}")
+  cd "$ROOT_DIR"
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS] [PACKAGE...]
+
+Release Moss packages to npm and PyPI.
+
+Options:
+  --dry-run       Build and pack without publishing
+  --npm-only      Only release npm packages
+  --pypi-only     Only release PyPI packages
+  --help          Show this help
+
+Packages:
+  If no packages specified, all packages are released.
+  Specify package directory names to release selectively:
+    $(basename "$0") vercel-sdk moss-cli
+
+Examples:
+  $(basename "$0") --dry-run                    # Dry run all packages
+  $(basename "$0") vercel-sdk                   # Release only vercel-sdk
+  $(basename "$0") --pypi-only --dry-run        # Dry run all Python packages
+EOF
+}
+
+DRY_RUN="false"
+NPM_ONLY="false"
+PYPI_ONLY="false"
+SELECTED_PACKAGES=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)   DRY_RUN="true"; shift ;;
+    --npm-only)  NPM_ONLY="true"; shift ;;
+    --pypi-only) PYPI_ONLY="true"; shift ;;
+    --help|-h)   usage; exit 0 ;;
+    -*)          fail "Unknown option: $1"; usage; exit 1 ;;
+    *)           SELECTED_PACKAGES+=("$1"); shift ;;
+  esac
+done
+
+echo ""
+log "Moss Package Release"
+[[ "$DRY_RUN" == "true" ]] && warn "DRY RUN MODE — nothing will be published"
+echo ""
+
+preflight
+
+# Determine which packages to release
+do_npm=()
+do_pypi=()
+
+if [[ ${#SELECTED_PACKAGES[@]} -gt 0 ]]; then
+  for sel in "${SELECTED_PACKAGES[@]}"; do
+    matched=false
+    for np in "${NPM_PACKAGES[@]}"; do
+      if [[ "$np" == "$sel" ]]; then
+        do_npm+=("$np")
+        matched=true
+      fi
+    done
+    for pp in "${PYPI_PACKAGES[@]}"; do
+      if [[ "$pp" == "$sel" ]]; then
+        do_pypi+=("$pp")
+        matched=true
+      fi
+    done
+    if [[ "$matched" == "false" ]]; then
+      fail "Unknown package: $sel"
+      exit 1
+    fi
+  done
+else
+  if [[ "$PYPI_ONLY" != "true" ]]; then
+    do_npm=("${NPM_PACKAGES[@]}")
+  fi
+  if [[ "$NPM_ONLY" != "true" ]]; then
+    do_pypi=("${PYPI_PACKAGES[@]}")
+  fi
+fi
+
+# Release npm packages
+for pkg in "${do_npm[@]}"; do
+  if ! release_npm "$PACKAGES_DIR/$pkg"; then
+    fail "Failed to release $pkg"
+    FAILED+=("$pkg")
+  fi
+done
+
+# Release PyPI packages
+for pkg in "${do_pypi[@]}"; do
+  if ! release_pypi "$PACKAGES_DIR/$pkg"; then
+    fail "Failed to release $pkg"
+    FAILED+=("$pkg")
+  fi
+done
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+hr
+log "Release Summary"
+echo ""
+
+if [[ ${#SUCCEEDED[@]} -gt 0 ]]; then
+  ok "Released (${#SUCCEEDED[@]}):"
+  for s in "${SUCCEEDED[@]}"; do
+    echo -e "     ${GREEN}•${NC} $s"
+  done
+fi
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  echo ""
+  fail "Failed (${#FAILED[@]}):"
+  for f in "${FAILED[@]}"; do
+    echo -e "     ${RED}•${NC} $f"
+  done
+  exit 1
+fi
+
+echo ""
+ok "All packages released successfully!"


### PR DESCRIPTION
## Summary
- Adds `scripts/release.sh` — a single script to build and publish all 8 Moss packages (3 npm, 5 PyPI)
- Supports `--dry-run`, `--npm-only`, `--pypi-only`, and selective package publishing
- Includes preflight checks for required tooling and auth

## Packages covered
**npm:** `@moss-tools/md-indexer`, `@moss-tools/vercel-sdk`, `vitepress-plugin-moss`
**PyPI:** `elevenlabs-moss`, `moss-cli`, `pipecat-moss`, `strands-agents-moss`, `vapi-moss`

## Usage
```bash
./scripts/release.sh --dry-run          # verify builds
./scripts/release.sh                    # publish all
./scripts/release.sh vercel-sdk         # publish one
./scripts/release.sh --pypi-only        # publish only Python packages
```

## Test plan
- [x] Dry run completes successfully for all 8 packages
- [ ] npm publish with valid auth
- [ ] PyPI publish with valid auth
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usemoss/moss/pull/142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
