### PR TITLE
feat/added langgraph-cookbook example(#90)

### DIFF
--- a/examples/cookbook/langgraph/.env.example
+++ b/examples/cookbook/langgraph/.env.example
@@ -1,0 +1,6 @@
+MOSS_PROJECT_ID=your-project-id
+MOSS_PROJECT_KEY=your-project-key
+MOSS_INDEX_NAME=your-existing-index
+
+GROQ_API_KEY=your-groq-api-key
+GROQ_MODEL=llama-3.3-70b-versatile

--- a/examples/cookbook/langgraph/README.md
+++ b/examples/cookbook/langgraph/README.md
@@ -1,0 +1,97 @@
+# LangGraph + Moss (Groq-backed) Cookbook Example
+
+Use [Moss](https://moss.dev) as the retrieval step inside a [LangGraph](https://www.langchain.com/langgraph) stateful agent graph.
+
+This cookbook keeps the graph intentionally small:
+
+```text
+User question -> retrieve node -> generate node -> grounded answer
+```
+
+The key detail is that the Moss index is loaded locally with `load_index()` before the graph runs, so retrieval stays in-memory instead of falling back to the cloud API.
+
+## Installation
+
+```bash
+cd examples/cookbook/langgraph
+pip install -e .
+```
+
+## Setup
+
+Copy `.env.example` to `.env` and fill in your values:
+
+```env
+MOSS_PROJECT_ID=your-project-id
+MOSS_PROJECT_KEY=your-project-key
+MOSS_INDEX_NAME=your-existing-index
+GROQ_API_KEY=your-groq-api-key
+GROQ_MODEL=llama-3.3-70b-versatile
+```
+
+If you do not already have a Moss index for testing, create one with:
+
+```bash
+python examples/cookbook/langgraph/create_index.py
+```
+
+That script creates a small FAQ-style index with metadata like `category=returns`
+so you can test both normal retrieval and the optional filter path. It prints the
+exact `MOSS_INDEX_NAME` value to put into `.env`.
+
+We provide a simple equality filter interface (`--filter-eq`) for portability
+across shells.
+
+## State Schema
+
+The graph uses a simple typed state:
+
+- `query`: user query passed into the graph
+- `metadata_filter`: optional Moss metadata filter dict passed through state
+- `top_k`: optional retrieval depth override
+- `retrieval_results`: docs written by the `retrieve` node
+- `retrieval_context`: formatted context written by the `retrieve` node
+- `retrieval_time_ms`: retrieval latency reported by Moss
+- `answer`: grounded final answer written by the `generate` node
+
+The `retrieve` node reads `query` and `metadata_filter` from state, calls `client.query()`, and writes the retrieved results back into state for the `generate` node.
+
+## Why `load_index()` Happens First
+
+`moss_langgraph.py` explicitly runs:
+
+```python
+await client.load_index(index_name)
+```
+
+before compiling and invoking the graph.
+
+That matters because:
+
+- Local loaded index: retrieval stays in-memory, typically around `~1-10ms`
+- No local load: `query()` falls back to the cloud API, typically around `~100-500ms`
+- Metadata filters are applied on locally loaded indexes, so preloading is the right path for filtered retrieval nodes
+
+## Run It
+
+Single question:
+
+```bash
+python examples/cookbook/langgraph/moss_langgraph.py --question "What is the refund policy?"
+```
+
+Single question with a metadata filter carried through graph state:
+
+```bash
+python examples/cookbook/langgraph/moss_langgraph.py --question "What is the refund policy?" --filter-eq category=returns
+```
+
+Interactive loop:
+
+```bash
+python examples/cookbook/langgraph/moss_langgraph.py
+```
+
+The script loads `.env` from the same directory as `moss_langgraph.py`, so you can run it from the repo root or from inside the example folder.
+
+In interactive mode, each turn lets you optionally provide a metadata filter in `field=value` form before the graph runs.

--- a/examples/cookbook/langgraph/README.md
+++ b/examples/cookbook/langgraph/README.md
@@ -49,12 +49,15 @@ The graph uses a simple typed state:
 - `query`: user query passed into the graph
 - `metadata_filter`: optional Moss metadata filter dict passed through state
 - `top_k`: optional retrieval depth override
-- `retrieval_results`: docs written by the `retrieve` node
+- `alpha`: optional Moss hybrid search blend override
+- `retrieval_results`: Moss `SearchResult` written by the `retrieve` node
 - `retrieval_context`: formatted context written by the `retrieve` node
 - `retrieval_time_ms`: retrieval latency reported by Moss
 - `answer`: grounded final answer written by the `generate` node
 
-The `retrieve` node reads `query` and `metadata_filter` from state, calls `client.query()`, and writes the retrieved results back into state for the `generate` node.
+The `retrieve` node reads `query`, `metadata_filter`, `top_k`, and optional
+`alpha` from state, calls `client.query()`, and writes the returned Moss
+`SearchResult` back into state for the `generate` node.
 
 ## Why `load_index()` Happens First
 
@@ -84,6 +87,12 @@ Single question with a metadata filter carried through graph state:
 
 ```bash
 python examples/cookbook/langgraph/moss_langgraph.py --question "What is the refund policy?" --filter-eq category=returns
+```
+
+Single question with an explicit hybrid-search blend:
+
+```bash
+python examples/cookbook/langgraph/moss_langgraph.py --question "What is the refund policy?" --alpha 0.6
 ```
 
 Interactive loop:

--- a/examples/cookbook/langgraph/README.md
+++ b/examples/cookbook/langgraph/README.md
@@ -2,6 +2,9 @@
 
 Use [Moss](https://moss.dev) as the retrieval step inside a [LangGraph](https://www.langchain.com/langgraph) stateful agent graph.
 
+> **Note:** This is a cookbook example, not a packaged integration.
+> `moss_langgraph.py` is a self-contained module you can adapt into your own project.
+
 This cookbook keeps the graph intentionally small:
 
 ```text
@@ -14,8 +17,11 @@ The key detail is that the Moss index is loaded locally with `load_index()` befo
 
 ```bash
 cd examples/cookbook/langgraph
-pip install -e .
+pip install "moss>=1.0.0" "langgraph>=0.2" langchain-groq python-dotenv
 ```
+
+No editable install is required. The runnable example imports the core helpers
+directly from `moss_langgraph.py` in this directory.
 
 ## Setup
 
@@ -32,7 +38,7 @@ GROQ_MODEL=llama-3.3-70b-versatile
 If you do not already have a Moss index for testing, create one with:
 
 ```bash
-python examples/cookbook/langgraph/create_index.py
+python create_index.py
 ```
 
 That script creates a small FAQ-style index with metadata like `category=returns`
@@ -61,7 +67,7 @@ The `retrieve` node reads `query`, `metadata_filter`, `top_k`, and optional
 
 ## Why `load_index()` Happens First
 
-`moss_langgraph.py` explicitly runs:
+The example explicitly runs:
 
 ```python
 await client.load_index(index_name)
@@ -80,27 +86,35 @@ That matters because:
 Single question:
 
 ```bash
-python examples/cookbook/langgraph/moss_langgraph.py --question "What is the refund policy?"
+python example_usage.py --question "What is the refund policy?"
 ```
 
 Single question with a metadata filter carried through graph state:
 
 ```bash
-python examples/cookbook/langgraph/moss_langgraph.py --question "What is the refund policy?" --filter-eq category=returns
+python example_usage.py --question "What is the refund policy?" --filter-eq category=returns
 ```
 
 Single question with an explicit hybrid-search blend:
 
 ```bash
-python examples/cookbook/langgraph/moss_langgraph.py --question "What is the refund policy?" --alpha 0.6
+python example_usage.py --question "What is the refund policy?" --alpha 0.6
 ```
 
 Interactive loop:
 
 ```bash
-python examples/cookbook/langgraph/moss_langgraph.py
+python example_usage.py
 ```
 
-The script loads `.env` from the same directory as `moss_langgraph.py`, so you can run it from the repo root or from inside the example folder.
+The script loads `.env` from this directory.
 
 In interactive mode, each turn lets you optionally provide a metadata filter in `field=value` form before the graph runs.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `moss_langgraph.py` | Core LangGraph + Moss helpers that can be imported into your own code |
+| `example_usage.py` | Groq-backed CLI example that imports from `moss_langgraph.py` |
+| `create_index.py` | Creates a small FAQ-style Moss index for local testing |

--- a/examples/cookbook/langgraph/README.md
+++ b/examples/cookbook/langgraph/README.md
@@ -17,11 +17,10 @@ The key detail is that the Moss index is loaded locally with `load_index()` befo
 
 ```bash
 cd examples/cookbook/langgraph
-pip install "moss>=1.0.0" "langgraph>=0.2" langchain-groq python-dotenv
+uv sync
 ```
 
-No editable install is required. The runnable example imports the core helpers
-directly from `moss_langgraph.py` in this directory.
+> Don't have `uv`? Install it with `curl -LsSf https://astral.sh/uv/install.sh | sh`
 
 ## Setup
 
@@ -38,7 +37,7 @@ GROQ_MODEL=llama-3.3-70b-versatile
 If you do not already have a Moss index for testing, create one with:
 
 ```bash
-python create_index.py
+uv run python create_index.py
 ```
 
 That script creates a small FAQ-style index with metadata like `category=returns`
@@ -86,25 +85,25 @@ That matters because:
 Single question:
 
 ```bash
-python example_usage.py --question "What is the refund policy?"
+uv run python example_usage.py --question "What is the refund policy?"
 ```
 
 Single question with a metadata filter carried through graph state:
 
 ```bash
-python example_usage.py --question "What is the refund policy?" --filter-eq category=returns
+uv run python example_usage.py --question "What is the refund policy?" --filter-eq category=returns
 ```
 
 Single question with an explicit hybrid-search blend:
 
 ```bash
-python example_usage.py --question "What is the refund policy?" --alpha 0.6
+uv run python example_usage.py --question "What is the refund policy?" --alpha 0.6
 ```
 
 Interactive loop:
 
 ```bash
-python example_usage.py
+uv run python example_usage.py
 ```
 
 The script loads `.env` from this directory.

--- a/examples/cookbook/langgraph/create_index.py
+++ b/examples/cookbook/langgraph/create_index.py
@@ -82,11 +82,11 @@ async def main() -> None:
 
     print("Suggested live tests:")
     print(
-        "python .\\examples\\cookbook\\langgraph\\moss_langgraph.py "
+        "python examples/cookbook/langgraph/moss_langgraph.py "
         '--question "What is the refund policy?"'
     )
     print(
-        "python .\\examples\\cookbook\\langgraph\\moss_langgraph.py "
+        "python examples/cookbook/langgraph/moss_langgraph.py "
         '--question "What is the refund policy?" --filter-eq category=returns'
     )
 

--- a/examples/cookbook/langgraph/create_index.py
+++ b/examples/cookbook/langgraph/create_index.py
@@ -1,0 +1,95 @@
+"""Create a small Moss index for the LangGraph cookbook example."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import time
+
+from dotenv import load_dotenv
+from moss import DocumentInfo, MossClient
+
+load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+
+
+def _build_documents() -> list[DocumentInfo]:
+    return [
+        DocumentInfo(
+            id="faq-returns-1",
+            text="Refunds are processed within 3 to 5 business days after the returned item is received and inspected.",
+            metadata={"category": "returns", "topic": "refund_timing"},
+        ),
+        DocumentInfo(
+            id="faq-returns-2",
+            text="Damaged products can be returned within 30 days of delivery with the original order number.",
+            metadata={"category": "returns", "topic": "damaged_items"},
+        ),
+        DocumentInfo(
+            id="faq-shipping-1",
+            text="Standard shipping usually arrives within 5 to 7 business days for domestic orders.",
+            metadata={"category": "shipping", "topic": "delivery_time"},
+        ),
+        DocumentInfo(
+            id="faq-orders-1",
+            text="Orders can be cancelled within 2 hours of purchase from the order history page.",
+            metadata={"category": "orders", "topic": "cancellation"},
+        ),
+        DocumentInfo(
+            id="faq-payment-1",
+            text="We accept major credit cards, debit cards, and selected wallet-based payment methods.",
+            metadata={"category": "payment", "topic": "methods"},
+        ),
+    ]
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create a demo Moss index for the LangGraph cookbook."
+    )
+    parser.add_argument(
+        "--index-name",
+        help="Optional index name. If omitted, a unique demo name is generated.",
+    )
+    args = parser.parse_args()
+
+    project_id = _require_env("MOSS_PROJECT_ID")
+    project_key = _require_env("MOSS_PROJECT_KEY")
+    index_name = args.index_name or f"langgraph-demo-{int(time.time())}"
+
+    client = MossClient(project_id, project_key)
+    documents = _build_documents()
+
+    print(f"Creating index '{index_name}' with {len(documents)} demo docs...")
+
+    try:
+        await client.create_index(index_name, documents)
+        print("Index created successfully.\n")
+    except RuntimeError as exc:
+        if "already exists" not in str(exc):
+            raise
+        print("Index already exists. Reusing it.\n")
+
+    print("Use this in examples/cookbook/langgraph/.env:")
+    print(f"MOSS_INDEX_NAME={index_name}\n")
+
+    print("Suggested live tests:")
+    print(
+        "python .\\examples\\cookbook\\langgraph\\moss_langgraph.py "
+        '--question "What is the refund policy?"'
+    )
+    print(
+        "python .\\examples\\cookbook\\langgraph\\moss_langgraph.py "
+        '--question "What is the refund policy?" --filter-eq category=returns'
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/cookbook/langgraph/create_index.py
+++ b/examples/cookbook/langgraph/create_index.py
@@ -82,11 +82,11 @@ async def main() -> None:
 
     print("Suggested live tests:")
     print(
-        "python example_usage.py "
+        "uv run python example_usage.py "
         '--question "What is the refund policy?"'
     )
     print(
-        "python example_usage.py "
+        "uv run python example_usage.py "
         '--question "What is the refund policy?" --filter-eq category=returns'
     )
 

--- a/examples/cookbook/langgraph/create_index.py
+++ b/examples/cookbook/langgraph/create_index.py
@@ -82,11 +82,11 @@ async def main() -> None:
 
     print("Suggested live tests:")
     print(
-        "python examples/cookbook/langgraph/moss_langgraph.py "
+        "python example_usage.py "
         '--question "What is the refund policy?"'
     )
     print(
-        "python examples/cookbook/langgraph/moss_langgraph.py "
+        "python example_usage.py "
         '--question "What is the refund policy?" --filter-eq category=returns'
     )
 

--- a/examples/cookbook/langgraph/example_usage.py
+++ b/examples/cookbook/langgraph/example_usage.py
@@ -1,0 +1,185 @@
+"""Runnable LangGraph + Moss cookbook example."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+
+from dotenv import load_dotenv
+from langchain_groq import ChatGroq
+from moss import MossClient
+
+from moss_langgraph import (
+    LangGraphMossState,
+    ask_question,
+    build_moss_graph,
+)
+
+load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+
+
+def _parse_filter_eq(raw: str | None) -> dict[str, object] | None:
+    """Parse a simple equality filter in the form: field=value."""
+    if not raw:
+        return None
+
+    if "=" not in raw:
+        raise ValueError(
+            "--filter-eq must be in the form field=value (e.g. category=returns)."
+        )
+
+    field, value = raw.split("=", 1)
+    field = field.strip()
+    value = value.strip()
+
+    if not field or not value:
+        raise ValueError(
+            "--filter-eq must be in the form field=value (e.g. category=returns)."
+        )
+
+    return {"field": field, "condition": {"$eq": value}}
+
+
+async def _load_index_before_graph_runs(client: MossClient, index_name: str) -> None:
+    """Explicitly load the Moss index before the graph starts."""
+    print(f"Loading Moss index '{index_name}' locally before the graph runs...")
+
+    # Local load keeps query() on the in-memory hot path and enables filters.
+    await client.load_index(index_name)
+
+    print(
+        "Local load complete. Retrieval now stays in-memory "
+        "(~1-10ms) instead of cloud fallback (~100-500ms).\n"
+    )
+
+
+def _print_response(result: LangGraphMossState) -> None:
+    search_result = result.get("retrieval_results")
+    docs = search_result.docs if search_result is not None else []
+    time_taken_ms = result.get("retrieval_time_ms")
+    latency = f"{time_taken_ms}ms" if time_taken_ms is not None else "unknown time"
+
+    print(f"\n[Moss returned {len(docs)} docs in {latency}]")
+    if docs:
+        for doc in docs:
+            print(f"- {doc.id} (score={doc.score:.3f})")
+    print(f"\nAssistant: {result.get('answer', 'No answer generated.')}\n")
+
+
+async def run_langgraph_agent(
+    question: str | None = None,
+    filter_eq: str | None = None,
+    top_k: int = 4,
+    alpha: float | None = None,
+) -> None:
+    """Run the LangGraph example in single-shot or interactive mode."""
+    project_id = _require_env("MOSS_PROJECT_ID")
+    project_key = _require_env("MOSS_PROJECT_KEY")
+    index_name = _require_env("MOSS_INDEX_NAME")
+    groq_api_key = _require_env("GROQ_API_KEY")
+    model = os.getenv("GROQ_MODEL", "llama-3.3-70b-versatile")
+
+    client = MossClient(project_id, project_key)
+    await _load_index_before_graph_runs(client, index_name)
+
+    llm = ChatGroq(model=model, api_key=groq_api_key, temperature=0)
+    graph = build_moss_graph(client, index_name, llm)
+
+    if question:
+        metadata_filter = _parse_filter_eq(filter_eq)
+        result = await ask_question(
+            graph,
+            user_question=question,
+            metadata_filter=metadata_filter,
+            top_k=top_k,
+            alpha=alpha,
+        )
+        _print_response(result)
+        return
+
+    print("=== Moss + LangGraph Grounded Agent ===")
+    print("Each turn runs: question -> retrieve node -> generate node")
+    print("Type 'quit' to exit.\n")
+
+    while True:
+        try:
+            user_question = input("You: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\nGoodbye!")
+            break
+
+        if not user_question:
+            continue
+        if user_question.lower() in {"quit", "exit", "q"}:
+            print("Goodbye!")
+            break
+
+        try:
+            raw_filter = input("Metadata filter (optional, field=value): ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\nGoodbye!")
+            break
+
+        try:
+            metadata_filter = _parse_filter_eq(raw_filter or None)
+            result = await ask_question(
+                graph,
+                user_question=user_question,
+                metadata_filter=metadata_filter,
+                top_k=top_k,
+                alpha=alpha,
+            )
+            _print_response(result)
+        except Exception as exc:
+            print(f"\nError: {exc}\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="LangGraph cookbook example using Moss as a retrieval node."
+    )
+    parser.add_argument(
+        "--question",
+        help="Single question to answer. Omit for interactive mode.",
+    )
+    parser.add_argument(
+        "--filter-eq",
+        help="Optional convenience filter in the form field=value (e.g. category=returns).",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=4,
+        help="Number of Moss results to retrieve per question.",
+    )
+    parser.add_argument(
+        "--alpha",
+        type=float,
+        default=None,
+        help=(
+            "Optional Moss hybrid search blend from 0.0 keyword-only to "
+            "1.0 semantic-only. Omit to use the SDK default."
+        ),
+    )
+    args = parser.parse_args()
+
+    asyncio.run(
+        run_langgraph_agent(
+            question=args.question,
+            filter_eq=args.filter_eq,
+            top_k=args.top_k,
+            alpha=args.alpha,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cookbook/langgraph/moss_langgraph.py
+++ b/examples/cookbook/langgraph/moss_langgraph.py
@@ -11,7 +11,7 @@ from typing import Any, NotRequired, TypedDict
 from dotenv import load_dotenv
 from langchain_groq import ChatGroq
 from langgraph.graph import END, START, StateGraph
-from moss import MossClient, QueryOptions
+from moss import MossClient, QueryOptions, SearchResult
 
 load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
 
@@ -22,22 +22,14 @@ SYSTEM_PROMPT = (
 )
 
 
-class RetrievedDoc(TypedDict):
-    """Minimal document shape stored in graph state after retrieval."""
-
-    id: str
-    text: str
-    score: float
-    metadata: dict[str, str]
-
-
 class LangGraphMossState(TypedDict):
     """State shared across the LangGraph nodes."""
 
     query: str
     metadata_filter: NotRequired[dict[str, Any] | None]
     top_k: NotRequired[int]
-    retrieval_results: NotRequired[list[RetrievedDoc]]
+    alpha: NotRequired[float | None]
+    retrieval_results: NotRequired[SearchResult]
     retrieval_context: NotRequired[str]
     retrieval_time_ms: NotRequired[int | None]
     answer: NotRequired[str]
@@ -68,16 +60,16 @@ def _parse_filter_eq(raw: str | None) -> dict[str, Any] | None:
     return {"field": field, "condition": {"$eq": value}}
 
 
-def _format_context(results: list[RetrievedDoc]) -> str:
-    if not results:
+def _format_context(result: SearchResult) -> str:
+    if not result.docs:
         return "No relevant Moss results were returned."
 
     blocks: list[str] = []
-    for idx, result in enumerate(results, start=1):
-        metadata = json.dumps(result["metadata"], sort_keys=True)
+    for idx, doc in enumerate(result.docs, start=1):
+        metadata = json.dumps(doc.metadata or {}, sort_keys=True)
         blocks.append(
-            f"[{idx}] id={result['id']} score={result['score']:.3f} "
-            f"metadata={metadata}\n{result['text']}"
+            f"[{idx}] id={doc.id} score={doc.score:.3f} "
+            f"metadata={metadata}\n{doc.text}"
         )
     return "\n\n".join(blocks)
 
@@ -126,30 +118,21 @@ def build_moss_graph(
         query = state["query"]
         metadata_filter = state.get("metadata_filter")
         top_k = state.get("top_k", 4)
+        alpha = state.get("alpha")
 
         result = await client.query(
             index_name,
             query,
             QueryOptions(
                 top_k=top_k,
-                alpha=0.8,
+                alpha=alpha,
                 filter=metadata_filter,
             ),
         )
 
-        retrieval_results: list[RetrievedDoc] = [
-            {
-                "id": doc.id,
-                "text": doc.text,
-                "score": doc.score,
-                "metadata": doc.metadata or {},
-            }
-            for doc in result.docs
-        ]
-
         return {
-            "retrieval_results": retrieval_results,
-            "retrieval_context": _format_context(retrieval_results),
+            "retrieval_results": result,
+            "retrieval_context": _format_context(result),
             "retrieval_time_ms": result.time_taken_ms,
         }
 
@@ -184,6 +167,7 @@ async def ask_question(
     user_question: str,
     metadata_filter: dict[str, Any] | None,
     top_k: int,
+    alpha: float | None,
 ) -> LangGraphMossState:
     """Run a single LangGraph invocation."""
     result = await graph.ainvoke(
@@ -191,20 +175,22 @@ async def ask_question(
             "query": user_question,
             "metadata_filter": metadata_filter,
             "top_k": top_k,
+            "alpha": alpha,
         }
     )
     return result
 
 
 def _print_response(result: LangGraphMossState) -> None:
-    docs = result.get("retrieval_results", [])
+    search_result = result.get("retrieval_results")
+    docs = search_result.docs if search_result is not None else []
     time_taken_ms = result.get("retrieval_time_ms")
     latency = f"{time_taken_ms}ms" if time_taken_ms is not None else "unknown time"
 
     print(f"\n[Moss returned {len(docs)} docs in {latency}]")
     if docs:
         for doc in docs:
-            print(f"- {doc['id']} (score={doc['score']:.3f})")
+            print(f"- {doc.id} (score={doc.score:.3f})")
     print(f"\nAssistant: {result.get('answer', 'No answer generated.')}\n")
 
 
@@ -212,6 +198,7 @@ async def run_langgraph_agent(
     question: str | None = None,
     filter_eq: str | None = None,
     top_k: int = 4,
+    alpha: float | None = None,
 ) -> None:
     """Run the LangGraph example in single-shot or interactive mode."""
     project_id = _require_env("MOSS_PROJECT_ID")
@@ -233,6 +220,7 @@ async def run_langgraph_agent(
             user_question=question,
             metadata_filter=metadata_filter,
             top_k=top_k,
+            alpha=alpha,
         )
         _print_response(result)
         return
@@ -269,6 +257,7 @@ async def run_langgraph_agent(
                 user_question=user_question,
                 metadata_filter=metadata_filter,
                 top_k=top_k,
+                alpha=alpha,
             )
             _print_response(result)
         except Exception as exc:
@@ -293,6 +282,15 @@ def main() -> None:
         default=4,
         help="Number of Moss results to retrieve per question.",
     )
+    parser.add_argument(
+        "--alpha",
+        type=float,
+        default=None,
+        help=(
+            "Optional Moss hybrid search blend from 0.0 keyword-only to "
+            "1.0 semantic-only. Omit to use the SDK default."
+        ),
+    )
     args = parser.parse_args()
 
     asyncio.run(
@@ -300,6 +298,7 @@ def main() -> None:
             question=args.question,
             filter_eq=args.filter_eq,
             top_k=args.top_k,
+            alpha=args.alpha,
         )
     )
 

--- a/examples/cookbook/langgraph/moss_langgraph.py
+++ b/examples/cookbook/langgraph/moss_langgraph.py
@@ -254,9 +254,13 @@ async def run_langgraph_agent(
             print("Goodbye!")
             break
 
-        raw_filter = input(
-            "Metadata filter (optional, field=value): "
-        ).strip()
+        try:
+            raw_filter = input(
+                "Metadata filter (optional, field=value): "
+            ).strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\nGoodbye!")
+            break
 
         try:
             metadata_filter = _parse_filter_eq(raw_filter or None)

--- a/examples/cookbook/langgraph/moss_langgraph.py
+++ b/examples/cookbook/langgraph/moss_langgraph.py
@@ -1,0 +1,304 @@
+"""LangGraph cookbook example using Moss as a retrieval node."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from typing import Any, NotRequired, TypedDict
+
+from dotenv import load_dotenv
+from langchain_groq import ChatGroq
+from langgraph.graph import END, START, StateGraph
+from moss import MossClient, QueryOptions
+
+load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
+
+SYSTEM_PROMPT = (
+    "You are a grounded assistant. Answer the user's question only from the "
+    "retrieved Moss context. If the context is missing or insufficient, say "
+    "that clearly instead of making up facts."
+)
+
+
+class RetrievedDoc(TypedDict):
+    """Minimal document shape stored in graph state after retrieval."""
+
+    id: str
+    text: str
+    score: float
+    metadata: dict[str, str]
+
+
+class LangGraphMossState(TypedDict):
+    """State shared across the LangGraph nodes."""
+
+    query: str
+    metadata_filter: NotRequired[dict[str, Any] | None]
+    top_k: NotRequired[int]
+    retrieval_results: NotRequired[list[RetrievedDoc]]
+    retrieval_context: NotRequired[str]
+    retrieval_time_ms: NotRequired[int | None]
+    answer: NotRequired[str]
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+
+
+def _parse_filter_eq(raw: str | None) -> dict[str, Any] | None:
+    """Parse a simple equality filter in the form: field=value."""
+    if not raw:
+        return None
+
+    if "=" not in raw:
+        raise ValueError("--filter-eq must be in the form field=value (e.g. category=returns).")
+
+    field, value = raw.split("=", 1)
+    field = field.strip()
+    value = value.strip()
+
+    if not field or not value:
+        raise ValueError("--filter-eq must be in the form field=value (e.g. category=returns).")
+
+    return {"field": field, "condition": {"$eq": value}}
+
+
+def _format_context(results: list[RetrievedDoc]) -> str:
+    if not results:
+        return "No relevant Moss results were returned."
+
+    blocks: list[str] = []
+    for idx, result in enumerate(results, start=1):
+        metadata = json.dumps(result["metadata"], sort_keys=True)
+        blocks.append(
+            f"[{idx}] id={result['id']} score={result['score']:.3f} "
+            f"metadata={metadata}\n{result['text']}"
+        )
+    return "\n\n".join(blocks)
+
+
+def _message_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+
+    if isinstance(content, list):
+        text_parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                text_parts.append(item)
+            elif isinstance(item, dict) and item.get("type") == "text":
+                text = item.get("text")
+                if isinstance(text, str):
+                    text_parts.append(text)
+        if text_parts:
+            return "\n".join(text_parts).strip()
+
+    return str(content)
+
+
+async def load_index_before_graph_runs(client: MossClient, index_name: str) -> None:
+    """Explicitly load the Moss index before the graph starts."""
+    print(f"Loading Moss index '{index_name}' locally before the graph runs...")
+
+    # Local load keeps query() on the in-memory hot path and enables filters.
+    await client.load_index(index_name)
+
+    print(
+        "Local load complete. Retrieval now stays in-memory "
+        "(~1-10ms) instead of cloud fallback (~100-500ms).\n"
+    )
+
+
+def build_moss_graph(
+    client: MossClient,
+    index_name: str,
+    llm: ChatGroq,
+):
+    """Build a LangGraph graph with retrieve -> generate nodes."""
+
+    async def retrieve(state: LangGraphMossState) -> dict[str, Any]:
+        """Retrieve documents from Moss and write them back into graph state."""
+        query = state["query"]
+        metadata_filter = state.get("metadata_filter")
+        top_k = state.get("top_k", 4)
+
+        result = await client.query(
+            index_name,
+            query,
+            QueryOptions(
+                top_k=top_k,
+                alpha=0.8,
+                filter=metadata_filter,
+            ),
+        )
+
+        retrieval_results: list[RetrievedDoc] = [
+            {
+                "id": doc.id,
+                "text": doc.text,
+                "score": doc.score,
+                "metadata": doc.metadata or {},
+            }
+            for doc in result.docs
+        ]
+
+        return {
+            "retrieval_results": retrieval_results,
+            "retrieval_context": _format_context(retrieval_results),
+            "retrieval_time_ms": result.time_taken_ms,
+        }
+
+    async def generate(state: LangGraphMossState) -> dict[str, str]:
+        """Generate a grounded answer from retrieved Moss context."""
+        response = await llm.ainvoke(
+            [
+                ("system", SYSTEM_PROMPT),
+                (
+                    "human",
+                    "Question:\n"
+                    f"{state['query']}\n\n"
+                    "Retrieved Moss context:\n"
+                    f"{state.get('retrieval_context', 'No retrieval context available.')}",
+                ),
+            ]
+        )
+
+        return {"answer": _message_to_text(response.content)}
+
+    graph = StateGraph(LangGraphMossState)
+    graph.add_node("retrieve", retrieve)
+    graph.add_node("generate", generate)
+    graph.add_edge(START, "retrieve")
+    graph.add_edge("retrieve", "generate")
+    graph.add_edge("generate", END)
+    return graph.compile()
+
+
+async def ask_question(
+    graph: Any,
+    user_question: str,
+    metadata_filter: dict[str, Any] | None,
+    top_k: int,
+) -> LangGraphMossState:
+    """Run a single LangGraph invocation."""
+    result = await graph.ainvoke(
+        {
+            "query": user_question,
+            "metadata_filter": metadata_filter,
+            "top_k": top_k,
+        }
+    )
+    return result
+
+
+def _print_response(result: LangGraphMossState) -> None:
+    docs = result.get("retrieval_results", [])
+    time_taken_ms = result.get("retrieval_time_ms")
+    latency = f"{time_taken_ms}ms" if time_taken_ms is not None else "unknown time"
+
+    print(f"\n[Moss returned {len(docs)} docs in {latency}]")
+    if docs:
+        for doc in docs:
+            print(f"- {doc['id']} (score={doc['score']:.3f})")
+    print(f"\nAssistant: {result.get('answer', 'No answer generated.')}\n")
+
+
+async def run_langgraph_agent(
+    question: str | None = None,
+    filter_eq: str | None = None,
+    top_k: int = 4,
+) -> None:
+    """Run the LangGraph example in single-shot or interactive mode."""
+    project_id = _require_env("MOSS_PROJECT_ID")
+    project_key = _require_env("MOSS_PROJECT_KEY")
+    index_name = _require_env("MOSS_INDEX_NAME")
+    groq_api_key = _require_env("GROQ_API_KEY")
+    model = os.getenv("GROQ_MODEL", "llama-3.3-70b-versatile")
+
+    client = MossClient(project_id, project_key)
+    await load_index_before_graph_runs(client, index_name)
+
+    llm = ChatGroq(model=model, api_key=groq_api_key, temperature=0)
+    graph = build_moss_graph(client, index_name, llm)
+
+    if question:
+        metadata_filter = _parse_filter_eq(filter_eq)
+        result = await ask_question(
+            graph,
+            user_question=question,
+            metadata_filter=metadata_filter,
+            top_k=top_k,
+        )
+        _print_response(result)
+        return
+
+    print("=== Moss + LangGraph Grounded Agent ===")
+    print("Each turn runs: question -> retrieve node -> generate node")
+    print("Type 'quit' to exit.\n")
+
+    while True:
+        try:
+            user_question = input("You: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\nGoodbye!")
+            break
+
+        if not user_question:
+            continue
+        if user_question.lower() in {"quit", "exit", "q"}:
+            print("Goodbye!")
+            break
+
+        raw_filter = input(
+            "Metadata filter (optional, field=value): "
+        ).strip()
+
+        try:
+            metadata_filter = _parse_filter_eq(raw_filter or None)
+            result = await ask_question(
+                graph,
+                user_question=user_question,
+                metadata_filter=metadata_filter,
+                top_k=top_k,
+            )
+            _print_response(result)
+        except Exception as exc:
+            print(f"\nError: {exc}\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="LangGraph cookbook example using Moss as a retrieval node."
+    )
+    parser.add_argument(
+        "--question",
+        help="Single question to answer. Omit for interactive mode.",
+    )
+    parser.add_argument(
+        "--filter-eq",
+        help="Optional convenience filter in the form field=value (e.g. category=returns).",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=4,
+        help="Number of Moss results to retrieve per question.",
+    )
+    args = parser.parse_args()
+
+    asyncio.run(
+        run_langgraph_agent(
+            question=args.question,
+            filter_eq=args.filter_eq,
+            top_k=args.top_k,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cookbook/langgraph/moss_langgraph.py
+++ b/examples/cookbook/langgraph/moss_langgraph.py
@@ -1,19 +1,12 @@
-"""LangGraph cookbook example using Moss as a retrieval node."""
+"""Core LangGraph + Moss integration helpers for the cookbook example."""
 
 from __future__ import annotations
 
-import argparse
-import asyncio
 import json
-import os
 from typing import Any, NotRequired, TypedDict
 
-from dotenv import load_dotenv
-from langchain_groq import ChatGroq
 from langgraph.graph import END, START, StateGraph
 from moss import MossClient, QueryOptions, SearchResult
-
-load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
 
 SYSTEM_PROMPT = (
     "You are a grounded assistant. Answer the user's question only from the "
@@ -33,31 +26,6 @@ class LangGraphMossState(TypedDict):
     retrieval_context: NotRequired[str]
     retrieval_time_ms: NotRequired[int | None]
     answer: NotRequired[str]
-
-
-def _require_env(name: str) -> str:
-    value = os.getenv(name)
-    if not value:
-        raise RuntimeError(f"Missing required environment variable: {name}")
-    return value
-
-
-def _parse_filter_eq(raw: str | None) -> dict[str, Any] | None:
-    """Parse a simple equality filter in the form: field=value."""
-    if not raw:
-        return None
-
-    if "=" not in raw:
-        raise ValueError("--filter-eq must be in the form field=value (e.g. category=returns).")
-
-    field, value = raw.split("=", 1)
-    field = field.strip()
-    value = value.strip()
-
-    if not field or not value:
-        raise ValueError("--filter-eq must be in the form field=value (e.g. category=returns).")
-
-    return {"field": field, "condition": {"$eq": value}}
 
 
 def _format_context(result: SearchResult) -> str:
@@ -93,23 +61,10 @@ def _message_to_text(content: Any) -> str:
     return str(content)
 
 
-async def load_index_before_graph_runs(client: MossClient, index_name: str) -> None:
-    """Explicitly load the Moss index before the graph starts."""
-    print(f"Loading Moss index '{index_name}' locally before the graph runs...")
-
-    # Local load keeps query() on the in-memory hot path and enables filters.
-    await client.load_index(index_name)
-
-    print(
-        "Local load complete. Retrieval now stays in-memory "
-        "(~1-10ms) instead of cloud fallback (~100-500ms).\n"
-    )
-
-
 def build_moss_graph(
     client: MossClient,
     index_name: str,
-    llm: ChatGroq,
+    llm: Any,
 ):
     """Build a LangGraph graph with retrieve -> generate nodes."""
 
@@ -179,129 +134,3 @@ async def ask_question(
         }
     )
     return result
-
-
-def _print_response(result: LangGraphMossState) -> None:
-    search_result = result.get("retrieval_results")
-    docs = search_result.docs if search_result is not None else []
-    time_taken_ms = result.get("retrieval_time_ms")
-    latency = f"{time_taken_ms}ms" if time_taken_ms is not None else "unknown time"
-
-    print(f"\n[Moss returned {len(docs)} docs in {latency}]")
-    if docs:
-        for doc in docs:
-            print(f"- {doc.id} (score={doc.score:.3f})")
-    print(f"\nAssistant: {result.get('answer', 'No answer generated.')}\n")
-
-
-async def run_langgraph_agent(
-    question: str | None = None,
-    filter_eq: str | None = None,
-    top_k: int = 4,
-    alpha: float | None = None,
-) -> None:
-    """Run the LangGraph example in single-shot or interactive mode."""
-    project_id = _require_env("MOSS_PROJECT_ID")
-    project_key = _require_env("MOSS_PROJECT_KEY")
-    index_name = _require_env("MOSS_INDEX_NAME")
-    groq_api_key = _require_env("GROQ_API_KEY")
-    model = os.getenv("GROQ_MODEL", "llama-3.3-70b-versatile")
-
-    client = MossClient(project_id, project_key)
-    await load_index_before_graph_runs(client, index_name)
-
-    llm = ChatGroq(model=model, api_key=groq_api_key, temperature=0)
-    graph = build_moss_graph(client, index_name, llm)
-
-    if question:
-        metadata_filter = _parse_filter_eq(filter_eq)
-        result = await ask_question(
-            graph,
-            user_question=question,
-            metadata_filter=metadata_filter,
-            top_k=top_k,
-            alpha=alpha,
-        )
-        _print_response(result)
-        return
-
-    print("=== Moss + LangGraph Grounded Agent ===")
-    print("Each turn runs: question -> retrieve node -> generate node")
-    print("Type 'quit' to exit.\n")
-
-    while True:
-        try:
-            user_question = input("You: ").strip()
-        except (EOFError, KeyboardInterrupt):
-            print("\nGoodbye!")
-            break
-
-        if not user_question:
-            continue
-        if user_question.lower() in {"quit", "exit", "q"}:
-            print("Goodbye!")
-            break
-
-        try:
-            raw_filter = input(
-                "Metadata filter (optional, field=value): "
-            ).strip()
-        except (EOFError, KeyboardInterrupt):
-            print("\nGoodbye!")
-            break
-
-        try:
-            metadata_filter = _parse_filter_eq(raw_filter or None)
-            result = await ask_question(
-                graph,
-                user_question=user_question,
-                metadata_filter=metadata_filter,
-                top_k=top_k,
-                alpha=alpha,
-            )
-            _print_response(result)
-        except Exception as exc:
-            print(f"\nError: {exc}\n")
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="LangGraph cookbook example using Moss as a retrieval node."
-    )
-    parser.add_argument(
-        "--question",
-        help="Single question to answer. Omit for interactive mode.",
-    )
-    parser.add_argument(
-        "--filter-eq",
-        help="Optional convenience filter in the form field=value (e.g. category=returns).",
-    )
-    parser.add_argument(
-        "--top-k",
-        type=int,
-        default=4,
-        help="Number of Moss results to retrieve per question.",
-    )
-    parser.add_argument(
-        "--alpha",
-        type=float,
-        default=None,
-        help=(
-            "Optional Moss hybrid search blend from 0.0 keyword-only to "
-            "1.0 semantic-only. Omit to use the SDK default."
-        ),
-    )
-    args = parser.parse_args()
-
-    asyncio.run(
-        run_langgraph_agent(
-            question=args.question,
-            filter_eq=args.filter_eq,
-            top_k=args.top_k,
-            alpha=args.alpha,
-        )
-    )
-
-
-if __name__ == "__main__":
-    main()

--- a/examples/cookbook/langgraph/pyproject.toml
+++ b/examples/cookbook/langgraph/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "langgraph-moss"
+version = "0.1.0"
+description = "LangGraph cookbook example for Moss retrieval"
+readme = "README.md"
+requires-python = ">=3.11,<3.14"
+license = { text = "BSD-2-Clause" }
+authors = [
+    { name = "InferEdge Inc.", email = "contact@moss.dev" }
+]
+dependencies = [
+    "langgraph>=0.2",
+    "langchain-groq",
+    "moss>=1.0.0b19",
+    "python-dotenv",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["create_index.py", "moss_langgraph.py"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    ".env.example",
+    "README.md",
+    "create_index.py",
+    "moss_langgraph.py",
+]

--- a/examples/cookbook/langgraph/pyproject.toml
+++ b/examples/cookbook/langgraph/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["create_index.py", "moss_langgraph.py", "test_integration.py"]
+packages = ["create_index.py", "moss_langgraph.py"]
 
 [tool.hatch.build.targets.sdist]
 include = [
@@ -28,5 +28,4 @@ include = [
     "README.md",
     "create_index.py",
     "moss_langgraph.py",
-    "test_integration.py",
 ]

--- a/examples/cookbook/langgraph/pyproject.toml
+++ b/examples/cookbook/langgraph/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 dependencies = [
     "langgraph>=0.2",
     "langchain-groq",
-    "moss>=1.0.0b19",
+    "moss>=1.0.0",
     "python-dotenv",
 ]
 

--- a/examples/cookbook/langgraph/pyproject.toml
+++ b/examples/cookbook/langgraph/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["create_index.py", "moss_langgraph.py"]
+packages = ["create_index.py", "moss_langgraph.py", "test_integration.py"]
 
 [tool.hatch.build.targets.sdist]
 include = [
@@ -28,4 +28,5 @@ include = [
     "README.md",
     "create_index.py",
     "moss_langgraph.py",
+    "test_integration.py",
 ]

--- a/examples/cookbook/langgraph/pyproject.toml
+++ b/examples/cookbook/langgraph/pyproject.toml
@@ -20,12 +20,11 @@ dependencies = [
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["create_index.py", "moss_langgraph.py"]
+packages = ["moss_langgraph.py"]
 
 [tool.hatch.build.targets.sdist]
 include = [
     ".env.example",
     "README.md",
-    "create_index.py",
     "moss_langgraph.py",
 ]

--- a/examples/cookbook/langgraph/pyproject.toml
+++ b/examples/cookbook/langgraph/pyproject.toml
@@ -7,7 +7,7 @@ name = "langgraph-moss"
 version = "0.1.0"
 description = "LangGraph cookbook example for Moss retrieval"
 readme = "README.md"
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11"
 license = { text = "BSD-2-Clause" }
 authors = [
     { name = "InferEdge Inc.", email = "contact@moss.dev" }

--- a/examples/cookbook/langgraph/test_integration.py
+++ b/examples/cookbook/langgraph/test_integration.py
@@ -1,0 +1,131 @@
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from moss_langgraph import (
+    _parse_filter_eq,
+    ask_question,
+    build_moss_graph,
+    load_index_before_graph_runs,
+    run_langgraph_agent,
+)
+
+
+class TestLangGraphHelpers(unittest.TestCase):
+    def test_parse_filter_eq_builds_moss_filter(self):
+        self.assertEqual(
+            _parse_filter_eq("category=returns"),
+            {"field": "category", "condition": {"$eq": "returns"}},
+        )
+
+    def test_parse_filter_eq_rejects_invalid_input(self):
+        with self.assertRaises(ValueError):
+            _parse_filter_eq("category")
+
+
+class TestLangGraphIntegration(unittest.IsolatedAsyncioTestCase):
+    async def test_load_index_before_graph_runs_calls_client(self):
+        client = MagicMock()
+        client.load_index = AsyncMock()
+
+        await load_index_before_graph_runs(client, "idx")
+
+        client.load_index.assert_awaited_once_with("idx")
+
+    async def test_ask_question_returns_retrieval_and_answer(self):
+        client = MagicMock()
+        client.query = AsyncMock(
+            return_value=MagicMock(
+                docs=[
+                    MagicMock(
+                        id="faq-returns-1",
+                        text="Refunds take 3 to 5 business days.",
+                        score=0.99,
+                        metadata={"category": "returns"},
+                    )
+                ],
+                time_taken_ms=7,
+            )
+        )
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(return_value=MagicMock(content="Grounded answer"))
+
+        graph = build_moss_graph(client, "idx", llm)
+        result = await ask_question(
+            graph,
+            user_question="What is the refund policy?",
+            metadata_filter={"field": "category", "condition": {"$eq": "returns"}},
+            top_k=2,
+        )
+
+        self.assertEqual(result["answer"], "Grounded answer")
+        self.assertEqual(result["retrieval_time_ms"], 7)
+        self.assertEqual(len(result["retrieval_results"]), 1)
+        self.assertEqual(result["retrieval_results"][0]["id"], "faq-returns-1")
+        self.assertIn("Refunds take 3 to 5 business days.", result["retrieval_context"])
+
+        client.query.assert_awaited_once()
+        call_args = client.query.await_args.args
+        self.assertEqual(call_args[0], "idx")
+        self.assertEqual(call_args[1], "What is the refund policy?")
+        self.assertEqual(call_args[2].top_k, 2)
+        self.assertEqual(
+            call_args[2].filter,
+            {"field": "category", "condition": {"$eq": "returns"}},
+        )
+
+    @patch.dict(
+        os.environ,
+        {
+            "MOSS_PROJECT_ID": "project-id",
+            "MOSS_PROJECT_KEY": "project-key",
+            "MOSS_INDEX_NAME": "demo-index",
+            "GROQ_API_KEY": "groq-key",
+            "GROQ_MODEL": "llama-3.3-70b-versatile",
+        },
+        clear=False,
+    )
+    @patch("moss_langgraph._print_response")
+    @patch("moss_langgraph.ChatGroq")
+    @patch("moss_langgraph.MossClient")
+    async def test_run_langgraph_agent_single_shot(self, mock_client_cls, mock_groq_cls, mock_print):
+        mock_client = mock_client_cls.return_value
+        mock_client.load_index = AsyncMock()
+        mock_client.query = AsyncMock(
+            return_value=MagicMock(
+                docs=[
+                    MagicMock(
+                        id="faq-returns-1",
+                        text="Refunds take 3 to 5 business days.",
+                        score=1.0,
+                        metadata={"category": "returns"},
+                    )
+                ],
+                time_taken_ms=3,
+            )
+        )
+
+        mock_llm = mock_groq_cls.return_value
+        mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="Grounded answer"))
+
+        await run_langgraph_agent(
+            question="What is the refund policy?",
+            filter_eq="category=returns",
+            top_k=1,
+        )
+
+        mock_client.load_index.assert_awaited_once_with("demo-index")
+        mock_client.query.assert_awaited_once()
+        mock_groq_cls.assert_called_once_with(
+            model="llama-3.3-70b-versatile",
+            api_key="groq-key",
+            temperature=0,
+        )
+        mock_print.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/cookbook/langgraph/test_integration.py
+++ b/examples/cookbook/langgraph/test_integration.py
@@ -59,12 +59,13 @@ class TestLangGraphIntegration(unittest.IsolatedAsyncioTestCase):
             user_question="What is the refund policy?",
             metadata_filter={"field": "category", "condition": {"$eq": "returns"}},
             top_k=2,
+            alpha=0.6,
         )
 
         self.assertEqual(result["answer"], "Grounded answer")
         self.assertEqual(result["retrieval_time_ms"], 7)
-        self.assertEqual(len(result["retrieval_results"]), 1)
-        self.assertEqual(result["retrieval_results"][0]["id"], "faq-returns-1")
+        self.assertEqual(len(result["retrieval_results"].docs), 1)
+        self.assertEqual(result["retrieval_results"].docs[0].id, "faq-returns-1")
         self.assertIn("Refunds take 3 to 5 business days.", result["retrieval_context"])
 
         client.query.assert_awaited_once()
@@ -72,6 +73,7 @@ class TestLangGraphIntegration(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(call_args[0], "idx")
         self.assertEqual(call_args[1], "What is the refund policy?")
         self.assertEqual(call_args[2].top_k, 2)
+        self.assertAlmostEqual(call_args[2].alpha, 0.6)
         self.assertEqual(
             call_args[2].filter,
             {"field": "category", "condition": {"$eq": "returns"}},
@@ -115,10 +117,12 @@ class TestLangGraphIntegration(unittest.IsolatedAsyncioTestCase):
             question="What is the refund policy?",
             filter_eq="category=returns",
             top_k=1,
+            alpha=0.7,
         )
 
         mock_client.load_index.assert_awaited_once_with("demo-index")
         mock_client.query.assert_awaited_once()
+        self.assertAlmostEqual(mock_client.query.await_args.args[2].alpha, 0.7)
         mock_groq_cls.assert_called_once_with(
             model="llama-3.3-70b-versatile",
             api_key="groq-key",

--- a/examples/cookbook/langgraph/test_integration.py
+++ b/examples/cookbook/langgraph/test_integration.py
@@ -6,10 +6,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 sys.path.insert(0, os.path.dirname(__file__))
 
 from moss_langgraph import (
-    _parse_filter_eq,
     ask_question,
     build_moss_graph,
-    load_index_before_graph_runs,
+)
+from example_usage import (
+    _load_index_before_graph_runs,
+    _parse_filter_eq,
     run_langgraph_agent,
 )
 
@@ -31,7 +33,7 @@ class TestLangGraphIntegration(unittest.IsolatedAsyncioTestCase):
         client = MagicMock()
         client.load_index = AsyncMock()
 
-        await load_index_before_graph_runs(client, "idx")
+        await _load_index_before_graph_runs(client, "idx")
 
         client.load_index.assert_awaited_once_with("idx")
 
@@ -90,9 +92,9 @@ class TestLangGraphIntegration(unittest.IsolatedAsyncioTestCase):
         },
         clear=False,
     )
-    @patch("moss_langgraph._print_response")
-    @patch("moss_langgraph.ChatGroq")
-    @patch("moss_langgraph.MossClient")
+    @patch("example_usage._print_response")
+    @patch("example_usage.ChatGroq")
+    @patch("example_usage.MossClient")
     async def test_run_langgraph_agent_single_shot(self, mock_client_cls, mock_groq_cls, mock_print):
         mock_client = mock_client_cls.return_value
         mock_client.load_index = AsyncMock()


### PR DESCRIPTION
## Pull Request Checklist

Please ensure that your PR meets the following requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [ ] I have updated the documentation (if applicable).
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Description

This PR adds a new cookbook example under `examples/cookbook/langgraph/` that demonstrates how to use Moss as the retrieval step inside a LangGraph stateful agent graph.

### What was implemented

The example now shows an end-to-end agent loop:

- user question enters the graph
- a `retrieve` node queries Moss
- retrieved documents are written back into graph state
- a `generate` node uses the retrieved context to produce a grounded answer

The cookbook explicitly demonstrates the behavior requested in the issue:

- Moss index loading happens locally through `load_index()` before the graph runs
- the retrieval node is a plain Python function
- `client.query()` is called from inside the retrieve step
- retrieval results are stored back into the graph state
- optional metadata filtering is passed through state and used during retrieval
- the example is documented with a short README explaining the state schema and the local-vs-cloud speed tradeoff

### Files added or updated

- `examples/cookbook/langgraph/moss_langgraph.py`
  - main LangGraph example
  - defines the graph state
  - loads the `.env` file from the example directory
  - explicitly calls `load_index()` before graph execution
  - implements the `retrieve` node and `generate` node
  - supports single-question and interactive modes
  - supports `--filter-eq field=value` for metadata filtering
  - prints retrieved documents, latency, and the final grounded answer

- `examples/cookbook/langgraph/create_index.py`
  - helper script for creating a demo Moss index
  - seeds a small FAQ-style corpus
  - includes metadata like `category=returns`
  - prints the generated `MOSS_INDEX_NAME`
  - makes it easy to test both normal retrieval and filtered retrieval

- `examples/cookbook/langgraph/README.md`
  - explains the purpose of the cookbook
  - documents the graph state schema
  - explains why `load_index()` must happen before graph execution
  - describes the retrieval speed difference between local loading and cloud fallback
  - documents setup and usage
  - reflects the Groq-based generation flow

- `examples/cookbook/langgraph/pyproject.toml`
  - adds the cookbook package metadata
  - declares dependencies for LangGraph, Groq, dotenv, and Moss
  - includes both the example script and the helper index creation script in the package build
  - aligns the Moss dependency with the local SDK version used in this repo

- `examples/cookbook/langgraph/.env.example`
  - provides the environment template for the cookbook
  - uses `GROQ_API_KEY` and `GROQ_MODEL`
  - keeps the Moss project and index configuration separate

### Validation performed

I tested the cookbook locally with the following checks:

- syntax validation on `moss_langgraph.py`
- CLI help output
- mocked LangGraph smoke tests
- live end-to-end execution with an existing Moss index
- filtered retrieval with `--filter-eq category=returns`

### Motivation

This cookbook gives users a clear, practical example of using Moss as the retrieval layer in a stateful LangGraph agent. It shows the recommended pattern for fast local retrieval, clean state passing, and grounded answer generation.
 
Fixes #90

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usemoss/moss/pull/182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
