### PR TITLE
fix: update requires-python to support Python 3.14

### DIFF
--- a/examples/cookbook/crewai/pyproject.toml
+++ b/examples/cookbook/crewai/pyproject.toml
@@ -7,7 +7,7 @@ name = "crewai-moss"
 version = "0.1.0"
 description = "CrewAI integration for Moss semantic search"
 readme = "README.md"
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11,<3.15"
 license = { text = "BSD-2-Clause" }
 authors = [
     { name = "InferEdge Inc.", email = "contact@moss.dev" }

--- a/examples/cookbook/crewai/pyproject.toml
+++ b/examples/cookbook/crewai/pyproject.toml
@@ -7,7 +7,7 @@ name = "crewai-moss"
 version = "0.1.0"
 description = "CrewAI integration for Moss semantic search"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<3.14"
 license = { text = "BSD-2-Clause" }
 authors = [
     { name = "InferEdge Inc.", email = "contact@moss.dev" }

--- a/packages/elevenlabs-moss/pyproject.toml
+++ b/packages/elevenlabs-moss/pyproject.toml
@@ -3,7 +3,7 @@ name = "elevenlabs-moss"
 version = "0.0.1"
 description = "Moss semantic search integration for ElevenLabs Conversational AI"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 dependencies = [
     "moss>=1.0.0",
     "elevenlabs>=2.40.0",

--- a/packages/pipecat-moss/pyproject.toml
+++ b/packages/pipecat-moss/pyproject.toml
@@ -3,7 +3,7 @@ name = "pipecat-moss"
 version = "0.0.3"
 description = "Moss vector search integration for Pipecat"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 dependencies = [
     "moss>=1.0.0",
     "loguru>=0.7.0",

--- a/packages/strands-agents-moss/pyproject.toml
+++ b/packages/strands-agents-moss/pyproject.toml
@@ -3,7 +3,7 @@ name = "strands-agents-moss"
 version = "0.0.1"
 description = "Moss semantic search integration for Strands Agents"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 dependencies = [
     "moss>=1.0.0",
     "strands-agents>=0.1.0",

--- a/packages/vapi-moss/pyproject.toml
+++ b/packages/vapi-moss/pyproject.toml
@@ -3,7 +3,7 @@ name = "vapi-moss"
 version = "0.0.1"
 description = "Moss semantic search integration for VAPI Custom Knowledge Base webhooks"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 dependencies = [
     "moss>=1.0.0",
 ]


### PR DESCRIPTION
## Summary
- Updated `requires-python` from `>=3.10,<3.14` to `>=3.10,<3.15` in four packages: elevenlabs-moss, pipecat-moss, strands-agents-moss, vapi-moss
- The publish workflows test against Python 3.10-3.14, but the `<3.14` upper bound caused pip to reject wheel installation during the 3.14 smoke test

## Note
The moss-md-indexer and vitepress-plugin-moss publish failures are caused by a missing `NPM_PUBLISH_TOKEN` repo secret -- not a code issue.

## Test plan
- [ ] Re-run publish workflows for elevenlabs-moss, vapi-moss, strands-agents-moss to verify 3.14 matrix passes
- [ ] Set `NPM_PUBLISH_TOKEN` secret and re-run moss-md-indexer / vitepress-plugin-moss workflows
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usemoss/moss/pull/151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
