### PR TITLE
examples/python: add multi-index search sample

### DIFF
--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -65,6 +65,16 @@ Requires `moss>=1.0.0`.
 python metadata_filtering.py
 ```
 
+### Multi-Index Search Sample
+
+Create three related indexes (products, reviews, faqs), bulk-load them with `load_indexes`, search across all three in one call with `query_multi_index`, and inspect the per-result `index_name` tagging.
+
+Requires `moss>=1.1.0`.
+
+```bash
+python multi_index_search.py
+```
+
 ## Requirements
 
 - Python 3.7+

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -5,7 +5,7 @@ This project demonstrates the usage of the Moss Python SDK for semantic search a
 ## Setup
 
 1. **Set up Python environment:**
-   - Ensure you have Python 3.7+ installed
+   - Ensure you have Python 3.10+ installed
    - Create a virtual environment (recommended):
 
      ```bash
@@ -77,5 +77,5 @@ python multi_index_search.py
 
 ## Requirements
 
-- Python 3.7+
+- Python 3.10+
 - Valid Moss project credentials

--- a/examples/python/multi_index_search.py
+++ b/examples/python/multi_index_search.py
@@ -1,0 +1,160 @@
+"""
+Multi-index search sample for the Moss Python SDK.
+
+Demonstrates the v1.1.0 additions:
+
+- ``load_indexes`` / ``unload_indexes`` for bulk lifecycle management
+- ``query_multi_index`` for searching across multiple loaded indexes in
+  one call, returning the global top-K with each result tagged by its
+  source ``index_name``
+
+All indexes participating in ``query_multi_index`` must be loaded
+locally and share the same embedding model.
+
+Requires ``moss>=1.1.0``.
+"""
+
+import asyncio
+import os
+from datetime import datetime
+from typing import List
+
+from dotenv import load_dotenv
+
+from moss import (
+    DocumentInfo,
+    LoadIndexesResult,
+    MossClient,
+    QueryOptions,
+)
+
+# Load environment variables
+load_dotenv()
+
+
+PRODUCT_DOCS: List[DocumentInfo] = [
+    DocumentInfo(
+        id="p1",
+        text="Sony WH-1000XM5 wireless noise-cancelling headphones with 30-hour battery life.",
+        metadata={"category": "electronics", "price": "399"},
+    ),
+    DocumentInfo(
+        id="p2",
+        text="Bose QuietComfort Ultra over-ear headphones, immersive audio and ANC.",
+        metadata={"category": "electronics", "price": "429"},
+    ),
+    DocumentInfo(
+        id="p3",
+        text="Apple AirPods Max with H1 chip, spatial audio, premium leather ear cushions.",
+        metadata={"category": "electronics", "price": "549"},
+    ),
+]
+
+REVIEW_DOCS: List[DocumentInfo] = [
+    DocumentInfo(
+        id="r1",
+        text="Battery on these wireless headphones easily lasts a 30-hour transatlantic week.",
+        metadata={"product_id": "p1", "stars": "5"},
+    ),
+    DocumentInfo(
+        id="r2",
+        text="Comfortable for long flights but the noise cancelling could be stronger.",
+        metadata={"product_id": "p2", "stars": "4"},
+    ),
+    DocumentInfo(
+        id="r3",
+        text="Sound quality is incredible but the battery degrades after a year of heavy use.",
+        metadata={"product_id": "p3", "stars": "3"},
+    ),
+]
+
+FAQ_DOCS: List[DocumentInfo] = [
+    DocumentInfo(
+        id="f1",
+        text="How long does the battery last on wireless noise-cancelling headphones?",
+        metadata={"topic": "battery"},
+    ),
+    DocumentInfo(
+        id="f2",
+        text="Do over-ear headphones support spatial audio for movies and games?",
+        metadata={"topic": "audio"},
+    ),
+    DocumentInfo(
+        id="f3",
+        text="What is the warranty period for premium wireless headphones?",
+        metadata={"topic": "warranty"},
+    ),
+]
+
+
+async def multi_index_search_sample() -> None:
+    """Bulk-load multiple indexes and search across them in one call."""
+    print("⭐ Moss Multi-Index Search Sample (Python) ⭐")
+
+    project_id = os.getenv("MOSS_PROJECT_ID")
+    project_key = os.getenv("MOSS_PROJECT_KEY")
+
+    if not project_id or not project_key:
+        print("❌ Please set MOSS_PROJECT_ID and MOSS_PROJECT_KEY in .env file")
+        print("Copy .env.template to .env and fill in your credentials")
+        return
+
+    client = MossClient(project_id, project_key)
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    products_index = f"sample-multi-products-{timestamp}"
+    reviews_index = f"sample-multi-reviews-{timestamp}"
+    faqs_index = f"sample-multi-faqs-{timestamp}"
+
+    all_indexes = [products_index, reviews_index, faqs_index]
+
+    try:
+        print("\n1. Creating three indexes with related but distinct content...")
+        await asyncio.gather(
+            client.create_index(products_index, PRODUCT_DOCS),
+            client.create_index(reviews_index, REVIEW_DOCS),
+            client.create_index(faqs_index, FAQ_DOCS),
+        )
+        print(f"   created: {all_indexes}")
+
+        # load_indexes is best-effort: failures on individual names do not
+        # roll back the others. Inspect ``load_result.failed`` to see
+        # which (if any) names failed and why.
+        print("\n2. Bulk-loading all three with load_indexes...")
+        load_result: LoadIndexesResult = await client.load_indexes(all_indexes)
+        print(f"   loaded: {load_result.loaded}")
+        print(f"   failed: {load_result.failed}")
+
+        print("\n3. Querying across all three indexes in one call.")
+        print("   Each result is tagged with its source index_name.")
+        results = await client.query_multi_index(
+            all_indexes,
+            "wireless headphones battery life",
+            QueryOptions(top_k=6),
+        )
+        print(f'\n   Query: "{results.query}"')
+        print(f"   Returned {len(results.docs)} docs (global top-K across indexes):\n")
+        for i, doc in enumerate(results.docs, 1):
+            preview = doc.text[:70] + "..." if len(doc.text) > 70 else doc.text
+            print(f"   {i}. [{doc.index_name}] [{doc.id}] score={doc.score:.3f}")
+            print(f"      {preview}")
+
+        print("\n4. Bulk-unloading all three with unload_indexes...")
+        await client.unload_indexes(all_indexes)
+        print("   unloaded.")
+
+        print("\n✅ Multi-index search sample completed")
+    finally:
+        print("\n5. Cleaning up indexes...")
+        for name in all_indexes:
+            try:
+                await client.delete_index(name)
+            except Exception:
+                pass
+
+
+__all__ = ["multi_index_search_sample"]
+
+
+if __name__ == "__main__":
+    asyncio.run(multi_index_search_sample())

--- a/examples/python/multi_index_search.py
+++ b/examples/python/multi_index_search.py
@@ -119,16 +119,17 @@ async def multi_index_search_sample() -> None:
 
         # load_indexes is best-effort: failures on individual names do not
         # roll back the others. Inspect ``load_result.failed`` to see
-        # which (if any) names failed and why.
+        # which (if any) names failed and why; downstream ops should use
+        # ``load_result.loaded`` rather than the original list.
         print("\n2. Bulk-loading all three with load_indexes...")
         load_result: LoadIndexesResult = await client.load_indexes(all_indexes)
         print(f"   loaded: {load_result.loaded}")
         print(f"   failed: {load_result.failed}")
 
-        print("\n3. Querying across all three indexes in one call.")
+        print("\n3. Querying across all loaded indexes in one call.")
         print("   Each result is tagged with its source index_name.")
         results = await client.query_multi_index(
-            all_indexes,
+            load_result.loaded,
             "wireless headphones battery life",
             QueryOptions(top_k=6),
         )
@@ -139,8 +140,8 @@ async def multi_index_search_sample() -> None:
             print(f"   {i}. [{doc.index_name}] [{doc.id}] score={doc.score:.3f}")
             print(f"      {preview}")
 
-        print("\n4. Bulk-unloading all three with unload_indexes...")
-        await client.unload_indexes(all_indexes)
+        print("\n4. Bulk-unloading with unload_indexes...")
+        await client.unload_indexes(load_result.loaded)
         print("   unloaded.")
 
         print("\n✅ Multi-index search sample completed")
@@ -149,8 +150,8 @@ async def multi_index_search_sample() -> None:
         for name in all_indexes:
             try:
                 await client.delete_index(name)
-            except Exception:
-                pass
+            except Exception as err:
+                print(f"   warning: failed to delete '{name}': {err}")
 
 
 __all__ = ["multi_index_search_sample"]

--- a/examples/python/requirements.txt
+++ b/examples/python/requirements.txt
@@ -1,3 +1,3 @@
-moss>=1.0.0
+moss>=1.1.0
 python-dotenv
 openai


### PR DESCRIPTION
## Summary

- Adds `examples/python/multi_index_search.py` demonstrating the v1.1.0 additions to the Moss Python SDK: `load_indexes`, `unload_indexes`, and `query_multi_index`.
- Three related indexes (products, reviews, faqs) are created, bulk-loaded in one call, and queried together. Each result carries its source `index_name`.
- README updated with a section pointing at the new sample. Requires `moss>=1.1.0`.

## Test plan

- [x] Ran the sample locally against `moss==1.1.0`. Three indexes created, bulk-loaded with `load_indexes` (no failures), `query_multi_index` returned the global top-6 across all three with `index_name` populated, bulk-unloaded with `unload_indexes`, indexes deleted in cleanup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usemoss/moss/pull/219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->