### PR TITLE
Added Pydantic AI CookBook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 .env
 .env.*
 !.env.template
+!.env.example
 .env.local
 dist/
 .next/

--- a/examples/cookbook/pydantic-ai/.env.example
+++ b/examples/cookbook/pydantic-ai/.env.example
@@ -1,0 +1,5 @@
+MOSS_PROJECT_ID=your-project-id
+MOSS_PROJECT_KEY=your-project-key
+MOSS_INDEX_NAME=your-index-name
+PYDANTIC_AI_MODEL=openai:gpt-4o
+OPENAI_API_KEY=your-openai-api-key

--- a/examples/cookbook/pydantic-ai/README.md
+++ b/examples/cookbook/pydantic-ai/README.md
@@ -1,0 +1,101 @@
+# Moss Pydantic AI Cookbook
+
+This cookbook shows how to expose [Moss](https://moss.dev) semantic search as a reusable tool inside a [Pydantic AI](https://ai.pydantic.dev/) agent.
+
+## Overview
+
+Moss is a semantic search platform that delivers sub-10ms retrieval by loading vector indices into local memory. This cookbook provides:
+
+1. **MossSearchTool** — a class that wraps `MossClient` and exposes a `.tool` property for Pydantic AI agents.
+2. **as_tool(...)** — a convenience helper that creates the tool in one call.
+
+## Installation
+
+```bash
+cd examples/cookbook/pydantic-ai
+pip install -e .
+```
+
+## Setup
+
+Create a `.env` file in this directory (see `.env.example`):
+
+```env
+MOSS_PROJECT_ID=your-project-id
+MOSS_PROJECT_KEY=your-project-key
+MOSS_INDEX_NAME=your-index-name
+PYDANTIC_AI_MODEL=openai:gpt-4o
+OPENAI_API_KEY=your-openai-api-key
+```
+
+## Quick Start
+
+### Using MossSearchTool
+
+```python
+import asyncio
+from moss import MossClient
+from pydantic_ai import Agent
+from moss_pydantic_ai import MossSearchTool
+
+async def main():
+    client = MossClient("your-project-id", "your-project-key")
+    moss = MossSearchTool(client=client, index_name="my-index")
+    await moss.load_index()                    # pre-load for fast queries
+
+    agent = Agent("openai:gpt-4o", tools=[moss.tool])
+    result = await agent.run("What is the refund policy?")
+    print(result.output)
+
+asyncio.run(main())
+```
+
+### Using the as_tool helper
+
+```python
+from moss import MossClient
+from moss_pydantic_ai import as_tool
+
+client = MossClient("your-project-id", "your-project-key")
+moss, tool = as_tool(client=client, index_name="my-index")
+await moss.load_index()
+
+agent = Agent("openai:gpt-4o", tools=[tool])
+```
+
+## Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `client` | (required) | A `MossClient` instance |
+| `index_name` | (required) | Name of the Moss index to query |
+| `tool_name` | `moss_search` | Tool name exposed to the LLM |
+| `tool_description` | *(auto)* | Tool description exposed to the LLM |
+| `top_k` | `5` | Number of results to retrieve per query |
+| `alpha` | `0.8` | Blend: 1.0 = semantic only, 0.0 = keyword only |
+
+## Run the Demo
+
+```bash
+python moss_pydantic_ai.py
+```
+
+The demo creates a `MossClient`, loads your index, defines a `MossSearchTool`, and runs a Pydantic AI agent against it.
+
+## How It Works
+
+Pydantic AI inspects the tool function's signature and docstring to derive the input schema and description. `MossSearchTool._build_tool()` creates an async `moss_search(query: str) -> str` function and wraps it in `pydantic_ai.Tool(...)`, so the parameter schema is auto-generated.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `moss_pydantic_ai.py` | `MossSearchTool` class, `as_tool()` helper, and runnable demo |
+| `test_integration.py` | Unit tests (mocked, no credentials required) |
+| `pyproject.toml` | Package metadata |
+| `.env.example` | Template for required environment variables |
+
+## Notes
+
+- This cookbook exposes Moss **search** because that is the concrete capability exposed by the current Python SDK.
+- If Moss later adds first-class workflow or action definitions, the same adapter pattern can be promoted into an official `moss.integrations.pydantic_ai` module.

--- a/examples/cookbook/pydantic-ai/README.md
+++ b/examples/cookbook/pydantic-ai/README.md
@@ -86,7 +86,7 @@ asyncio.run(main())
 ## Run the Demo
 
 ```bash
-uv run python moss_pydantic_ai.py
+uv run python example.py
 ```
 
 The demo creates a `MossClient`, loads your index, defines a `MossSearchTool`, and runs a Pydantic AI agent against it.
@@ -107,7 +107,8 @@ Pydantic AI inspects the tool function's signature and docstring to derive the i
 
 | File | Description |
 |------|-------------|
-| `moss_pydantic_ai.py` | `MossSearchTool` class, `as_tool()` helper, and runnable demo |
+| `moss_pydantic_ai.py` | `MossSearchTool` class and `as_tool()` helper |
+| `example.py` | Runnable cookbook demo using the helper module |
 | `test_integration.py` | Unit tests (mocked, no credentials required) |
 | `pyproject.toml` | Package metadata |
 | `.env.example` | Template for required environment variables |

--- a/examples/cookbook/pydantic-ai/README.md
+++ b/examples/cookbook/pydantic-ai/README.md
@@ -29,6 +29,7 @@ OPENAI_API_KEY=your-openai-api-key
 ```
 
 This cookbook uses `await moss.load_index()` in the demo flow. On the first run, Moss may download the local query model used for in-memory search before the agent runs.
+If `MOSS_INDEX_NAME` does not exist yet, `example.py` creates a small demo index automatically before loading it.
 
 ## Quick Start
 
@@ -89,7 +90,7 @@ asyncio.run(main())
 uv run python example.py
 ```
 
-The demo creates a `MossClient`, loads your index, defines a `MossSearchTool`, and runs a Pydantic AI agent against it.
+The demo creates a `MossClient`, creates the demo index if needed, loads that index, defines a `MossSearchTool`, and runs a Pydantic AI agent against it.
 
 Because the demo preloads the index, the first run can take longer while Moss fetches the local query model cache.
 

--- a/examples/cookbook/pydantic-ai/README.md
+++ b/examples/cookbook/pydantic-ai/README.md
@@ -6,14 +6,14 @@ This cookbook shows how to expose [Moss](https://moss.dev) semantic search as a 
 
 Moss is a semantic search platform that delivers sub-10ms retrieval by loading vector indices into local memory. This cookbook provides:
 
-1. **MossSearchTool** — a class that wraps `MossClient` and exposes a `.tool` property for Pydantic AI agents.
-2. **as_tool(...)** — a convenience helper that creates the tool in one call.
+1. **MossSearchTool** - a class that wraps `MossClient` and exposes a `.tool` property for Pydantic AI agents.
+2. **as_tool(...)** - a convenience helper that creates the tool in one call.
 
 ## Installation
 
 ```bash
 cd examples/cookbook/pydantic-ai
-pip install -e .
+uv sync
 ```
 
 ## Setup
@@ -41,7 +41,7 @@ from moss_pydantic_ai import MossSearchTool
 async def main():
     client = MossClient("your-project-id", "your-project-key")
     moss = MossSearchTool(client=client, index_name="my-index")
-    await moss.load_index()                    # pre-load for fast queries
+    await moss.load_index()  # pre-load for fast queries
 
     agent = Agent("openai:gpt-4o", tools=[moss.tool])
     result = await agent.run("What is the refund policy?")
@@ -53,14 +53,21 @@ asyncio.run(main())
 ### Using the as_tool helper
 
 ```python
+import asyncio
 from moss import MossClient
+from pydantic_ai import Agent
 from moss_pydantic_ai import as_tool
 
-client = MossClient("your-project-id", "your-project-key")
-moss, tool = as_tool(client=client, index_name="my-index")
-await moss.load_index()
+async def main():
+    client = MossClient("your-project-id", "your-project-key")
+    moss, tool = as_tool(client=client, index_name="my-index")
+    await moss.load_index()
 
-agent = Agent("openai:gpt-4o", tools=[tool])
+    agent = Agent("openai:gpt-4o", tools=[tool])
+    result = await agent.run("What is the refund policy?")
+    print(result.output)
+
+asyncio.run(main())
 ```
 
 ## Configuration
@@ -77,10 +84,16 @@ agent = Agent("openai:gpt-4o", tools=[tool])
 ## Run the Demo
 
 ```bash
-python moss_pydantic_ai.py
+uv run python moss_pydantic_ai.py
 ```
 
 The demo creates a `MossClient`, loads your index, defines a `MossSearchTool`, and runs a Pydantic AI agent against it.
+
+## Run the Tests
+
+```bash
+uv run python test_integration.py
+```
 
 ## How It Works
 

--- a/examples/cookbook/pydantic-ai/README.md
+++ b/examples/cookbook/pydantic-ai/README.md
@@ -28,6 +28,8 @@ PYDANTIC_AI_MODEL=openai:gpt-4o
 OPENAI_API_KEY=your-openai-api-key
 ```
 
+This cookbook uses `await moss.load_index()` in the demo flow. On the first run, Moss may download the local query model used for in-memory search before the agent runs.
+
 ## Quick Start
 
 ### Using MossSearchTool
@@ -88,6 +90,8 @@ uv run python moss_pydantic_ai.py
 ```
 
 The demo creates a `MossClient`, loads your index, defines a `MossSearchTool`, and runs a Pydantic AI agent against it.
+
+Because the demo preloads the index, the first run can take longer while Moss fetches the local query model cache.
 
 ## Run the Tests
 

--- a/examples/cookbook/pydantic-ai/README.md
+++ b/examples/cookbook/pydantic-ai/README.md
@@ -4,10 +4,7 @@ This cookbook shows how to expose [Moss](https://moss.dev) semantic search as a 
 
 ## Overview
 
-Moss is a semantic search platform that delivers sub-10ms retrieval by loading vector indices into local memory. This cookbook provides:
-
-1. **MossSearchTool** - a class that wraps `MossClient` and exposes a `.tool` property for Pydantic AI agents.
-2. **as_tool(...)** - a convenience helper that creates the tool in one call.
+Moss is a semantic search platform that delivers sub-10ms retrieval by loading vector indices into local memory. This cookbook provides `MossSearchTool`, a small wrapper around `MossClient` that exposes a `.tool` property for Pydantic AI agents.
 
 ## Installation
 
@@ -53,26 +50,6 @@ async def main():
 asyncio.run(main())
 ```
 
-### Using the as_tool helper
-
-```python
-import asyncio
-from moss import MossClient
-from pydantic_ai import Agent
-from moss_pydantic_ai import as_tool
-
-async def main():
-    client = MossClient("your-project-id", "your-project-key")
-    moss, tool = as_tool(client=client, index_name="my-index")
-    await moss.load_index()
-
-    agent = Agent("openai:gpt-4o", tools=[tool])
-    result = await agent.run("What is the refund policy?")
-    print(result.output)
-
-asyncio.run(main())
-```
-
 ## Configuration
 
 | Parameter | Default | Description |
@@ -80,7 +57,6 @@ asyncio.run(main())
 | `client` | (required) | A `MossClient` instance |
 | `index_name` | (required) | Name of the Moss index to query |
 | `tool_name` | `moss_search` | Tool name exposed to the LLM |
-| `tool_description` | *(auto)* | Tool description exposed to the LLM |
 | `top_k` | `5` | Number of results to retrieve per query |
 | `alpha` | `0.8` | Blend: 1.0 = semantic only, 0.0 = keyword only |
 
@@ -108,7 +84,7 @@ Pydantic AI inspects the tool function's signature and docstring to derive the i
 
 | File | Description |
 |------|-------------|
-| `moss_pydantic_ai.py` | `MossSearchTool` class and `as_tool()` helper |
+| `moss_pydantic_ai.py` | `MossSearchTool` class |
 | `example.py` | Runnable cookbook demo using the helper module |
 | `test_integration.py` | Unit tests (mocked, no credentials required) |
 | `pyproject.toml` | Package metadata |

--- a/examples/cookbook/pydantic-ai/README.md
+++ b/examples/cookbook/pydantic-ai/README.md
@@ -25,7 +25,7 @@ PYDANTIC_AI_MODEL=openai:gpt-4o
 OPENAI_API_KEY=your-openai-api-key
 ```
 
-This cookbook uses `await moss.load_index()` in the demo flow. On the first run, Moss may download the local query model used for in-memory search before the agent runs.
+This cookbook eagerly calls `await moss.load_index()` before the agent runs. On the first run, that preload step may download the local query model used for in-memory search.
 If `MOSS_INDEX_NAME` does not exist yet, `example.py` creates a small demo index automatically before loading it.
 
 ## Quick Start
@@ -68,7 +68,7 @@ uv run python example.py
 
 The demo creates a `MossClient`, creates the demo index if needed, loads that index, defines a `MossSearchTool`, and runs a Pydantic AI agent against it.
 
-Because the demo preloads the index, the first run can take longer while Moss fetches the local query model cache.
+Because the demo eagerly preloads the index before `agent.run(...)`, the first run can take longer while Moss fetches the local query model cache.
 
 ## Run the Tests
 

--- a/examples/cookbook/pydantic-ai/example.py
+++ b/examples/cookbook/pydantic-ai/example.py
@@ -4,7 +4,7 @@ import asyncio
 import os
 
 from dotenv import load_dotenv
-from moss import MossClient
+from moss import DocumentInfo, MossClient
 from pydantic_ai import Agent
 
 from moss_pydantic_ai import MossSearchTool
@@ -17,6 +17,32 @@ def _require_env(name: str) -> str:
     return value
 
 
+async def _ensure_demo_index(client: MossClient, index_name: str) -> None:
+    """Create a small demo index if it does not already exist."""
+    existing_indexes = await client.list_indexes()
+    if any(index.name == index_name for index in existing_indexes):
+        return
+
+    docs = [
+        DocumentInfo(
+            id="reset-password",
+            text=(
+                "To reset your password, go to Settings > Security, choose Reset "
+                "Password, and follow the email verification link."
+            ),
+        ),
+        DocumentInfo(
+            id="refund-policy",
+            text="Refunds are processed within 3-5 business days after approval.",
+        ),
+        DocumentInfo(
+            id="support-hours",
+            text="Customer support is available Monday to Friday, 9 AM to 6 PM IST.",
+        ),
+    ]
+    await client.create_index(index_name, docs)
+
+
 async def main() -> None:
     """Run the cookbook example using the Moss-backed search tool."""
     load_dotenv()
@@ -25,9 +51,11 @@ async def main() -> None:
         _require_env("MOSS_PROJECT_ID"),
         _require_env("MOSS_PROJECT_KEY"),
     )
+    index_name = _require_env("MOSS_INDEX_NAME")
+    await _ensure_demo_index(client, index_name)
     moss = MossSearchTool(
         client=client,
-        index_name=_require_env("MOSS_INDEX_NAME"),
+        index_name=index_name,
     )
     await moss.load_index()
 

--- a/examples/cookbook/pydantic-ai/example.py
+++ b/examples/cookbook/pydantic-ai/example.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+from moss import MossClient
+from pydantic_ai import Agent
+
+from moss_pydantic_ai import MossSearchTool
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+
+
+async def main() -> None:
+    """Run the cookbook example using the Moss-backed search tool."""
+    load_dotenv()
+
+    client = MossClient(
+        _require_env("MOSS_PROJECT_ID"),
+        _require_env("MOSS_PROJECT_KEY"),
+    )
+    moss = MossSearchTool(
+        client=client,
+        index_name=_require_env("MOSS_INDEX_NAME"),
+    )
+    await moss.load_index()
+
+    agent = Agent(
+        _require_env("PYDANTIC_AI_MODEL"),
+        system_prompt=(
+            "Answer user questions with the help of Moss search when "
+            "factual lookup from the knowledge base is needed."
+        ),
+        tools=[moss.tool],
+    )
+
+    question = os.getenv(
+        "PYDANTIC_AI_PROMPT",
+        "How to reset password?",
+    )
+    result = await agent.run(question)
+    print(result.output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/cookbook/pydantic-ai/moss_pydantic_ai.py
+++ b/examples/cookbook/pydantic-ai/moss_pydantic_ai.py
@@ -14,8 +14,6 @@ __all__ = ["MossSearchTool", "as_tool"]
 logger = logging.getLogger("moss_pydantic_ai")
 
 
-
-
 class MossSearchTool:
     """Moss semantic search exposed as a Pydantic AI tool."""
 
@@ -43,8 +41,6 @@ class MossSearchTool:
         self._load_lock = asyncio.Lock()
         self._tool_obj = self._build_tool()
 
-
-
     async def load_index(self) -> None:
         """Pre-load the Moss index into memory for fast queries.
 
@@ -60,12 +56,6 @@ class MossSearchTool:
 
     async def search(self, query: str) -> str:
         """Query the Moss index and return formatted results."""
-        if not self._index_loaded:
-            raise RuntimeError(
-                f"Index '{self._index_name}' not loaded. "
-                "Call 'await moss_tool.load_index()' first."
-            )
-
         result = await self._client.query(
             self._index_name,
             query,
@@ -82,8 +72,6 @@ class MossSearchTool:
     def tool(self) -> Tool:
         """Return the ``pydantic_ai.Tool`` to pass to an Agent."""
         return self._tool_obj
-
-
 
     def _build_tool(self) -> Tool:
         """Build a Pydantic AI Tool wrapping :meth:`search`."""
@@ -124,8 +112,6 @@ class MossSearchTool:
         return "\n".join(lines)
 
 
-
-
 def as_tool(
     *,
     client: MossClient,
@@ -145,8 +131,6 @@ def as_tool(
         alpha=alpha,
     )
     return moss, moss.tool
-
-
 
 
 def _require_env(name: str) -> str:
@@ -184,7 +168,7 @@ async def main() -> None:
 
     question = os.getenv(
         "PYDANTIC_AI_PROMPT",
-        "What does the knowledge base say about refunds?",
+        "How to reset password?",
     )
     result = await agent.run(question)
     print(result.output)

--- a/examples/cookbook/pydantic-ai/moss_pydantic_ai.py
+++ b/examples/cookbook/pydantic-ai/moss_pydantic_ai.py
@@ -1,10 +1,3 @@
-"""Cookbook example: use Moss semantic search as a Pydantic AI tool.
-
-This module provides a reusable ``MossSearchTool`` class and a convenience
-``as_tool()`` helper.  Copy this file into your own project, or install the
-cookbook as a package with ``pip install -e .``
-"""
-
 from __future__ import annotations
 
 import asyncio
@@ -21,29 +14,10 @@ __all__ = ["MossSearchTool", "as_tool"]
 logger = logging.getLogger("moss_pydantic_ai")
 
 
-# ---------------------------------------------------------------------------
-# Core adapter
-# ---------------------------------------------------------------------------
 
 
 class MossSearchTool:
-    """Moss semantic search exposed as a Pydantic AI tool.
-
-    Manages the :class:`MossClient` lifecycle and exposes a ``.tool``
-    property returning a :class:`pydantic_ai.Tool` ready to be passed
-    to ``Agent(tools=[...])``.
-
-    Usage::
-
-        from moss import MossClient
-        from moss_pydantic_ai import MossSearchTool
-
-        client = MossClient("pid", "pkey")
-        moss = MossSearchTool(client=client, index_name="my-index")
-        await moss.load_index()
-
-        agent = Agent("openai:gpt-4o", tools=[moss.tool])
-    """
+    """Moss semantic search exposed as a Pydantic AI tool."""
 
     def __init__(
         self,
@@ -55,17 +29,7 @@ class MossSearchTool:
         top_k: int = 5,
         alpha: float = 0.8,
     ) -> None:
-        """Initialize with a shared MossClient and retrieval settings.
-
-        Args:
-            client: A pre-built :class:`MossClient` instance.
-            index_name: Name of the Moss index to query.
-            tool_name: Name exposed to the LLM for tool selection.
-            tool_description: Description exposed to the LLM.  If ``None``
-                a sensible default is used.
-            top_k: Number of results to retrieve per query.
-            alpha: Blend between semantic (1.0) and keyword (0.0) scoring.
-        """
+        """Initialize with a shared MossClient and retrieval settings."""
         self._client = client
         self._index_name = index_name
         self._tool_name = tool_name
@@ -79,7 +43,7 @@ class MossSearchTool:
         self._load_lock = asyncio.Lock()
         self._tool_obj = self._build_tool()
 
-    # -- public API ---------------------------------------------------------
+
 
     async def load_index(self) -> None:
         """Pre-load the Moss index into memory for fast queries.
@@ -95,17 +59,7 @@ class MossSearchTool:
             logger.info("Moss index '%s' ready", self._index_name)
 
     async def search(self, query: str) -> str:
-        """Query the Moss index and return formatted results.
-
-        Args:
-            query: Natural-language search text.
-
-        Returns:
-            Formatted string of search results suitable for LLM context.
-
-        Raises:
-            RuntimeError: If :meth:`load_index` has not been called.
-        """
+        """Query the Moss index and return formatted results."""
         if not self._index_loaded:
             raise RuntimeError(
                 f"Index '{self._index_name}' not loaded. "
@@ -129,7 +83,7 @@ class MossSearchTool:
         """Return the ``pydantic_ai.Tool`` to pass to an Agent."""
         return self._tool_obj
 
-    # -- internals ----------------------------------------------------------
+
 
     def _build_tool(self) -> Tool:
         """Build a Pydantic AI Tool wrapping :meth:`search`."""
@@ -170,9 +124,6 @@ class MossSearchTool:
         return "\n".join(lines)
 
 
-# ---------------------------------------------------------------------------
-# Convenience helper
-# ---------------------------------------------------------------------------
 
 
 def as_tool(
@@ -184,17 +135,7 @@ def as_tool(
     top_k: int = 5,
     alpha: float = 0.8,
 ) -> tuple[MossSearchTool, Tool]:
-    """Create a ``MossSearchTool`` and return ``(instance, tool)``.
-
-    This is a shortcut when you only need the tool object for ``Agent(tools=[...])``.
-    You still need to call ``await instance.load_index()`` before running the agent.
-
-    Example::
-
-        moss, tool = as_tool(client=client, index_name="docs")
-        await moss.load_index()
-        agent = Agent("openai:gpt-4o", tools=[tool])
-    """
+    """Create a ``MossSearchTool`` and return ``(instance, tool)`` as a shortcut."""
     moss = MossSearchTool(
         client=client,
         index_name=index_name,
@@ -206,9 +147,6 @@ def as_tool(
     return moss, moss.tool
 
 
-# ---------------------------------------------------------------------------
-# Runnable demo
-# ---------------------------------------------------------------------------
 
 
 def _require_env(name: str) -> str:

--- a/examples/cookbook/pydantic-ai/moss_pydantic_ai.py
+++ b/examples/cookbook/pydantic-ai/moss_pydantic_ai.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from collections.abc import Sequence
 from typing import Any
 
@@ -131,48 +130,3 @@ def as_tool(
         alpha=alpha,
     )
     return moss, moss.tool
-
-
-def _require_env(name: str) -> str:
-    value = os.getenv(name)
-    if not value:
-        raise RuntimeError(f"Missing required environment variable: {name}")
-    return value
-
-
-async def main() -> None:
-    """Run an interactive example using the Moss-backed search tool."""
-    from dotenv import load_dotenv
-    from pydantic_ai import Agent
-
-    load_dotenv()
-
-    client = MossClient(
-        _require_env("MOSS_PROJECT_ID"),
-        _require_env("MOSS_PROJECT_KEY"),
-    )
-    moss = MossSearchTool(
-        client=client,
-        index_name=_require_env("MOSS_INDEX_NAME"),
-    )
-    await moss.load_index()
-
-    agent = Agent(
-        _require_env("PYDANTIC_AI_MODEL"),
-        system_prompt=(
-            "Answer user questions with the help of Moss search when "
-            "factual lookup from the knowledge base is needed."
-        ),
-        tools=[moss.tool],
-    )
-
-    question = os.getenv(
-        "PYDANTIC_AI_PROMPT",
-        "How to reset password?",
-    )
-    result = await agent.run(question)
-    print(result.output)
-
-
-if __name__ == "__main__":
-    asyncio.run(main())

--- a/examples/cookbook/pydantic-ai/moss_pydantic_ai.py
+++ b/examples/cookbook/pydantic-ai/moss_pydantic_ai.py
@@ -4,11 +4,17 @@ from typing import Any
 from moss import MossClient, QueryOptions
 from pydantic_ai import Tool
 
-__all__ = ["MossSearchTool", "as_tool"]
+__all__ = ["MossSearchTool"]
 
 
 class MossSearchTool:
     """Moss semantic search exposed as a Pydantic AI tool."""
+
+    _TOOL_DESCRIPTION = (
+        "Use this tool whenever the user asks for information that should come from the Moss "
+        "knowledge base, such as refunds, account help, support policies, or product facts. "
+        "Pass the user's question as the query and use the returned results to answer."
+    )
 
     def __init__(
         self,
@@ -16,7 +22,6 @@ class MossSearchTool:
         client: MossClient,
         index_name: str,
         tool_name: str = "moss_search",
-        tool_description: str | None = None,
         top_k: int = 5,
         alpha: float = 0.8,
     ) -> None:
@@ -24,10 +29,6 @@ class MossSearchTool:
         self._client = client
         self._index_name = index_name
         self._tool_name = tool_name
-        self._tool_description = tool_description or (
-            "Search the knowledge base using Moss semantic search. "
-            "Returns the most relevant documents for a given query."
-        )
         self._top_k = top_k
         self._alpha = alpha
         self._tool_obj = self._build_tool()
@@ -66,7 +67,7 @@ class MossSearchTool:
             moss_search,
             takes_ctx=False,
             name=self._tool_name,
-            description=self._tool_description,
+            description=self._TOOL_DESCRIPTION,
         )
 
     @staticmethod
@@ -87,24 +88,3 @@ class MossSearchTool:
             text = getattr(doc, "text", "") or ""
             lines.append(f"{idx}. {text}{suffix}")
         return "\n".join(lines)
-
-
-def as_tool(
-    *,
-    client: MossClient,
-    index_name: str,
-    tool_name: str = "moss_search",
-    tool_description: str | None = None,
-    top_k: int = 5,
-    alpha: float = 0.8,
-) -> tuple[MossSearchTool, Tool]:
-    """Create a ``MossSearchTool`` and return ``(instance, tool)`` as a shortcut."""
-    moss = MossSearchTool(
-        client=client,
-        index_name=index_name,
-        tool_name=tool_name,
-        tool_description=tool_description,
-        top_k=top_k,
-        alpha=alpha,
-    )
-    return moss, moss.tool

--- a/examples/cookbook/pydantic-ai/moss_pydantic_ai.py
+++ b/examples/cookbook/pydantic-ai/moss_pydantic_ai.py
@@ -1,0 +1,256 @@
+"""Cookbook example: use Moss semantic search as a Pydantic AI tool.
+
+This module provides a reusable ``MossSearchTool`` class and a convenience
+``as_tool()`` helper.  Copy this file into your own project, or install the
+cookbook as a package with ``pip install -e .``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import Sequence
+from typing import Any
+
+from moss import MossClient, QueryOptions
+from pydantic_ai import Tool
+
+__all__ = ["MossSearchTool", "as_tool"]
+
+logger = logging.getLogger("moss_pydantic_ai")
+
+
+# ---------------------------------------------------------------------------
+# Core adapter
+# ---------------------------------------------------------------------------
+
+
+class MossSearchTool:
+    """Moss semantic search exposed as a Pydantic AI tool.
+
+    Manages the :class:`MossClient` lifecycle and exposes a ``.tool``
+    property returning a :class:`pydantic_ai.Tool` ready to be passed
+    to ``Agent(tools=[...])``.
+
+    Usage::
+
+        from moss import MossClient
+        from moss_pydantic_ai import MossSearchTool
+
+        client = MossClient("pid", "pkey")
+        moss = MossSearchTool(client=client, index_name="my-index")
+        await moss.load_index()
+
+        agent = Agent("openai:gpt-4o", tools=[moss.tool])
+    """
+
+    def __init__(
+        self,
+        *,
+        client: MossClient,
+        index_name: str,
+        tool_name: str = "moss_search",
+        tool_description: str | None = None,
+        top_k: int = 5,
+        alpha: float = 0.8,
+    ) -> None:
+        """Initialize with a shared MossClient and retrieval settings.
+
+        Args:
+            client: A pre-built :class:`MossClient` instance.
+            index_name: Name of the Moss index to query.
+            tool_name: Name exposed to the LLM for tool selection.
+            tool_description: Description exposed to the LLM.  If ``None``
+                a sensible default is used.
+            top_k: Number of results to retrieve per query.
+            alpha: Blend between semantic (1.0) and keyword (0.0) scoring.
+        """
+        self._client = client
+        self._index_name = index_name
+        self._tool_name = tool_name
+        self._tool_description = tool_description or (
+            "Search the knowledge base using Moss semantic search. "
+            "Returns the most relevant documents for a given query."
+        )
+        self._top_k = top_k
+        self._alpha = alpha
+        self._index_loaded = False
+        self._load_lock = asyncio.Lock()
+        self._tool_obj = self._build_tool()
+
+    # -- public API ---------------------------------------------------------
+
+    async def load_index(self) -> None:
+        """Pre-load the Moss index into memory for fast queries.
+
+        Safe to call multiple times; only the first call triggers loading.
+        """
+        async with self._load_lock:
+            if self._index_loaded:
+                return
+            logger.info("Loading Moss index '%s'", self._index_name)
+            await self._client.load_index(self._index_name)
+            self._index_loaded = True
+            logger.info("Moss index '%s' ready", self._index_name)
+
+    async def search(self, query: str) -> str:
+        """Query the Moss index and return formatted results.
+
+        Args:
+            query: Natural-language search text.
+
+        Returns:
+            Formatted string of search results suitable for LLM context.
+
+        Raises:
+            RuntimeError: If :meth:`load_index` has not been called.
+        """
+        if not self._index_loaded:
+            raise RuntimeError(
+                f"Index '{self._index_name}' not loaded. "
+                "Call 'await moss_tool.load_index()' first."
+            )
+
+        result = await self._client.query(
+            self._index_name,
+            query,
+            QueryOptions(top_k=self._top_k, alpha=self._alpha),
+        )
+        logger.info(
+            "Moss query returned %d docs in %sms",
+            len(result.docs),
+            result.time_taken_ms,
+        )
+        return self._format_results(result.docs)
+
+    @property
+    def tool(self) -> Tool:
+        """Return the ``pydantic_ai.Tool`` to pass to an Agent."""
+        return self._tool_obj
+
+    # -- internals ----------------------------------------------------------
+
+    def _build_tool(self) -> Tool:
+        """Build a Pydantic AI Tool wrapping :meth:`search`."""
+        instance = self
+
+        async def moss_search(query: str) -> str:
+            """Search the knowledge base for relevant documents.
+
+            Args:
+                query: Natural-language question or lookup text.
+            """
+            return await instance.search(query)
+
+        return Tool(
+            moss_search,
+            takes_ctx=False,
+            name=self._tool_name,
+            description=self._tool_description,
+        )
+
+    @staticmethod
+    def _format_results(documents: Sequence[Any]) -> str:
+        """Format Moss search results into a numbered string."""
+        if not documents:
+            return "No relevant results found."
+
+        lines = ["Relevant knowledge base results:", ""]
+        for idx, doc in enumerate(documents, start=1):
+            meta = doc.metadata or {}
+            extras = []
+            if source := meta.get("source"):
+                extras.append(f"source={source}")
+            if (score := getattr(doc, "score", None)) is not None:
+                extras.append(f"score={score:.3f}")
+            suffix = f" ({', '.join(extras)})" if extras else ""
+            text = getattr(doc, "text", "") or ""
+            lines.append(f"{idx}. {text}{suffix}")
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Convenience helper
+# ---------------------------------------------------------------------------
+
+
+def as_tool(
+    *,
+    client: MossClient,
+    index_name: str,
+    tool_name: str = "moss_search",
+    tool_description: str | None = None,
+    top_k: int = 5,
+    alpha: float = 0.8,
+) -> tuple[MossSearchTool, Tool]:
+    """Create a ``MossSearchTool`` and return ``(instance, tool)``.
+
+    This is a shortcut when you only need the tool object for ``Agent(tools=[...])``.
+    You still need to call ``await instance.load_index()`` before running the agent.
+
+    Example::
+
+        moss, tool = as_tool(client=client, index_name="docs")
+        await moss.load_index()
+        agent = Agent("openai:gpt-4o", tools=[tool])
+    """
+    moss = MossSearchTool(
+        client=client,
+        index_name=index_name,
+        tool_name=tool_name,
+        tool_description=tool_description,
+        top_k=top_k,
+        alpha=alpha,
+    )
+    return moss, moss.tool
+
+
+# ---------------------------------------------------------------------------
+# Runnable demo
+# ---------------------------------------------------------------------------
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+
+
+async def main() -> None:
+    """Run an interactive example using the Moss-backed search tool."""
+    from dotenv import load_dotenv
+    from pydantic_ai import Agent
+
+    load_dotenv()
+
+    client = MossClient(
+        _require_env("MOSS_PROJECT_ID"),
+        _require_env("MOSS_PROJECT_KEY"),
+    )
+    moss = MossSearchTool(
+        client=client,
+        index_name=_require_env("MOSS_INDEX_NAME"),
+    )
+    await moss.load_index()
+
+    agent = Agent(
+        _require_env("PYDANTIC_AI_MODEL"),
+        system_prompt=(
+            "Answer user questions with the help of Moss search when "
+            "factual lookup from the knowledge base is needed."
+        ),
+        tools=[moss.tool],
+    )
+
+    question = os.getenv(
+        "PYDANTIC_AI_PROMPT",
+        "What does the knowledge base say about refunds?",
+    )
+    result = await agent.run(question)
+    print(result.output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/cookbook/pydantic-ai/moss_pydantic_ai.py
+++ b/examples/cookbook/pydantic-ai/moss_pydantic_ai.py
@@ -1,16 +1,10 @@
 from __future__ import annotations
-
-import asyncio
-import logging
 from collections.abc import Sequence
 from typing import Any
-
 from moss import MossClient, QueryOptions
 from pydantic_ai import Tool
 
 __all__ = ["MossSearchTool", "as_tool"]
-
-logger = logging.getLogger("moss_pydantic_ai")
 
 
 class MossSearchTool:
@@ -36,22 +30,11 @@ class MossSearchTool:
         )
         self._top_k = top_k
         self._alpha = alpha
-        self._index_loaded = False
-        self._load_lock = asyncio.Lock()
         self._tool_obj = self._build_tool()
 
     async def load_index(self) -> None:
-        """Pre-load the Moss index into memory for fast queries.
-
-        Safe to call multiple times; only the first call triggers loading.
-        """
-        async with self._load_lock:
-            if self._index_loaded:
-                return
-            logger.info("Loading Moss index '%s'", self._index_name)
-            await self._client.load_index(self._index_name)
-            self._index_loaded = True
-            logger.info("Moss index '%s' ready", self._index_name)
+        """Pre-load the Moss index into memory for fast queries."""
+        await self._client.load_index(self._index_name)
 
     async def search(self, query: str) -> str:
         """Query the Moss index and return formatted results."""
@@ -59,11 +42,6 @@ class MossSearchTool:
             self._index_name,
             query,
             QueryOptions(top_k=self._top_k, alpha=self._alpha),
-        )
-        logger.info(
-            "Moss query returned %d docs in %sms",
-            len(result.docs),
-            result.time_taken_ms,
         )
         return self._format_results(result.docs)
 

--- a/examples/cookbook/pydantic-ai/pyproject.toml
+++ b/examples/cookbook/pydantic-ai/pyproject.toml
@@ -19,4 +19,4 @@ dependencies = [
 ]
 
 [tool.setuptools]
-py-modules = ["moss_pydantic_ai", "test_integration"]
+py-modules = ["example", "moss_pydantic_ai", "test_integration"]

--- a/examples/cookbook/pydantic-ai/pyproject.toml
+++ b/examples/cookbook/pydantic-ai/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "pydantic-ai-moss-cookbook"
@@ -18,11 +18,5 @@ dependencies = [
     "python-dotenv>=1.0.0",
 ]
 
-[tool.hatch.build.targets.wheel]
-packages = ["moss_pydantic_ai.py"]
-
-[tool.hatch.build.targets.sdist]
-include = [
-    "README.md",
-    "moss_pydantic_ai.py",
-]
+[tool.setuptools]
+py-modules = ["moss_pydantic_ai", "test_integration"]

--- a/examples/cookbook/pydantic-ai/pyproject.toml
+++ b/examples/cookbook/pydantic-ai/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pydantic-ai-moss-cookbook"
+version = "0.1.0"
+description = "Pydantic AI cookbook example for Moss semantic search"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "BSD-2-Clause" }
+authors = [
+    { name = "InferEdge Inc.", email = "contact@moss.dev" }
+]
+dependencies = [
+    "moss>=1.0.0",
+    "pydantic-ai>=0.8.0",
+    "python-dotenv>=1.0.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["moss_pydantic_ai.py"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "README.md",
+    "moss_pydantic_ai.py",
+]

--- a/examples/cookbook/pydantic-ai/test_integration.py
+++ b/examples/cookbook/pydantic-ai/test_integration.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from moss_pydantic_ai import MossSearchTool, as_tool
+from moss_pydantic_ai import MossSearchTool
 
 
 # ---------------------------------------------------------------------------
@@ -58,12 +58,10 @@ class TestMossSearchToolInit(unittest.TestCase):
             client=client,
             index_name="idx",
             tool_name="custom_search",
-            tool_description="Custom desc",
             top_k=10,
             alpha=0.5,
         )
         self.assertEqual(tool._tool_name, "custom_search")
-        self.assertEqual(tool._tool_description, "Custom desc")
         self.assertEqual(tool._top_k, 10)
         self.assertAlmostEqual(tool._alpha, 0.5)
 
@@ -170,39 +168,6 @@ class TestSearch(unittest.IsolatedAsyncioTestCase):
         output = await tool.search("q")
 
         self.assertIn("source=faq.md", output)
-
-
-# ---------------------------------------------------------------------------
-# as_tool helper
-# ---------------------------------------------------------------------------
-
-
-class TestAsTool(unittest.TestCase):
-    """Tests for the as_tool() convenience helper."""
-
-    @patch("moss_pydantic_ai.MossClient")
-    def test_returns_tuple(self, mock_client_cls):
-        client = mock_client_cls.return_value
-        moss, tool = as_tool(client=client, index_name="idx")
-
-        self.assertIsInstance(moss, MossSearchTool)
-        from pydantic_ai import Tool
-
-        self.assertIsInstance(tool, Tool)
-
-    @patch("moss_pydantic_ai.MossClient")
-    def test_forwards_parameters(self, mock_client_cls):
-        client = mock_client_cls.return_value
-        moss, _ = as_tool(
-            client=client,
-            index_name="idx",
-            tool_name="custom",
-            top_k=3,
-            alpha=0.5,
-        )
-        self.assertEqual(moss._tool_name, "custom")
-        self.assertEqual(moss._top_k, 3)
-        self.assertAlmostEqual(moss._alpha, 0.5)
 
 
 # ---------------------------------------------------------------------------

--- a/examples/cookbook/pydantic-ai/test_integration.py
+++ b/examples/cookbook/pydantic-ai/test_integration.py
@@ -1,0 +1,237 @@
+"""Tests for the Pydantic AI + Moss cookbook integration.
+
+All tests use mocked MossClient — no Moss credentials required.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from moss_pydantic_ai import MossSearchTool, as_tool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_search_result(docs=None):
+    """Create a mock SearchResult."""
+    result = MagicMock()
+    result.docs = docs or []
+    result.time_taken_ms = 1.5
+    return result
+
+
+def _mock_doc(text="sample text", score=0.95, doc_id="d1", metadata=None):
+    """Create a mock QueryResultDocumentInfo."""
+    doc = MagicMock()
+    doc.text = text
+    doc.score = score
+    doc.id = doc_id
+    doc.metadata = metadata or {}
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# MossSearchTool — init
+# ---------------------------------------------------------------------------
+
+
+class TestMossSearchToolInit(unittest.TestCase):
+    """Construction and default values."""
+
+    @patch("moss_pydantic_ai.MossClient")
+    def test_defaults(self, mock_client_cls):
+        client = mock_client_cls.return_value
+        tool = MossSearchTool(client=client, index_name="idx")
+        self.assertEqual(tool._index_name, "idx")
+        self.assertEqual(tool._top_k, 5)
+        self.assertAlmostEqual(tool._alpha, 0.8)
+        self.assertEqual(tool._tool_name, "moss_search")
+        self.assertFalse(tool._index_loaded)
+
+    @patch("moss_pydantic_ai.MossClient")
+    def test_custom_values(self, mock_client_cls):
+        client = mock_client_cls.return_value
+        tool = MossSearchTool(
+            client=client,
+            index_name="idx",
+            tool_name="custom_search",
+            tool_description="Custom desc",
+            top_k=10,
+            alpha=0.5,
+        )
+        self.assertEqual(tool._tool_name, "custom_search")
+        self.assertEqual(tool._tool_description, "Custom desc")
+        self.assertEqual(tool._top_k, 10)
+        self.assertAlmostEqual(tool._alpha, 0.5)
+
+    @patch("moss_pydantic_ai.MossClient")
+    def test_tool_property_returns_pydantic_tool(self, mock_client_cls):
+        client = mock_client_cls.return_value
+        moss = MossSearchTool(client=client, index_name="idx")
+        from pydantic_ai import Tool
+
+        self.assertIsInstance(moss.tool, Tool)
+
+
+# ---------------------------------------------------------------------------
+# MossSearchTool — load_index
+# ---------------------------------------------------------------------------
+
+
+class TestLoadIndex(unittest.IsolatedAsyncioTestCase):
+    """Tests for load_index()."""
+
+    async def test_load_index_sets_flag(self):
+        client = MagicMock()
+        client.load_index = AsyncMock()
+        tool = MossSearchTool(client=client, index_name="idx")
+
+        await tool.load_index()
+
+        client.load_index.assert_awaited_once_with("idx")
+        self.assertTrue(tool._index_loaded)
+
+    async def test_load_index_only_loads_once(self):
+        client = MagicMock()
+        client.load_index = AsyncMock()
+        tool = MossSearchTool(client=client, index_name="idx")
+
+        await tool.load_index()
+        await tool.load_index()
+
+        client.load_index.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# MossSearchTool — search
+# ---------------------------------------------------------------------------
+
+
+class TestSearch(unittest.IsolatedAsyncioTestCase):
+    """Tests for search()."""
+
+    async def test_search_formats_results(self):
+        client = MagicMock()
+        client.load_index = AsyncMock()
+        client.query = AsyncMock(
+            return_value=_mock_search_result(
+                [
+                    _mock_doc("first result", 0.9, "d1"),
+                    _mock_doc("second result", 0.7, "d2"),
+                ]
+            )
+        )
+        tool = MossSearchTool(client=client, index_name="idx")
+        await tool.load_index()
+
+        output = await tool.search("test query")
+
+        self.assertIn("first result", output)
+        self.assertIn("second result", output)
+        self.assertIn("score=0.900", output)
+        self.assertIn("score=0.700", output)
+
+    async def test_search_empty_results(self):
+        client = MagicMock()
+        client.load_index = AsyncMock()
+        client.query = AsyncMock(return_value=_mock_search_result([]))
+        tool = MossSearchTool(client=client, index_name="idx")
+        await tool.load_index()
+
+        output = await tool.search("empty query")
+
+        self.assertEqual(output, "No relevant results found.")
+
+    async def test_search_raises_if_not_loaded(self):
+        client = MagicMock()
+        tool = MossSearchTool(client=client, index_name="idx")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            await tool.search("test")
+        self.assertIn("not loaded", str(ctx.exception))
+
+    async def test_search_includes_metadata_source(self):
+        client = MagicMock()
+        client.load_index = AsyncMock()
+        client.query = AsyncMock(
+            return_value=_mock_search_result(
+                [_mock_doc("doc text", 0.85, "d1", {"source": "faq.md"})]
+            )
+        )
+        tool = MossSearchTool(client=client, index_name="idx")
+        await tool.load_index()
+
+        output = await tool.search("q")
+
+        self.assertIn("source=faq.md", output)
+
+
+# ---------------------------------------------------------------------------
+# as_tool helper
+# ---------------------------------------------------------------------------
+
+
+class TestAsTool(unittest.TestCase):
+    """Tests for the as_tool() convenience helper."""
+
+    @patch("moss_pydantic_ai.MossClient")
+    def test_returns_tuple(self, mock_client_cls):
+        client = mock_client_cls.return_value
+        moss, tool = as_tool(client=client, index_name="idx")
+
+        self.assertIsInstance(moss, MossSearchTool)
+        from pydantic_ai import Tool
+
+        self.assertIsInstance(tool, Tool)
+
+    @patch("moss_pydantic_ai.MossClient")
+    def test_forwards_parameters(self, mock_client_cls):
+        client = mock_client_cls.return_value
+        moss, _ = as_tool(
+            client=client,
+            index_name="idx",
+            tool_name="custom",
+            top_k=3,
+            alpha=0.5,
+        )
+        self.assertEqual(moss._tool_name, "custom")
+        self.assertEqual(moss._top_k, 3)
+        self.assertAlmostEqual(moss._alpha, 0.5)
+
+
+# ---------------------------------------------------------------------------
+# Format results — edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestFormatResults(unittest.TestCase):
+    """Tests for _format_results edge cases."""
+
+    def test_empty_docs(self):
+        result = MossSearchTool._format_results([])
+        self.assertIn("No relevant results found", result)
+
+    def test_numbered_results(self):
+        docs = [
+            _mock_doc("first", 0.9),
+            _mock_doc("second", 0.8),
+            _mock_doc("third", 0.7),
+        ]
+        result = MossSearchTool._format_results(docs)
+        self.assertIn("1. first", result)
+        self.assertIn("2. second", result)
+        self.assertIn("3. third", result)
+
+    def test_doc_with_no_metadata(self):
+        doc = _mock_doc("plain text", 0.99, metadata={})
+        result = MossSearchTool._format_results([doc])
+        self.assertIn("1. plain text", result)
+        self.assertIn("score=0.990", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/cookbook/pydantic-ai/test_integration.py
+++ b/examples/cookbook/pydantic-ai/test_integration.py
@@ -1,6 +1,6 @@
 """Tests for the Pydantic AI + Moss cookbook integration.
 
-All tests use mocked MossClient — no Moss credentials required.
+All tests use mocked MossClient - no Moss credentials required.
 """
 
 from __future__ import annotations
@@ -35,7 +35,7 @@ def _mock_doc(text="sample text", score=0.95, doc_id="d1", metadata=None):
 
 
 # ---------------------------------------------------------------------------
-# MossSearchTool — init
+# MossSearchTool - init
 # ---------------------------------------------------------------------------
 
 
@@ -78,7 +78,7 @@ class TestMossSearchToolInit(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# MossSearchTool — load_index
+# MossSearchTool - load_index
 # ---------------------------------------------------------------------------
 
 
@@ -107,7 +107,7 @@ class TestLoadIndex(unittest.IsolatedAsyncioTestCase):
 
 
 # ---------------------------------------------------------------------------
-# MossSearchTool — search
+# MossSearchTool - search
 # ---------------------------------------------------------------------------
 
 
@@ -204,7 +204,7 @@ class TestAsTool(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Format results — edge cases
+# Format results - edge cases
 # ---------------------------------------------------------------------------
 
 

--- a/examples/cookbook/pydantic-ai/test_integration.py
+++ b/examples/cookbook/pydantic-ai/test_integration.py
@@ -50,7 +50,6 @@ class TestMossSearchToolInit(unittest.TestCase):
         self.assertEqual(tool._top_k, 5)
         self.assertAlmostEqual(tool._alpha, 0.8)
         self.assertEqual(tool._tool_name, "moss_search")
-        self.assertFalse(tool._index_loaded)
 
     @patch("moss_pydantic_ai.MossClient")
     def test_custom_values(self, mock_client_cls):
@@ -85,7 +84,7 @@ class TestMossSearchToolInit(unittest.TestCase):
 class TestLoadIndex(unittest.IsolatedAsyncioTestCase):
     """Tests for load_index()."""
 
-    async def test_load_index_sets_flag(self):
+    async def test_load_index_calls_client(self):
         client = MagicMock()
         client.load_index = AsyncMock()
         tool = MossSearchTool(client=client, index_name="idx")
@@ -93,9 +92,8 @@ class TestLoadIndex(unittest.IsolatedAsyncioTestCase):
         await tool.load_index()
 
         client.load_index.assert_awaited_once_with("idx")
-        self.assertTrue(tool._index_loaded)
 
-    async def test_load_index_only_loads_once(self):
+    async def test_load_index_calls_client_each_time(self):
         client = MagicMock()
         client.load_index = AsyncMock()
         tool = MossSearchTool(client=client, index_name="idx")
@@ -103,7 +101,7 @@ class TestLoadIndex(unittest.IsolatedAsyncioTestCase):
         await tool.load_index()
         await tool.load_index()
 
-        client.load_index.assert_awaited_once()
+        self.assertEqual(client.load_index.await_count, 2)
 
 
 # ---------------------------------------------------------------------------
@@ -146,13 +144,17 @@ class TestSearch(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(output, "No relevant results found.")
 
-    async def test_search_raises_if_not_loaded(self):
+    async def test_search_queries_without_preload(self):
         client = MagicMock()
+        client.query = AsyncMock(
+            return_value=_mock_search_result([_mock_doc("fallback result", 0.88, "d1")])
+        )
         tool = MossSearchTool(client=client, index_name="idx")
 
-        with self.assertRaises(RuntimeError) as ctx:
-            await tool.search("test")
-        self.assertIn("not loaded", str(ctx.exception))
+        output = await tool.search("test")
+
+        client.query.assert_awaited_once()
+        self.assertIn("fallback result", output)
 
     async def test_search_includes_metadata_source(self):
         client = MagicMock()


### PR DESCRIPTION
## Pull Request Checklist

Please ensure that your PR meets the following requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [x] I have updated the documentation (if applicable).
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Description

This PR adds a cookbook that shows how to use Moss semantic search as a tool inside a Pydantic AI agent.
Right now, if you're building an AI agent with Pydantic AI and want it to search your Moss knowledge base, you have to write all the glue code yourself. This cookbook gives you a ready-made MossSearchTool class and an as_tool() helper that does the wiring for you  just point it at your Moss index and plug it into your agent.

## Summary

Added a Pydantic AI cookbook that lets developers plug Moss search into their AI agents with a few lines of code — includes a reusable tool class, a convenience helper, a runnable demo, and 15 unit tests.

Fixes #144 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usemoss/moss/pull/147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
