### PR TITLE
Add C SDK examples

### DIFF
--- a/examples/c/README.md
+++ b/examples/c/README.md
@@ -4,7 +4,7 @@ This project demonstrates the usage of the Moss C SDK (`libmoss`) for semantic s
 
 ## Setup
 
-From this directory (`examples/c`), download the `libmoss` archive for your platform from the [latest release](https://github.com/usemoss/moss/releases) and extract it so that `include/` and `lib/` sit alongside the `.c` files.
+From this directory (`examples/c`), download the `libmoss` archive for your platform from the [`c-sdk-v0.9.0` release](https://github.com/usemoss/moss/releases/tag/c-sdk-v0.9.0) and extract it so that `include/` and `lib/` sit alongside the `.c` files.
 
 | Archive | OS | Arch |
 | --- | --- | --- |
@@ -38,6 +38,13 @@ examples/c/
 
 ## Running Samples
 
+Each sample reads `MOSS_PROJECT_ID` and `MOSS_PROJECT_KEY` from the environment. You can also pass them as positional arguments (`./<sample> <id> <key>`), but env vars are preferred so the key doesn't end up in shell history or `ps` output.
+
+```bash
+export MOSS_PROJECT_ID=...
+export MOSS_PROJECT_KEY=...
+```
+
 ### macOS
 
 Build and run any sample (replace `<sample>` with `session_usage`, `example_usage`, or `metadata_filtering`):
@@ -47,7 +54,7 @@ clang <sample>.c -o <sample> \
   -Iinclude -Llib -lmoss \
   -framework Security -framework SystemConfiguration
 
-DYLD_LIBRARY_PATH=lib ./<sample> <project_id> <project_key>
+DYLD_LIBRARY_PATH=lib ./<sample>
 ```
 
 `DYLD_LIBRARY_PATH=lib` is required at runtime: the prebuilt `libmoss.dylib` has a build-server install path baked in, and this env var redirects the dynamic loader to your local copy.
@@ -59,7 +66,7 @@ gcc <sample>.c -o <sample> \
   -Iinclude -Llib -lmoss \
   -lpthread -lm -ldl
 
-LD_LIBRARY_PATH=lib ./<sample> <project_id> <project_key>
+LD_LIBRARY_PATH=lib ./<sample>
 ```
 
 ## What each sample does

--- a/examples/c/README.md
+++ b/examples/c/README.md
@@ -4,76 +4,71 @@ This project demonstrates the usage of the Moss C SDK (`libmoss`) for semantic s
 
 ## Setup
 
-Download `libmoss` for your platform from the [latest release](https://github.com/usemoss/moss/releases) and extract it next to these examples:
+From this directory (`examples/c`), download the `libmoss` archive for your platform from the [latest release](https://github.com/usemoss/moss/releases) and extract it so that `include/` and `lib/` sit alongside the `.c` files.
 
 | Archive | OS | Arch |
 | --- | --- | --- |
-| `libmoss-vX.Y.Z-aarch64-apple-darwin.tar.gz` | macOS | ARM64 (Apple Silicon) |
-| `libmoss-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz` | Linux | x86_64 |
-| `libmoss-vX.Y.Z-aarch64-unknown-linux-gnu.tar.gz` | Linux | ARM64 |
-| `libmoss-vX.Y.Z-x86_64-pc-windows-msvc.tar.gz` | Windows | x86_64 |
+| `libmoss-v0.9.0-aarch64-apple-darwin.tar.gz` | macOS | ARM64 (Apple Silicon) |
+| `libmoss-v0.9.0-x86_64-unknown-linux-gnu.tar.gz` | Linux | x86_64 |
+| `libmoss-v0.9.0-aarch64-unknown-linux-gnu.tar.gz` | Linux | ARM64 |
+| `libmoss-v0.9.0-x86_64-pc-windows-msvc.tar.gz` | Windows | x86_64 |
 
-Each archive contains an `include/` directory (with `libmoss.h`) and a `lib/` directory (with `libmoss.{dylib,so,dll}` and `libmoss.{a,lib}`). The build commands below assume these sit in the current directory — if you extracted elsewhere, replace `include` and `lib` with the appropriate paths.
+For example, on Apple Silicon macOS:
+
+```bash
+gh release download c-sdk-v0.9.0 --repo usemoss/moss \
+  --pattern 'libmoss-v0.9.0-aarch64-apple-darwin.tar.gz'
+tar xzf libmoss-v0.9.0-aarch64-apple-darwin.tar.gz --strip-components=1
+```
+
+After extraction, this directory should contain:
+
+```
+examples/c/
+├── README.md
+├── example_usage.c
+├── metadata_filtering.c
+├── session_usage.c
+├── include/
+│   └── libmoss.h
+└── lib/
+    ├── libmoss.dylib  (or .so / .dll)
+    └── libmoss.a      (or .lib)
+```
 
 ## Running Samples
 
-Each sample takes your Moss project credentials as CLI arguments:
+### macOS
+
+Build and run any sample (replace `<sample>` with `session_usage`, `example_usage`, or `metadata_filtering`):
 
 ```bash
-./<sample> <project_id> <project_key>
-```
-
-### Session Usage
-
-Create a client, open a session, add documents with metadata, query, and push to the cloud:
-
-```bash
-clang session_usage.c -o session_usage \
+clang <sample>.c -o <sample> \
   -Iinclude -Llib -lmoss \
   -framework Security -framework SystemConfiguration
 
-export DYLD_LIBRARY_PATH=lib
-./session_usage <project_id> <project_key>
+DYLD_LIBRARY_PATH=lib ./<sample> <project_id> <project_key>
 ```
 
-### Comprehensive Cloud Example
+`DYLD_LIBRARY_PATH=lib` is required at runtime: the prebuilt `libmoss.dylib` has a build-server install path baked in, and this env var redirects the dynamic loader to your local copy.
 
-Full cloud CRUD workflow — create index, add/get/delete docs, query, cleanup:
-
-```bash
-clang example_usage.c -o example_usage \
-  -Iinclude -Llib -lmoss \
-  -framework Security -framework SystemConfiguration
-
-./example_usage <project_id> <project_key>
-```
-
-### Metadata Filtering Sample
-
-Create an index, load it locally, and run queries filtered by document metadata using `$eq`, `$and`, `$in`, and `$near` operators:
-
-```bash
-clang metadata_filtering.c -o metadata_filtering \
-  -Iinclude -Llib -lmoss \
-  -framework Security -framework SystemConfiguration
-
-./metadata_filtering <project_id> <project_key>
-```
-
-## Linux
-
-Replace the `clang` invocation with `gcc` and swap the framework flags:
+### Linux
 
 ```bash
 gcc <sample>.c -o <sample> \
   -Iinclude -Llib -lmoss \
   -lpthread -lm -ldl
 
-export LD_LIBRARY_PATH=lib
-./<sample> <project_id> <project_key>
+LD_LIBRARY_PATH=lib ./<sample> <project_id> <project_key>
 ```
+
+## What each sample does
+
+- **`session_usage.c`**: Create a client, open a session, add documents with metadata, query (with and without filters), then push the session to the cloud.
+- **`example_usage.c`**: Full cloud CRUD: create an index, list/get indexes, add and delete documents, run semantic search, clean up.
+- **`metadata_filtering.c`**: Create an index, load it locally, and run queries filtered with `$eq`, `$and`, `$in`, and `$near` operators.
 
 ## Requirements
 
 - C compiler (`clang` on macOS, `gcc` on Linux)
-- Valid Moss project credentials
+- Valid Moss project credentials. Get them at [moss.dev](https://moss.dev).

--- a/examples/c/README.md
+++ b/examples/c/README.md
@@ -1,0 +1,79 @@
+# Moss C SDK Examples
+
+This project demonstrates the usage of the Moss C SDK (`libmoss`) for semantic search and document indexing.
+
+## Setup
+
+Download `libmoss` for your platform from the [latest release](https://github.com/usemoss/moss/releases) and extract it next to these examples:
+
+| Archive | OS | Arch |
+| --- | --- | --- |
+| `libmoss-vX.Y.Z-aarch64-apple-darwin.tar.gz` | macOS | ARM64 (Apple Silicon) |
+| `libmoss-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz` | Linux | x86_64 |
+| `libmoss-vX.Y.Z-aarch64-unknown-linux-gnu.tar.gz` | Linux | ARM64 |
+| `libmoss-vX.Y.Z-x86_64-pc-windows-msvc.tar.gz` | Windows | x86_64 |
+
+Each archive contains an `include/` directory (with `libmoss.h`) and a `lib/` directory (with `libmoss.{dylib,so,dll}` and `libmoss.{a,lib}`). The build commands below assume these sit in the current directory — if you extracted elsewhere, replace `include` and `lib` with the appropriate paths.
+
+## Running Samples
+
+Each sample takes your Moss project credentials as CLI arguments:
+
+```bash
+./<sample> <project_id> <project_key>
+```
+
+### Session Usage
+
+Create a client, open a session, add documents with metadata, query, and push to the cloud:
+
+```bash
+clang session_usage.c -o session_usage \
+  -Iinclude -Llib -lmoss \
+  -framework Security -framework SystemConfiguration
+
+export DYLD_LIBRARY_PATH=lib
+./session_usage <project_id> <project_key>
+```
+
+### Comprehensive Cloud Example
+
+Full cloud CRUD workflow — create index, add/get/delete docs, query, cleanup:
+
+```bash
+clang example_usage.c -o example_usage \
+  -Iinclude -Llib -lmoss \
+  -framework Security -framework SystemConfiguration
+
+./example_usage <project_id> <project_key>
+```
+
+### Metadata Filtering Sample
+
+Create an index, load it locally, and run queries filtered by document metadata using `$eq`, `$and`, `$in`, and `$near` operators:
+
+```bash
+clang metadata_filtering.c -o metadata_filtering \
+  -Iinclude -Llib -lmoss \
+  -framework Security -framework SystemConfiguration
+
+./metadata_filtering <project_id> <project_key>
+```
+
+## Linux
+
+Replace the `clang` invocation with `gcc` and swap the framework flags:
+
+```bash
+gcc <sample>.c -o <sample> \
+  -Iinclude -Llib -lmoss \
+  -lpthread -lm -ldl
+
+export LD_LIBRARY_PATH=lib
+./<sample> <project_id> <project_key>
+```
+
+## Requirements
+
+- C compiler (`clang` on macOS, `gcc` on Linux)
+- Valid Moss project credentials

--- a/examples/c/example_usage.c
+++ b/examples/c/example_usage.c
@@ -250,7 +250,7 @@ int main(int argc, char *argv[]) {
     /* ── 11. Final search ─────────────────────────────────────── */
 
     printf("\n11. Final search to verify everything works...\n");
-    MossQueryOptions final_opts = { .top_k = 2 };
+    MossQueryOptions final_opts = { .top_k = 2, .alpha = 0.5f };
     MossSearchResult *final_search = NULL;
     check(moss_client_query(client, index_name, "machine learning algorithms", &final_opts, &final_search), "query_final");
     for (size_t i = 0; i < final_search->doc_count; i++) {

--- a/examples/c/example_usage.c
+++ b/examples/c/example_usage.c
@@ -1,18 +1,19 @@
 /**
- * example_usage.c — Complete cloud workflow example for the Moss C SDK.
+ * example_usage.c: Complete cloud workflow example for the Moss C SDK.
  *
  * Demonstrates: create index, get index, list indexes, add docs,
  * get docs, load index, query, delete docs, delete index.
  *
+ * See README.md for setup. After extracting the libmoss release archive
+ * so that include/ and lib/ sit next to this file:
+ *
  * Build (macOS):
- *   cargo build --release
- *   clang examples/example_usage.c -o examples/example_usage \
- *     -I. -Ltarget/release -lmoss \
+ *   clang example_usage.c -o example_usage \
+ *     -Iinclude -Llib -lmoss \
  *     -framework Security -framework SystemConfiguration
  *
  * Run:
- *   export DYLD_LIBRARY_PATH=target/release
- *   ./examples/example_usage <project_id> <project_key>
+ *   DYLD_LIBRARY_PATH=lib ./example_usage <project_id> <project_key>
  */
 
 #include "libmoss.h"

--- a/examples/c/example_usage.c
+++ b/examples/c/example_usage.c
@@ -1,0 +1,268 @@
+/**
+ * example_usage.c — Complete cloud workflow example for the Moss C SDK.
+ *
+ * Demonstrates: create index, get index, list indexes, add docs,
+ * get docs, load index, query, delete docs, delete index.
+ *
+ * Build (macOS):
+ *   cargo build --release
+ *   clang examples/example_usage.c -o examples/example_usage \
+ *     -I. -Ltarget/release -lmoss \
+ *     -framework Security -framework SystemConfiguration
+ *
+ * Run:
+ *   export DYLD_LIBRARY_PATH=target/release
+ *   ./examples/example_usage <project_id> <project_key>
+ */
+
+#include "libmoss.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+static void check(MossResult r, const char *context) {
+    if (r != OK) {
+        const char *err = moss_last_error();
+        fprintf(stderr, "ERROR [%s]: %s\n", context, err ? err : "(no details)");
+        exit(1);
+    }
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 3) {
+        fprintf(stderr, "Usage: %s <project_id> <project_key>\n", argv[0]);
+        return 1;
+    }
+
+    const char *project_id  = argv[1];
+    const char *project_key = argv[2];
+
+    printf("Moss C SDK Complete Example\n");
+    printf("SDK version: %s\n\n", moss_sdk_version());
+
+    /* ── Create client ────────────────────────────────────────── */
+
+    MossClient *client = NULL;
+    check(moss_client_new(project_id, project_key, &client), "client_new");
+
+    /* ── Build unique index name ──────────────────────────────── */
+
+    char index_name[64];
+    time_t now = time(NULL);
+    struct tm *t = localtime(&now);
+    snprintf(index_name, sizeof(index_name),
+             "example-cloud-index-%04d%02d%02d-%02d%02d%02d",
+             t->tm_year + 1900, t->tm_mon + 1, t->tm_mday,
+             t->tm_hour, t->tm_min, t->tm_sec);
+
+    /* ── 1. Create index with documents ───────────────────────── */
+
+    printf("1. Creating index with documents...\n");
+
+    MossMetadataEntry meta_ml[]  = {
+        { .key = "category",   .value = "ai" },
+        { .key = "topic",      .value = "machine_learning" },
+        { .key = "difficulty", .value = "intermediate" },
+    };
+    MossMetadataEntry meta_dl[]  = {
+        { .key = "category",   .value = "ai" },
+        { .key = "topic",      .value = "deep_learning" },
+        { .key = "difficulty", .value = "advanced" },
+    };
+    MossMetadataEntry meta_nlp[] = {
+        { .key = "category",   .value = "ai" },
+        { .key = "topic",      .value = "nlp" },
+        { .key = "difficulty", .value = "intermediate" },
+    };
+    MossMetadataEntry meta_cv[]  = {
+        { .key = "category",   .value = "ai" },
+        { .key = "topic",      .value = "computer_vision" },
+        { .key = "difficulty", .value = "intermediate" },
+    };
+    MossMetadataEntry meta_rl[]  = {
+        { .key = "category",   .value = "ai" },
+        { .key = "topic",      .value = "reinforcement_learning" },
+        { .key = "difficulty", .value = "advanced" },
+    };
+
+    MossDocumentInfo docs[] = {
+        {
+            .id = "doc1",
+            .text = "Machine learning is a subset of artificial intelligence that enables computers to learn and improve from experience without being explicitly programmed.",
+            .metadata = meta_ml, .metadata_count = 3,
+        },
+        {
+            .id = "doc2",
+            .text = "Deep learning uses neural networks with multiple layers to model and understand complex patterns in data.",
+            .metadata = meta_dl, .metadata_count = 3,
+        },
+        {
+            .id = "doc3",
+            .text = "Natural language processing enables computers to interpret and manipulate human language for various applications.",
+            .metadata = meta_nlp, .metadata_count = 3,
+        },
+        {
+            .id = "doc4",
+            .text = "Computer vision enables machines to interpret and understand visual information from the world around them.",
+            .metadata = meta_cv, .metadata_count = 3,
+        },
+        {
+            .id = "doc5",
+            .text = "Reinforcement learning is a type of machine learning where an agent learns to make decisions by performing actions and receiving rewards.",
+            .metadata = meta_rl, .metadata_count = 3,
+        },
+    };
+
+    MossMutationResult *created = NULL;
+    check(moss_client_create_index(client, index_name, docs, 5, NULL, &created), "create_index");
+    printf("   Index created: job_id=%s  doc_count=%zu\n", created->job_id, created->doc_count);
+    moss_free_mutation_result(created);
+
+    /* ── 2. Get index information ─────────────────────────────── */
+
+    printf("\n2. Getting index information...\n");
+    MossIndexInfo *info = NULL;
+    check(moss_client_get_index(client, index_name, &info), "get_index");
+    printf("   Name: %s\n", info->name);
+    printf("   Doc count: %zu\n", info->doc_count);
+    printf("   Model: %s\n", info->model.id);
+    printf("   Status: %s\n", info->status);
+    moss_free_index_info(info);
+
+    /* ── 3. List all indexes ──────────────────────────────────── */
+
+    printf("\n3. Listing all indexes...\n");
+    MossIndexInfo *indexes = NULL;
+    size_t index_count = 0;
+    check(moss_client_list_indexes(client, &indexes, &index_count), "list_indexes");
+    for (size_t i = 0; i < index_count; i++) {
+        printf("   - %s: %zu docs, status: %s\n",
+               indexes[i].name, indexes[i].doc_count, indexes[i].status);
+    }
+    moss_free_index_info_list(indexes, index_count);
+
+    /* ── 4. Add more documents ────────────────────────────────── */
+
+    printf("\n4. Adding more documents...\n");
+
+    MossMetadataEntry meta_ds[] = {
+        { .key = "category",   .value = "data_science" },
+        { .key = "topic",      .value = "analytics" },
+        { .key = "difficulty", .value = "intermediate" },
+    };
+    MossMetadataEntry meta_cloud[] = {
+        { .key = "category",   .value = "infrastructure" },
+        { .key = "topic",      .value = "cloud" },
+        { .key = "difficulty", .value = "beginner" },
+    };
+
+    MossDocumentInfo new_docs[] = {
+        {
+            .id = "doc6",
+            .text = "Data science combines statistics, programming, and domain expertise to extract insights from data.",
+            .metadata = meta_ds, .metadata_count = 3,
+        },
+        {
+            .id = "doc7",
+            .text = "Cloud computing provides on-demand access to computing resources over the internet.",
+            .metadata = meta_cloud, .metadata_count = 3,
+        },
+    };
+
+    MossMutationOptions mut_opts = { .upsert = true };
+    MossMutationResult *add_result = NULL;
+    check(moss_client_add_docs(client, index_name, new_docs, 2, &mut_opts, &add_result), "add_docs");
+    printf("   Documents added: job_id=%s  doc_count=%zu\n", add_result->job_id, add_result->doc_count);
+    moss_free_mutation_result(add_result);
+
+    /* ── 5. Get all documents ─────────────────────────────────── */
+
+    printf("\n5. Getting all documents...\n");
+    MossDocumentInfo *all_docs = NULL;
+    size_t all_count = 0;
+    check(moss_client_get_docs(client, index_name, NULL, 0, &all_docs, &all_count), "get_docs_all");
+    printf("   Total documents: %zu\n", all_count);
+    moss_free_documents(all_docs, all_count);
+
+    /* ── 6. Get specific documents ────────────────────────────── */
+
+    printf("\n6. Getting specific documents...\n");
+    const char *specific_ids[] = { "doc1", "doc2", "doc6" };
+    MossDocumentInfo *specific_docs = NULL;
+    size_t specific_count = 0;
+    check(moss_client_get_docs(client, index_name, specific_ids, 3, &specific_docs, &specific_count), "get_docs_specific");
+    for (size_t i = 0; i < specific_count; i++) {
+        printf("   - %s: %.50s...\n", specific_docs[i].id, specific_docs[i].text);
+    }
+    moss_free_documents(specific_docs, specific_count);
+
+    /* ── 7. Load index for querying ───────────────────────────── */
+
+    printf("\n7. Loading index for querying...\n");
+    MossIndexInfo *loaded = NULL;
+    check(moss_client_load_index(client, index_name, NULL, &loaded), "load_index");
+    printf("   Loaded: %s (%zu docs)\n", loaded->name, loaded->doc_count);
+    moss_free_index_info(loaded);
+
+    /* ── 8. Semantic search ───────────────────────────────────── */
+
+    printf("\n8. Performing semantic search...\n");
+    MossQueryOptions qopts = {
+        .top_k = 3,
+        .alpha = 0.6f,
+    };
+    MossSearchResult *search = NULL;
+    check(moss_client_query(client, index_name, "artificial intelligence and neural networks", &qopts, &search), "query");
+
+    printf("   Query: \"%s\"\n", search->query);
+    printf("   Found %zu results:\n", search->doc_count);
+    for (size_t i = 0; i < search->doc_count; i++) {
+        MossQueryResultDoc *doc = &search->docs[i];
+        printf("   %zu. [%s] score=%.3f\n", i + 1, doc->id, doc->score);
+        printf("      %.80s...\n", doc->text);
+    }
+    moss_free_search_result(search);
+
+    /* ── 9. Delete some documents ─────────────────────────────── */
+
+    printf("\n9. Deleting some documents...\n");
+    const char *del_ids[] = { "doc6", "doc7" };
+    MossMutationResult *del_result = NULL;
+    check(moss_client_delete_docs(client, index_name, del_ids, 2, &del_result), "delete_docs");
+    printf("   Deleted: doc_count=%zu\n", del_result->doc_count);
+    moss_free_mutation_result(del_result);
+
+    /* ── 10. Verify remaining documents ───────────────────────── */
+
+    printf("\n10. Verifying document count after deletion...\n");
+    MossDocumentInfo *remaining = NULL;
+    size_t remaining_count = 0;
+    check(moss_client_get_docs(client, index_name, NULL, 0, &remaining, &remaining_count), "get_docs_remaining");
+    printf("   Remaining documents: %zu\n", remaining_count);
+    moss_free_documents(remaining, remaining_count);
+
+    /* ── 11. Final search ─────────────────────────────────────── */
+
+    printf("\n11. Final search to verify everything works...\n");
+    MossQueryOptions final_opts = { .top_k = 2 };
+    MossSearchResult *final_search = NULL;
+    check(moss_client_query(client, index_name, "machine learning algorithms", &final_opts, &final_search), "query_final");
+    for (size_t i = 0; i < final_search->doc_count; i++) {
+        printf("   %zu. [%s] score=%.3f\n", i + 1, final_search->docs[i].id, final_search->docs[i].score);
+    }
+    moss_free_search_result(final_search);
+
+    /* ── 12. Cleanup ──────────────────────────────────────────── */
+
+    printf("\n12. Cleaning up — deleting the test index...\n");
+    bool deleted = false;
+    check(moss_client_delete_index(client, index_name, &deleted), "delete_index");
+    printf("   Index deleted: %s\n", deleted ? "true" : "false");
+
+    moss_client_free(client);
+    printf("\nAll operations completed successfully.\n");
+
+    return 0;
+}

--- a/examples/c/example_usage.c
+++ b/examples/c/example_usage.c
@@ -13,14 +13,15 @@
  *     -framework Security -framework SystemConfiguration
  *
  * Run:
- *   DYLD_LIBRARY_PATH=lib ./example_usage <project_id> <project_key>
+ *   export MOSS_PROJECT_ID=...
+ *   export MOSS_PROJECT_KEY=...
+ *   DYLD_LIBRARY_PATH=lib ./example_usage
  */
 
 #include "libmoss.h"
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <time.h>
 
 static void check(MossResult r, const char *context) {
@@ -32,13 +33,15 @@ static void check(MossResult r, const char *context) {
 }
 
 int main(int argc, char *argv[]) {
-    if (argc < 3) {
-        fprintf(stderr, "Usage: %s <project_id> <project_key>\n", argv[0]);
+    const char *project_id  = getenv("MOSS_PROJECT_ID");
+    const char *project_key = getenv("MOSS_PROJECT_KEY");
+    if (argc > 1) project_id  = argv[1];
+    if (argc > 2) project_key = argv[2];
+    if (!project_id || !project_key) {
+        fprintf(stderr, "Usage: %s [<project_id> <project_key>]\n", argv[0]);
+        fprintf(stderr, "Or set MOSS_PROJECT_ID and MOSS_PROJECT_KEY environment variables.\n");
         return 1;
     }
-
-    const char *project_id  = argv[1];
-    const char *project_key = argv[2];
 
     printf("Moss C SDK Complete Example\n");
     printf("SDK version: %s\n\n", moss_sdk_version());
@@ -257,7 +260,7 @@ int main(int argc, char *argv[]) {
 
     /* ── 12. Cleanup ──────────────────────────────────────────── */
 
-    printf("\n12. Cleaning up — deleting the test index...\n");
+    printf("\n12. Cleaning up: deleting the test index...\n");
     bool deleted = false;
     check(moss_client_delete_index(client, index_name, &deleted), "delete_index");
     printf("   Index deleted: %s\n", deleted ? "true" : "false");

--- a/examples/c/metadata_filtering.c
+++ b/examples/c/metadata_filtering.c
@@ -1,18 +1,19 @@
 /**
- * metadata_filtering.c — Metadata filtering example for the Moss C SDK.
+ * metadata_filtering.c: Metadata filtering example for the Moss C SDK.
  *
  * Demonstrates: $eq, $and, $in, and $near filter operators
  * on a cloud index loaded locally.
  *
+ * See README.md for setup. After extracting the libmoss release archive
+ * so that include/ and lib/ sit next to this file:
+ *
  * Build (macOS):
- *   cargo build --release
- *   clang examples/metadata_filtering.c -o examples/metadata_filtering \
- *     -I. -Ltarget/release -lmoss \
+ *   clang metadata_filtering.c -o metadata_filtering \
+ *     -Iinclude -Llib -lmoss \
  *     -framework Security -framework SystemConfiguration
  *
  * Run:
- *   export DYLD_LIBRARY_PATH=target/release
- *   ./examples/metadata_filtering <project_id> <project_key>
+ *   DYLD_LIBRARY_PATH=lib ./metadata_filtering <project_id> <project_key>
  */
 
 #include "libmoss.h"

--- a/examples/c/metadata_filtering.c
+++ b/examples/c/metadata_filtering.c
@@ -1,0 +1,191 @@
+/**
+ * metadata_filtering.c — Metadata filtering example for the Moss C SDK.
+ *
+ * Demonstrates: $eq, $and, $in, and $near filter operators
+ * on a cloud index loaded locally.
+ *
+ * Build (macOS):
+ *   cargo build --release
+ *   clang examples/metadata_filtering.c -o examples/metadata_filtering \
+ *     -I. -Ltarget/release -lmoss \
+ *     -framework Security -framework SystemConfiguration
+ *
+ * Run:
+ *   export DYLD_LIBRARY_PATH=target/release
+ *   ./examples/metadata_filtering <project_id> <project_key>
+ */
+
+#include "libmoss.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+static void check(MossResult r, const char *context) {
+    if (r != OK) {
+        const char *err = moss_last_error();
+        fprintf(stderr, "ERROR [%s]: %s\n", context, err ? err : "(no details)");
+        exit(1);
+    }
+}
+
+static void print_results(MossSearchResult *res) {
+    for (size_t i = 0; i < res->doc_count; i++) {
+        MossQueryResultDoc *doc = &res->docs[i];
+        printf("   - %s | score=%.3f", doc->id, doc->score);
+        if (doc->metadata_count > 0) {
+            printf(" | metadata={");
+            for (size_t j = 0; j < doc->metadata_count; j++) {
+                if (j > 0) printf(", ");
+                printf("%s: %s", doc->metadata[j].key, doc->metadata[j].value);
+            }
+            printf("}");
+        }
+        printf("\n");
+    }
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 3) {
+        fprintf(stderr, "Usage: %s <project_id> <project_key>\n", argv[0]);
+        return 1;
+    }
+
+    const char *project_id  = argv[1];
+    const char *project_key = argv[2];
+
+    printf("Moss Metadata Filtering Sample (C)\n\n");
+
+    MossClient *client = NULL;
+    check(moss_client_new(project_id, project_key, &client), "client_new");
+
+    /* ── Build unique index name ──────────────────────────────── */
+
+    char index_name[64];
+    time_t now = time(NULL);
+    struct tm *t = localtime(&now);
+    snprintf(index_name, sizeof(index_name),
+             "metadata-filter-sample-%04d%02d%02d-%02d%02d%02d",
+             t->tm_year + 1900, t->tm_mon + 1, t->tm_mday,
+             t->tm_hour, t->tm_min, t->tm_sec);
+
+    /* ── Documents ────────────────────────────────────────────── */
+
+    MossMetadataEntry meta1[] = {
+        { .key = "category", .value = "shoes" },
+        { .key = "brand",    .value = "swiftfit" },
+        { .key = "price",    .value = "79" },
+        { .key = "city",     .value = "new-york" },
+        { .key = "location", .value = "40.7580,-73.9855" },
+    };
+    MossMetadataEntry meta2[] = {
+        { .key = "category", .value = "shoes" },
+        { .key = "brand",    .value = "peakstride" },
+        { .key = "price",    .value = "149" },
+        { .key = "city",     .value = "seattle" },
+        { .key = "location", .value = "47.6062,-122.3321" },
+    };
+    MossMetadataEntry meta3[] = {
+        { .key = "category", .value = "bags" },
+        { .key = "brand",    .value = "urbanpack" },
+        { .key = "price",    .value = "95" },
+        { .key = "city",     .value = "new-york" },
+        { .key = "location", .value = "40.7505,-73.9934" },
+    };
+
+    MossDocumentInfo docs[] = {
+        {
+            .id = "doc1",
+            .text = "Running shoes with breathable mesh for daily training.",
+            .metadata = meta1, .metadata_count = 5,
+        },
+        {
+            .id = "doc2",
+            .text = "Trail running shoes built for rocky mountain terrain.",
+            .metadata = meta2, .metadata_count = 5,
+        },
+        {
+            .id = "doc3",
+            .text = "Lightweight city backpack with laptop compartment.",
+            .metadata = meta3, .metadata_count = 5,
+        },
+    };
+
+    /* ── 1. Create index ──────────────────────────────────────── */
+
+    printf("1. Creating index...\n");
+    MossMutationResult *cr = NULL;
+    check(moss_client_create_index(client, index_name, docs, 3, NULL, &cr), "create_index");
+    moss_free_mutation_result(cr);
+
+    /* ── 2. Load index locally (required for filtering) ───────── */
+
+    printf("2. Loading index locally (required for filtering)...\n");
+    MossIndexInfo *loaded = NULL;
+    check(moss_client_load_index(client, index_name, NULL, &loaded), "load_index");
+    moss_free_index_info(loaded);
+
+    /* ── 3. $eq filter: category == shoes ─────────────────────── */
+
+    printf("\n3. $eq filter: category == shoes\n");
+    MossQueryOptions eq_opts = {
+        .top_k       = 5,
+        .alpha       = 0.5f,
+        .filter_json = "{\"field\": \"category\", \"condition\": {\"$eq\": \"shoes\"}}",
+    };
+    MossSearchResult *eq_res = NULL;
+    check(moss_client_query(client, index_name, "running gear", &eq_opts, &eq_res), "query_eq");
+    print_results(eq_res);
+    moss_free_search_result(eq_res);
+
+    /* ── 4. $and filter: shoes AND price < 100 ────────────────── */
+
+    printf("\n4. $and filter: shoes and price < 100\n");
+    MossQueryOptions and_opts = {
+        .top_k       = 5,
+        .alpha       = 0.6f,
+        .filter_json = "{\"$and\": ["
+                        "{\"field\": \"category\", \"condition\": {\"$eq\": \"shoes\"}},"
+                        "{\"field\": \"price\", \"condition\": {\"$lt\": \"100\"}}"
+                       "]}",
+    };
+    MossSearchResult *and_res = NULL;
+    check(moss_client_query(client, index_name, "running shoes", &and_opts, &and_res), "query_and");
+    print_results(and_res);
+    moss_free_search_result(and_res);
+
+    /* ── 5. $in filter: city in [new-york] ────────────────────── */
+
+    printf("\n5. $in filter: city in [new-york]\n");
+    MossQueryOptions in_opts = {
+        .top_k       = 5,
+        .filter_json = "{\"field\": \"city\", \"condition\": {\"$in\": [\"new-york\"]}}",
+    };
+    MossSearchResult *in_res = NULL;
+    check(moss_client_query(client, index_name, "city essentials", &in_opts, &in_res), "query_in");
+    print_results(in_res);
+    moss_free_search_result(in_res);
+
+    /* ── 6. $near filter: within 5km of Times Square ──────────── */
+
+    printf("\n6. $near filter: within 5km of Times Square\n");
+    MossQueryOptions near_opts = {
+        .top_k       = 5,
+        .filter_json = "{\"field\": \"location\", \"condition\": {\"$near\": \"40.7580,-73.9855,5000\"}}",
+    };
+    MossSearchResult *near_res = NULL;
+    check(moss_client_query(client, index_name, "city products", &near_opts, &near_res), "query_near");
+    print_results(near_res);
+    moss_free_search_result(near_res);
+
+    printf("\nMetadata filtering sample completed.\n");
+
+    /* ── 7. Cleanup ───────────────────────────────────────────── */
+
+    printf("\n7. Cleaning up index...\n");
+    bool deleted = false;
+    check(moss_client_delete_index(client, index_name, &deleted), "delete_index");
+
+    moss_client_free(client);
+    return 0;
+}

--- a/examples/c/metadata_filtering.c
+++ b/examples/c/metadata_filtering.c
@@ -13,7 +13,9 @@
  *     -framework Security -framework SystemConfiguration
  *
  * Run:
- *   DYLD_LIBRARY_PATH=lib ./metadata_filtering <project_id> <project_key>
+ *   export MOSS_PROJECT_ID=...
+ *   export MOSS_PROJECT_KEY=...
+ *   DYLD_LIBRARY_PATH=lib ./metadata_filtering
  */
 
 #include "libmoss.h"
@@ -47,13 +49,15 @@ static void print_results(MossSearchResult *res) {
 }
 
 int main(int argc, char *argv[]) {
-    if (argc < 3) {
-        fprintf(stderr, "Usage: %s <project_id> <project_key>\n", argv[0]);
+    const char *project_id  = getenv("MOSS_PROJECT_ID");
+    const char *project_key = getenv("MOSS_PROJECT_KEY");
+    if (argc > 1) project_id  = argv[1];
+    if (argc > 2) project_key = argv[2];
+    if (!project_id || !project_key) {
+        fprintf(stderr, "Usage: %s [<project_id> <project_key>]\n", argv[0]);
+        fprintf(stderr, "Or set MOSS_PROJECT_ID and MOSS_PROJECT_KEY environment variables.\n");
         return 1;
     }
-
-    const char *project_id  = argv[1];
-    const char *project_key = argv[2];
 
     printf("Moss Metadata Filtering Sample (C)\n\n");
 

--- a/examples/c/metadata_filtering.c
+++ b/examples/c/metadata_filtering.c
@@ -164,6 +164,7 @@ int main(int argc, char *argv[]) {
     printf("\n5. $in filter: city in [new-york]\n");
     MossQueryOptions in_opts = {
         .top_k       = 5,
+        .alpha       = 0.5f,
         .filter_json = "{\"field\": \"city\", \"condition\": {\"$in\": [\"new-york\"]}}",
     };
     MossSearchResult *in_res = NULL;
@@ -176,6 +177,7 @@ int main(int argc, char *argv[]) {
     printf("\n6. $near filter: within 5km of Times Square\n");
     MossQueryOptions near_opts = {
         .top_k       = 5,
+        .alpha       = 0.5f,
         .filter_json = "{\"field\": \"location\", \"condition\": {\"$near\": \"40.7580,-73.9855,5000\"}}",
     };
     MossSearchResult *near_res = NULL;

--- a/examples/c/session_usage.c
+++ b/examples/c/session_usage.c
@@ -1,18 +1,19 @@
 /**
- * session_usage.c — Session workflow example for the Moss C SDK.
+ * session_usage.c: Session workflow example for the Moss C SDK.
  *
  * Demonstrates: create client, open session, add docs with metadata,
  * query, query with filter, get docs, push to cloud.
  *
+ * See README.md for setup. After extracting the libmoss release archive
+ * so that include/ and lib/ sit next to this file:
+ *
  * Build (macOS):
- *   cargo build --release
- *   clang examples/session_usage.c -o examples/session_usage \
- *     -I. -Ltarget/release -lmoss \
+ *   clang session_usage.c -o session_usage \
+ *     -Iinclude -Llib -lmoss \
  *     -framework Security -framework SystemConfiguration
  *
  * Run:
- *   export DYLD_LIBRARY_PATH=target/release
- *   ./examples/session_usage <project_id> <project_key>
+ *   DYLD_LIBRARY_PATH=lib ./session_usage <project_id> <project_key>
  */
 
 #include "libmoss.h"

--- a/examples/c/session_usage.c
+++ b/examples/c/session_usage.c
@@ -1,0 +1,152 @@
+/**
+ * session_usage.c — Session workflow example for the Moss C SDK.
+ *
+ * Demonstrates: create client, open session, add docs with metadata,
+ * query, query with filter, get docs, push to cloud.
+ *
+ * Build (macOS):
+ *   cargo build --release
+ *   clang examples/session_usage.c -o examples/session_usage \
+ *     -I. -Ltarget/release -lmoss \
+ *     -framework Security -framework SystemConfiguration
+ *
+ * Run:
+ *   export DYLD_LIBRARY_PATH=target/release
+ *   ./examples/session_usage <project_id> <project_key>
+ */
+
+#include "libmoss.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void check(MossResult r, const char *context) {
+    if (r != OK) {
+        const char *err = moss_last_error();
+        fprintf(stderr, "ERROR [%s]: %s\n", context, err ? err : "(no details)");
+        exit(1);
+    }
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 3) {
+        fprintf(stderr, "Usage: %s <project_id> <project_key>\n", argv[0]);
+        return 1;
+    }
+
+    const char *project_id  = argv[1];
+    const char *project_key = argv[2];
+
+    printf("Moss SDK version: %s\n\n", moss_sdk_version());
+
+    /* ── 1. Create client ─────────────────────────────────────── */
+
+    MossClient *client = NULL;
+    check(moss_client_new(project_id, project_key, &client), "client_new");
+    printf("Client created.\n");
+
+    /* ── 2. Create session ────────────────────────────────────── */
+
+    MossSession *session = NULL;
+    check(moss_client_session(client, "c-sdk-demo", NULL, &session), "session");
+    printf("Session created: name=%s, doc_count=%zu\n",
+           moss_session_name(session), moss_session_doc_count(session));
+
+    /* ── 3. Add documents ─────────────────────────────────────── */
+
+    MossMetadataEntry meta1[] = {
+        { .key = "type",     .value = "billing" },
+        { .key = "priority", .value = "high"    },
+    };
+    MossMetadataEntry meta2[] = {
+        { .key = "type", .value = "gardening" },
+    };
+
+    MossDocumentInfo docs[] = {
+        {
+            .id             = "doc-1",
+            .text           = "Customer requested a billing refund and invoice review.",
+            .metadata       = meta1,
+            .metadata_count = 2,
+            .embedding      = NULL,
+            .embedding_dim  = 0,
+        },
+        {
+            .id             = "doc-2",
+            .text           = "How to prune tomato plants in a home garden.",
+            .metadata       = meta2,
+            .metadata_count = 1,
+            .embedding      = NULL,
+            .embedding_dim  = 0,
+        },
+    };
+
+    size_t added = 0, updated = 0;
+    check(moss_session_add_docs(session, docs, 2, NULL, &added, &updated), "add_docs");
+    printf("Added %zu, updated %zu. Total docs: %zu\n\n",
+           added, updated, moss_session_doc_count(session));
+
+    /* ── 4. Query ─────────────────────────────────────────────── */
+
+    MossSearchResult *result = NULL;
+    check(moss_session_query(session, "billing refund", NULL, &result), "query");
+
+    printf("Query: \"%s\" — %zu results in %llu ms\n",
+           result->query, result->doc_count, (unsigned long long)result->time_taken_ms);
+    for (size_t i = 0; i < result->doc_count; i++) {
+        MossQueryResultDoc *doc = &result->docs[i];
+        printf("  [%zu] id=%s  score=%.4f  text=\"%.60s...\"\n",
+               i, doc->id, doc->score, doc->text);
+    }
+    moss_free_search_result(result);
+    printf("\n");
+
+    /* ── 5. Query with filter ─────────────────────────────────── */
+
+    MossQueryOptions opts = {
+        .top_k       = 5,
+        .alpha       = 0.8f,
+        .filter_json = "{\"field\": \"type\", \"condition\": {\"$eq\": \"billing\"}}",
+        .embedding     = NULL,
+        .embedding_dim = 0,
+    };
+    MossSearchResult *filtered = NULL;
+    check(moss_session_query(session, "refund", &opts, &filtered), "query_filtered");
+
+    printf("Filtered query: \"%s\" — %zu results\n", filtered->query, filtered->doc_count);
+    for (size_t i = 0; i < filtered->doc_count; i++) {
+        printf("  [%zu] id=%s  score=%.4f\n",
+               i, filtered->docs[i].id, filtered->docs[i].score);
+    }
+    moss_free_search_result(filtered);
+    printf("\n");
+
+    /* ── 6. Get documents ─────────────────────────────────────── */
+
+    MossDocumentInfo *fetched = NULL;
+    size_t fetched_count = 0;
+    check(moss_session_get_docs(session, NULL, 0, &fetched, &fetched_count), "get_docs");
+
+    printf("All docs (%zu):\n", fetched_count);
+    for (size_t i = 0; i < fetched_count; i++) {
+        printf("  id=%s  text=\"%.50s...\"\n", fetched[i].id, fetched[i].text);
+    }
+    moss_free_documents(fetched, fetched_count);
+    printf("\n");
+
+    /* ── 7. Push to cloud ─────────────────────────────────────── */
+
+    MossPushIndexResult *push = NULL;
+    check(moss_session_push_index(session, &push), "push_index");
+    printf("Pushed! job_id=%s  status=%s  doc_count=%zu\n",
+           push->job_id, push->status, push->doc_count);
+    moss_free_push_index_result(push);
+
+    /* ── 8. Cleanup ───────────────────────────────────────────── */
+
+    moss_session_free(session);
+    moss_client_free(client);
+    printf("\nDone.\n");
+
+    return 0;
+}

--- a/examples/c/session_usage.c
+++ b/examples/c/session_usage.c
@@ -13,13 +13,15 @@
  *     -framework Security -framework SystemConfiguration
  *
  * Run:
- *   DYLD_LIBRARY_PATH=lib ./session_usage <project_id> <project_key>
+ *   export MOSS_PROJECT_ID=...
+ *   export MOSS_PROJECT_KEY=...
+ *   DYLD_LIBRARY_PATH=lib ./session_usage
  */
 
 #include "libmoss.h"
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 static void check(MossResult r, const char *context) {
     if (r != OK) {
@@ -30,13 +32,15 @@ static void check(MossResult r, const char *context) {
 }
 
 int main(int argc, char *argv[]) {
-    if (argc < 3) {
-        fprintf(stderr, "Usage: %s <project_id> <project_key>\n", argv[0]);
+    const char *project_id  = getenv("MOSS_PROJECT_ID");
+    const char *project_key = getenv("MOSS_PROJECT_KEY");
+    if (argc > 1) project_id  = argv[1];
+    if (argc > 2) project_key = argv[2];
+    if (!project_id || !project_key) {
+        fprintf(stderr, "Usage: %s [<project_id> <project_key>]\n", argv[0]);
+        fprintf(stderr, "Or set MOSS_PROJECT_ID and MOSS_PROJECT_KEY environment variables.\n");
         return 1;
     }
-
-    const char *project_id  = argv[1];
-    const char *project_key = argv[2];
 
     printf("Moss SDK version: %s\n\n", moss_sdk_version());
 
@@ -92,7 +96,7 @@ int main(int argc, char *argv[]) {
     MossSearchResult *result = NULL;
     check(moss_session_query(session, "billing refund", NULL, &result), "query");
 
-    printf("Query: \"%s\" — %zu results in %llu ms\n",
+    printf("Query: \"%s\" - %zu results in %llu ms\n",
            result->query, result->doc_count, (unsigned long long)result->time_taken_ms);
     for (size_t i = 0; i < result->doc_count; i++) {
         MossQueryResultDoc *doc = &result->docs[i];
@@ -114,7 +118,7 @@ int main(int argc, char *argv[]) {
     MossSearchResult *filtered = NULL;
     check(moss_session_query(session, "refund", &opts, &filtered), "query_filtered");
 
-    printf("Filtered query: \"%s\" — %zu results\n", filtered->query, filtered->doc_count);
+    printf("Filtered query: \"%s\" - %zu results\n", filtered->query, filtered->doc_count);
     for (size_t i = 0; i < filtered->doc_count; i++) {
         printf("  [%zu] id=%s  score=%.4f\n",
                i, filtered->docs[i].id, filtered->docs[i].score);
@@ -143,7 +147,13 @@ int main(int argc, char *argv[]) {
            push->job_id, push->status, push->doc_count);
     moss_free_push_index_result(push);
 
-    /* ── 8. Cleanup ───────────────────────────────────────────── */
+    /* ── 8. Delete the cloud index ────────────────────────────── */
+
+    bool deleted = false;
+    check(moss_client_delete_index(client, "c-sdk-demo", &deleted), "delete_index");
+    printf("Cloud index deleted: %s\n", deleted ? "true" : "false");
+
+    /* ── 9. Free handles ──────────────────────────────────────── */
 
     moss_session_free(session);
     moss_client_free(client);


### PR DESCRIPTION
## Summary

- Adds three C SDK examples under `examples/c/`: `session_usage.c`, `example_usage.c`, `metadata_filtering.c`.
- Adds a README walking through downloading the prebuilt `libmoss` from GitHub Releases (`c-sdk-v0.9.0`), extracting with `--strip-components=1` so `include/` and `lib/` land next to the `.c` files, and building with `clang`/`gcc`. Notes that `DYLD_LIBRARY_PATH=lib` (or `LD_LIBRARY_PATH=lib` on Linux) is required at runtime because the prebuilt dylib has a CI install path baked in.

## Test plan

- [x] `gh release download c-sdk-v0.9.0 ... && tar xzf ... --strip-components=1` produces the documented `include/` + `lib/` layout
- [x] All three samples build clean with the documented `clang -Iinclude -Llib -lmoss ...` line on macOS arm64
- [x] `example_usage` runs end-to-end against a real project (create index, add/get/delete docs, query, cleanup)
- [x] `metadata_filtering` runs end-to-end (`\$eq`, `\$and`, `\$in`, `\$near` all return sensible results)
- [x] `session_usage` builds and runs against a real project
- [ ] Verify on Linux x86_64 / arm64
- [ ] Verify on Windows x86_64