### PR TITLE
docs: add banner images to README header and Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 <div align="center">
 
-<img src="assets/moss-logo.png" alt="Moss" width="80" />
-
-# Moss
-
-### Real-time semantic search for AI agents. Sub-10 ms.
+<img src="https://github.com/user-attachments/assets/2e1fb567-c003-49b5-a07e-eb687ad20d68" alt="Moss — Real-time semantic search for AI agents. Sub-10 ms." width="1200" />
 
 [![License](https://img.shields.io/badge/License-BSD_2--Clause-orange.svg)](https://opensource.org/licenses/BSD-2-Clause)
 [![PyPI](https://img.shields.io/pypi/v/moss?color=deepgreen)](https://pypi.org/project/moss/)
@@ -251,7 +247,11 @@ Full Python SDK source code is available at [`sdks/python/`](sdks/python/).
 
 ## Contributing
 
-We welcome contributions! Here's where the community can have the most impact:
+<div align="center">
+  <img src="https://github.com/user-attachments/assets/ebf1c972-7f8c-451c-8f67-58dbec3954e8" alt="We welcome contributions!" width="1200" />
+</div>
+
+Here's where the community can have the most impact:
 
 - **New SDK bindings** — Swift, Go, Elixir,...
 - **Framework integrations** — CrewAI, Haystack, AutoGen


### PR DESCRIPTION
## Summary
- Replace text-based header (small logo + H1 + tagline) with a designed banner image at the top of the README
- Add a contributions banner inside the Contributing section
- Drop the duplicate "We welcome contributions!" sentence below the H2
- Both banners hosted on GitHub user-attachments — no repo bloat

## Test plan
- [ ] Verify both banners render correctly on github.com README view
- [ ] Confirm header banner appears above the badges
- [ ] Confirm contributions banner appears inside the Contributing section, below the H2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usemoss/moss/pull/223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->