### PR TITLE
chore: fix lint errors surfaced by widened CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
-    - name: Set up Bun
-      uses: oven-sh/setup-bun@v2
-      with:
-        bun-version: latest
 
     - name: examples/javascript - install, lint, type-check
       working-directory: examples/javascript
@@ -57,9 +53,9 @@ jobs:
     # native-bindings tarball that requires a Rust toolchain build to produce.
     # It needs its own dedicated CI job, not this top-level lint sweep.
 
-    - name: apps/moss-bun - install, type-check (bun)
-      working-directory: apps/moss-bun
-      run: bun install --frozen-lockfile && bun run type-check
+    # apps/moss-bun is skipped: its `type-check` script invokes `bun check`,
+    # which is not a real bun subcommand and exits with an error. Track separately;
+    # this is a pre-existing bug in apps/moss-bun/package.json, not a CI issue.
 
     - name: examples/javascript-web - install, type-check
       working-directory: examples/javascript-web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
+    - name: Set up Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: latest
 
     - name: examples/javascript - install, lint, type-check
       working-directory: examples/javascript
@@ -53,10 +57,9 @@ jobs:
     # native-bindings tarball that requires a Rust toolchain build to produce.
     # It needs its own dedicated CI job, not this top-level lint sweep.
 
-    - name: apps/moss-bun - install, type-check
+    - name: apps/moss-bun - install, type-check (bun)
       working-directory: apps/moss-bun
-      # moss-bun uses bun, only bun.lock is checked in; npm install (not ci) is fine for type-check
-      run: npm install --no-audit --no-fund && npm run type-check
+      run: bun install --frozen-lockfile && bun run type-check
 
     - name: examples/javascript-web - install, type-check
       working-directory: examples/javascript-web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up pnpm
-      uses: pnpm/action-setup@v4
-      with:
-        version: 10
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         pip install ruff mypy
         if [ -f examples/python/requirements.txt ]; then pip install -r examples/python/requirements.txt; fi
     - name: Lint with ruff
-      run: ruff check apps examples packages moss-live-labs
+      run: ruff check apps examples packages moss-live-labs --extend-exclude '*.ipynb'
     - name: Type check with mypy
       run: mypy examples/python apps/pipecat-moss apps/livekit-moss-vercel --ignore-missing-imports --exclude "apps/pipecat-moss/hume-ollama-local/create_index.py"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main, fix/repo-hygiene-paths-ci-docs ]  # TODO(temp): drop side-branch entry before merging
+    branches: [ main ]
 
 jobs:
   python-lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, fix/repo-hygiene-paths-ci-docs ]  # TODO(temp): drop side-branch entry before merging
 
 jobs:
   python-lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         pip install ruff mypy
         if [ -f examples/python/requirements.txt ]; then pip install -r examples/python/requirements.txt; fi
     - name: Lint with ruff
-      run: ruff check apps examples packages moss-live-labs --extend-exclude '*.ipynb'
+      run: ruff check . --extend-exclude '**/*.ipynb'
     - name: Type check with mypy
       run: mypy examples/python apps/pipecat-moss apps/livekit-moss-vercel --ignore-missing-imports --exclude "apps/pipecat-moss/hume-ollama-local/create_index.py"
 
@@ -32,27 +32,46 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Set up pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
         node-version: '20'
-        cache: 'npm'
-        cache-dependency-path: |
-          package-lock.json
-          examples/javascript/package-lock.json
-          apps/next-js/package-lock.json
-    - name: Install root dependencies
-      run: npm ci
-    - name: Install examples/javascript dependencies
+
+    - name: examples/javascript - install, lint, type-check
       working-directory: examples/javascript
-      run: npm ci
-    - name: Install apps/next-js dependencies
+      run: npm ci && npm run lint && npm run type-check
+
+    - name: apps/next-js - install, lint, type-check
       working-directory: apps/next-js
-      run: npm ci
-    - name: Lint (examples/javascript + apps/next-js)
-      run: npm run lint
-    - name: Type check (examples/javascript + apps/next-js)
-      run: npm run type-check
+      run: npm ci && npm run lint && npm run type-check
+
+    - name: sdks/javascript/sdk - install, lint
+      working-directory: sdks/javascript/sdk
+      run: npm ci && npm run lint
+
+    - name: apps/moss-bun - install, type-check
+      working-directory: apps/moss-bun
+      run: npm ci && npm run type-check
+
+    - name: examples/javascript-web - install, type-check
+      working-directory: examples/javascript-web
+      run: npm ci && npm run type-check
+
+    - name: apps/livekit-moss-vercel/agent-react - install, lint (pnpm)
+      working-directory: apps/livekit-moss-vercel/agent-react
+      run: pnpm install --frozen-lockfile && pnpm run lint
+
+    - name: moss-live-labs/examples/image-search/react-app - install, lint
+      working-directory: moss-live-labs/examples/image-search/react-app
+      run: npm ci && npm run lint
+
+    - name: moss-live-labs/examples/image-search/setup-js - install, lint, type-check
+      working-directory: moss-live-labs/examples/image-search/setup-js
+      run: npm ci && npm run lint && npm run type-check
 
   cookbook-langchain-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,7 @@ jobs:
       working-directory: moss-live-labs/examples/image-search/react-app
       run: npm ci && npm run lint
 
-    - name: moss-live-labs/examples/image-search/setup-js - install, lint, type-check
-      working-directory: moss-live-labs/examples/image-search/setup-js
-      run: npm ci && npm run lint && npm run type-check
+    # moss-live-labs/examples/image-search/setup-js: covered separately.
 
   cookbook-langchain-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,8 @@ jobs:
 
     - name: apps/moss-bun - install, type-check
       working-directory: apps/moss-bun
-      run: npm ci && npm run type-check
+      # moss-bun uses bun, only bun.lock is checked in; npm install (not ci) is fine for type-check
+      run: npm install --no-audit --no-fund && npm run type-check
 
     - name: examples/javascript-web - install, type-check
       working-directory: examples/javascript-web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,30 +36,23 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
-
-    - name: examples/javascript - install, lint, type-check
+        cache: 'npm'
+        cache-dependency-path: |
+          package-lock.json
+          examples/javascript/package-lock.json
+          apps/next-js/package-lock.json
+    - name: Install root dependencies
+      run: npm ci
+    - name: Install examples/javascript dependencies
       working-directory: examples/javascript
-      run: npm ci && npm run lint && npm run type-check
-
-    - name: apps/next-js - install, lint, type-check
+      run: npm ci
+    - name: Install apps/next-js dependencies
       working-directory: apps/next-js
-      run: npm ci && npm run lint && npm run type-check
-
-    # sdks/javascript/sdk: covered separately.
-
-    # apps/moss-bun: covered separately.
-
-    - name: examples/javascript-web - install, type-check
-      working-directory: examples/javascript-web
-      run: npm ci && npm run type-check
-
-    # apps/livekit-moss-vercel/agent-react: covered separately.
-
-    - name: moss-live-labs/examples/image-search/react-app - install, lint
-      working-directory: moss-live-labs/examples/image-search/react-app
-      run: npm ci && npm run lint
-
-    # moss-live-labs/examples/image-search/setup-js: covered separately.
+      run: npm ci
+    - name: Lint (examples/javascript + apps/next-js)
+      run: npm run lint
+    - name: Type check (examples/javascript + apps/next-js)
+      run: npm run type-check
 
   cookbook-langchain-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,9 @@ jobs:
       working-directory: apps/next-js
       run: npm ci && npm run lint && npm run type-check
 
-    - name: sdks/javascript/sdk - install, lint
-      working-directory: sdks/javascript/sdk
-      run: npm ci && npm run lint
+    # sdks/javascript/sdk is skipped: its package.json depends on a local
+    # native-bindings tarball that requires a Rust toolchain build to produce.
+    # It needs its own dedicated CI job, not this top-level lint sweep.
 
     - name: apps/moss-bun - install, type-check
       working-directory: apps/moss-bun

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,21 +49,15 @@ jobs:
       working-directory: apps/next-js
       run: npm ci && npm run lint && npm run type-check
 
-    # sdks/javascript/sdk is skipped: its package.json depends on a local
-    # native-bindings tarball that requires a Rust toolchain build to produce.
-    # It needs its own dedicated CI job, not this top-level lint sweep.
+    # sdks/javascript/sdk: covered separately.
 
-    # apps/moss-bun is skipped: its `type-check` script invokes `bun check`,
-    # which is not a real bun subcommand and exits with an error. Track separately;
-    # this is a pre-existing bug in apps/moss-bun/package.json, not a CI issue.
+    # apps/moss-bun: covered separately.
 
     - name: examples/javascript-web - install, type-check
       working-directory: examples/javascript-web
       run: npm ci && npm run type-check
 
-    - name: apps/livekit-moss-vercel/agent-react - install, lint (pnpm)
-      working-directory: apps/livekit-moss-vercel/agent-react
-      run: pnpm install --frozen-lockfile && pnpm run lint
+    # apps/livekit-moss-vercel/agent-react: covered separately.
 
     - name: moss-live-labs/examples/image-search/react-app - install, lint
       working-directory: moss-live-labs/examples/image-search/react-app

--- a/apps/agora-moss/llm_proxy.py
+++ b/apps/agora-moss/llm_proxy.py
@@ -77,6 +77,7 @@ app = FastAPI()
 
 @app.post("/chat/completions")
 async def chat_completions(request: Request) -> Response:
+    """Forward OpenAI-compatible chat completion requests to the configured upstream."""
     upstream = os.environ.get("LLM_PROXY_UPSTREAM")
     if not upstream:
         return JSONResponse(

--- a/apps/agora-moss/pyproject.toml
+++ b/apps/agora-moss/pyproject.toml
@@ -34,6 +34,8 @@ ignore = ["D100", "D104"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["D101", "D102", "D103", "D107"]
+"test_*.py" = ["D101", "D102", "D103", "D107"]
+"start_agent.py" = ["E501"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/apps/agora-moss/server.py
+++ b/apps/agora-moss/server.py
@@ -52,7 +52,8 @@ app = mcp.streamable_http_app()  # ASGI application for uvicorn
 # Useful when the chosen LLM provider is strict about OpenAI schema (e.g.
 # Gemini's OpenAI-compat endpoint). See ``llm_proxy.py``.
 if os.environ.get("LLM_PROXY_UPSTREAM"):
-    from llm_proxy import app as proxy_app  # noqa: E402
     from starlette.routing import Mount  # noqa: E402
+
+    from llm_proxy import app as proxy_app  # noqa: E402
 
     app.router.routes.insert(0, Mount("/llm", app=proxy_app))

--- a/apps/agora-moss/test_mcp_client.py
+++ b/apps/agora-moss/test_mcp_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 

--- a/apps/elevenlabs-moss/create_index.py
+++ b/apps/elevenlabs-moss/create_index.py
@@ -1,9 +1,9 @@
 import asyncio
+import logging
 import os
 
 from dotenv import load_dotenv
 from moss import DocumentInfo, MossClient
-import logging
 
 logger = logging.getLogger("create_index")
 

--- a/apps/moss-llamaindex/backend/main.py
+++ b/apps/moss-llamaindex/backend/main.py
@@ -55,10 +55,10 @@ async def lifespan(app: FastAPI):
         try:
             print(f"[startup] Loading seed index '{_seed}' into memory…")
             await sessions["seed"]["client"].load_index(_seed)
-            print(f"[startup] Seed index ready.")
+            print("[startup] Seed index ready.")
         except Exception as e:
             print(f"[startup] Warning: could not load seed index '{_seed}': {e}")
-            print(f"[startup] Sample PDF will be unavailable until the index is created.")
+            print("[startup] Sample PDF will be unavailable until the index is created.")
             sessions.pop("seed", None)
     yield
 

--- a/apps/moss-llamaindex/backend/seed_index.py
+++ b/apps/moss-llamaindex/backend/seed_index.py
@@ -124,10 +124,10 @@ async def seed(pdf_path: str, index_name: str) -> str:
     await client.create_index(index_name, docs)
     await client.load_index(index_name)
 
-    print(f"\nDone!")
+    print("\nDone!")
     print(f"  Index name : {index_name}")
     print(f"  Chunk count: {len(docs)}")
-    print(f"\nTo use this as a cached session in main.py, set:")
+    print("\nTo use this as a cached session in main.py, set:")
     print(f"  SEED_INDEX_NAME={index_name}")
     return index_name
 

--- a/apps/next-js/app/page.tsx
+++ b/apps/next-js/app/page.tsx
@@ -41,6 +41,7 @@ export default function MossDemo() {
       const saved = localStorage.getItem('moss_credentials');
       if (saved) {
         const p = JSON.parse(saved) as { projectId: string; projectKey: string };
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         if (p.projectId && p.projectKey) { setCredentials(p); setCredInput(p); setShowCreds(false); }
       }
     } catch {}
@@ -171,10 +172,13 @@ export default function MossDemo() {
   // Keystroke search
   useEffect(() => {
     if (!isIndexLoaded || !searchQuery.trim()) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSearchError(null);
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setHasSearched(true);
     runSearch(searchQuery);
-  }, [searchQuery, isIndexLoaded]); // eslint-disable-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchQuery, isIndexLoaded]);
 
   // Re-run immediately when topK/alpha change (no debounce needed)
   useEffect(() => {

--- a/apps/next-js/app/page.tsx
+++ b/apps/next-js/app/page.tsx
@@ -55,10 +55,9 @@ export default function MossDemo() {
 
   const [docs, setDocs] = useState<DocumentInfo[]>(INITIAL_DOCS);
   const [modifiedIds, setModifiedIds] = useState<Set<string>>(new Set(INITIAL_DOCS.map(d => d.id)));
-  const indexNameRef = useRef(
-    `demo-index-${globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2)}`
+  const [indexName] = useState(
+    () => `demo-index-${globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2)}`
   );
-  const indexName = indexNameRef.current;
   const [isIndexLoaded, setIsIndexLoaded] = useState(false);
   const [buildState, setBuildState] = useState<'idle' | 'building' | 'done' | 'error'>('idle');
   const [buildMessage, setBuildMessage] = useState<string | null>(null);

--- a/apps/next-js/app/page.tsx
+++ b/apps/next-js/app/page.tsx
@@ -56,6 +56,7 @@ export default function MossDemo() {
 
   const [docs, setDocs] = useState<DocumentInfo[]>(INITIAL_DOCS);
   const [modifiedIds, setModifiedIds] = useState<Set<string>>(new Set(INITIAL_DOCS.map(d => d.id)));
+  // Lazy initializer runs exactly once on mount; indexName is stable across renders.
   const [indexName] = useState(
     () => `demo-index-${globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2)}`
   );

--- a/apps/vapi-moss/server.py
+++ b/apps/vapi-moss/server.py
@@ -17,7 +17,6 @@ from contextlib import asynccontextmanager
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
-
 from vapi_moss import MossVapiSearch, verify_vapi_signature
 
 load_dotenv(override=True)

--- a/benchmarks/bench_chroma.py
+++ b/benchmarks/bench_chroma.py
@@ -4,15 +4,14 @@ This measures end-to-end latency: embed the query via an external API,
 then search a local in-memory ChromaDB collection.
 """
 
-import os
 
 from dotenv import load_dotenv
 
 load_dotenv()
 
-from corpus import get_documents, get_queries
-from embedding import EmbeddingClient
-from stats import Timer, BenchmarkResult
+from corpus import get_documents, get_queries  # noqa: E402
+from embedding import EmbeddingClient  # noqa: E402
+from stats import Timer, BenchmarkResult  # noqa: E402
 
 DOC_COUNT = 100_000
 TOP_K = 5

--- a/benchmarks/bench_moss.py
+++ b/benchmarks/bench_moss.py
@@ -11,8 +11,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from corpus import get_documents, get_queries
-from stats import Timer, BenchmarkResult
+from corpus import get_documents, get_queries  # noqa: E402
+from stats import Timer, BenchmarkResult  # noqa: E402
 
 DOC_COUNT = 100_000
 TOP_K = 5
@@ -29,7 +29,7 @@ async def run_async():
     print(f"  warmup rounds  : {WARMUP_ROUNDS}")
     print(f"  query rounds   : {QUERY_ROUNDS}")
     print(f"  queries/round  : {len(queries)}")
-    print(f"  embedding      : built-in (moss-minilm)")
+    print("  embedding      : built-in (moss-minilm)")
 
     # --- Setup ---
     client = MossClient(

--- a/benchmarks/bench_pinecone.py
+++ b/benchmarks/bench_pinecone.py
@@ -6,16 +6,15 @@ included in the measured latency.
 """
 
 import os
-import sys
 import time
 
 from dotenv import load_dotenv
 
 load_dotenv()
 
-from corpus import get_documents, get_queries
-from embedding import EmbeddingClient
-from stats import Timer, BenchmarkResult
+from corpus import get_documents, get_queries  # noqa: E402
+from embedding import EmbeddingClient  # noqa: E402
+from stats import Timer, BenchmarkResult  # noqa: E402
 
 DOC_COUNT = 100_000
 TOP_K = 5

--- a/benchmarks/bench_qdrant.py
+++ b/benchmarks/bench_qdrant.py
@@ -12,9 +12,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from corpus import get_documents, get_queries
-from embedding import EmbeddingClient
-from stats import Timer, BenchmarkResult
+from corpus import get_documents, get_queries  # noqa: E402
+from embedding import EmbeddingClient  # noqa: E402
+from stats import Timer, BenchmarkResult  # noqa: E402
 
 DOC_COUNT = 100_000
 TOP_K = 5

--- a/benchmarks/run_all.py
+++ b/benchmarks/run_all.py
@@ -33,7 +33,7 @@ def main():
             sys.exit(1)
 
     print("=" * 70)
-    print(f"  Benchmark Suite")
+    print("  Benchmark Suite")
     print(f"  Date: {datetime.now():%Y-%m-%d %H:%M:%S}")
     print(f"  Running: {', '.join(targets)}")
     print("=" * 70)

--- a/examples/cookbook/daytona/log_agent.py
+++ b/examples/cookbook/daytona/log_agent.py
@@ -3,11 +3,10 @@ import os
 from pathlib import Path
 from typing import List, Optional
 
-from dotenv import load_dotenv
 from daytona import Daytona, DaytonaConfig
-from langchain_openai import ChatOpenAI
+from dotenv import load_dotenv
 from langchain.agents import create_agent
-from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_openai import ChatOpenAI
 from moss import MossClient
 
 from log_ingest import get_log_search_tool, parse_log_lines
@@ -53,11 +52,6 @@ async def _build_agent(index_name: str):
         top_k=7,
     )
     llm = ChatOpenAI(model="gpt-5.1", temperature=0)
-    prompt = ChatPromptTemplate.from_messages([
-        ("system", _SYSTEM_PROMPT),
-        ("human", "{input}"),
-        MessagesPlaceholder(variable_name="agent_scratchpad"),
-    ])
     agent = create_agent(llm, [search_tool], system_prompt=_SYSTEM_PROMPT)
     return agent
 

--- a/examples/cookbook/daytona/log_ingest.py
+++ b/examples/cookbook/daytona/log_ingest.py
@@ -5,8 +5,7 @@ import re
 from typing import List, Optional
 
 from langchain_core.tools import Tool
-
-from moss import MossClient, QueryOptions, DocumentInfo
+from moss import DocumentInfo, MossClient, QueryOptions
 
 logger = logging.getLogger(__name__)
 

--- a/examples/cookbook/daytona/pyproject.toml
+++ b/examples/cookbook/daytona/pyproject.toml
@@ -25,3 +25,7 @@ packages = ["log_agent.py", "log_ingest.py", "mock_logs.py"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
+
+[tool.ruff.lint.per-file-ignores]
+"log_agent.py" = ["E501"]
+"log_ingest.py" = ["E501"]

--- a/examples/cookbook/langchain/moss_langchain.py
+++ b/examples/cookbook/langchain/moss_langchain.py
@@ -1,5 +1,4 @@
 from typing import Any, List, Optional
-import os
 from pydantic import Field, PrivateAttr
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.callbacks import CallbackManagerForRetrieverRun, AsyncCallbackManagerForRetrieverRun

--- a/examples/cookbook/moss-cognee-daytona/main.py
+++ b/examples/cookbook/moss-cognee-daytona/main.py
@@ -49,13 +49,13 @@ import sys
 import time
 
 from daytona import (
-    Daytona,
-    DaytonaConfig,
-    DaytonaAuthorizationError,
     CreateSandboxFromImageParams,
-    SessionExecuteRequest,
+    Daytona,
+    DaytonaAuthorizationError,
+    DaytonaConfig,
     Image,
     Resources,
+    SessionExecuteRequest,
     VolumeMount,
 )
 from dotenv import load_dotenv

--- a/examples/cookbook/moss-cognee-daytona/pyproject.toml
+++ b/examples/cookbook/moss-cognee-daytona/pyproject.toml
@@ -17,3 +17,6 @@ packages = ["main.py"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
+
+[tool.ruff.lint.per-file-ignores]
+"main.py" = ["E501"]

--- a/examples/voice-agents/mortgage-lending/agent.py
+++ b/examples/voice-agents/mortgage-lending/agent.py
@@ -196,7 +196,7 @@ class MortgageRetrievalAgent(Agent):
         greeting = (
             "Got it, let me hand you over to our payment flow."
             if not data.loan_number
-            else f"Got it. I have your loan number on file — connecting you to payments now."
+            else "Got it. I have your loan number on file — connecting you to payments now."
         )
         return PaymentFlowAgent(), greeting
 

--- a/moss-live-labs/community-demos/voice-agents/bharat-benefits/bot.py
+++ b/moss-live-labs/community-demos/voice-agents/bharat-benefits/bot.py
@@ -38,7 +38,6 @@ import base64
 import collections
 import os
 import re
-import struct
 import sys
 import tempfile
 import time

--- a/moss-live-labs/examples/advanced-voice-agent/moss-utils/create_index.py
+++ b/moss-live-labs/examples/advanced-voice-agent/moss-utils/create_index.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from moss import MossClient, ParseFileInput
+from moss import MossClient, ParseFileInput  # noqa: E402
 
 PROJECT_ID = os.getenv("MOSS_PROJECT_ID")
 PROJECT_KEY = os.getenv("MOSS_PROJECT_KEY")

--- a/moss-live-labs/examples/voice-agent/agent.py
+++ b/moss-live-labs/examples/voice-agent/agent.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import os
 from dotenv import load_dotenv

--- a/moss-live-labs/python/advance_query.py
+++ b/moss-live-labs/python/advance_query.py
@@ -1,6 +1,6 @@
 import os
 import asyncio
-from moss import MossClient, DocumentInfo, QueryOptions
+from moss import MossClient, QueryOptions
 from dotenv import load_dotenv
 load_dotenv()
 

--- a/moss-live-labs/python/simple_quickstart.py
+++ b/moss-live-labs/python/simple_quickstart.py
@@ -1,6 +1,6 @@
 import os
 import asyncio
-from moss import MossClient, DocumentInfo, QueryOptions
+from moss import MossClient
 from dotenv import load_dotenv
 load_dotenv()
 

--- a/packages/moss-cli/src/moss_cli/output.py
+++ b/packages/moss-cli/src/moss_cli/output.py
@@ -176,7 +176,7 @@ def print_mutation_result(result: Any, json_mode: bool = False) -> None:
     if json_mode:
         _print_json(_mutation_to_dict(result))
         return
-    console.print(f"[green]Job submitted[/green]")
+    console.print("[green]Job submitted[/green]")
     console.print(f"  Job ID:  {result.job_id}")
     console.print(f"  Index:   {result.index_name}")
     console.print(f"  Docs:    {result.doc_count}")

--- a/packages/moss-data-connector/_template/src/connector.py
+++ b/packages/moss-data-connector/_template/src/connector.py
@@ -4,7 +4,8 @@ host package (`moss_connector_template` → `moss_connector_<source>`).
 
 from __future__ import annotations
 
-from typing import Any, Callable, Iterator
+from collections.abc import Callable, Iterator
+from typing import Any
 
 from moss import DocumentInfo
 

--- a/packages/moss-data-connector/_template/tests/test_template.py
+++ b/packages/moss-data-connector/_template/tests/test_template.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any
-from unittest.mock import patch
 
 import pytest  # noqa: F401
-
 from moss import DocumentInfo  # noqa: F401
 
 # TODO: update these imports to match your renamed package.

--- a/packages/moss-data-connector/moss-connector-mongodb/pyproject.toml
+++ b/packages/moss-data-connector/moss-connector-mongodb/pyproject.toml
@@ -52,5 +52,8 @@ target-version = "py310"
 [tool.ruff.lint]
 select = ["E", "W", "F", "I", "B", "UP"]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/test_integration_mongodb_moss.py" = ["E501"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/packages/moss-data-connector/moss-connector-mongodb/src/connector.py
+++ b/packages/moss-data-connector/moss-connector-mongodb/src/connector.py
@@ -10,7 +10,8 @@ wrap it with `str()` to render the hex string, e.g.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Iterator, Optional
+from collections.abc import Callable, Iterator
+from typing import Any
 
 from moss import DocumentInfo
 from pymongo import MongoClient
@@ -32,8 +33,8 @@ class MongoDBConnector:
         database: str,
         collection: str,
         mapper: Callable[[dict[str, Any]], DocumentInfo],
-        filter: Optional[dict[str, Any]] = None,
-        projection: Optional[dict[str, Any]] = None,
+        filter: dict[str, Any] | None = None,
+        projection: dict[str, Any] | None = None,
     ) -> None:
         self.uri = uri
         self.database = database

--- a/packages/moss-data-connector/moss-connector-mongodb/tests/test_integration_mongodb_moss.py
+++ b/packages/moss-data-connector/moss-connector-mongodb/tests/test_integration_mongodb_moss.py
@@ -35,7 +35,6 @@ except ImportError:
     pass
 
 from moss import DocumentInfo, MossClient, QueryOptions  # noqa: E402
-
 from moss_connector_mongodb import MongoDBConnector, ingest  # noqa: E402
 
 # Point this at whatever Mongo you're running locally.

--- a/packages/moss-data-connector/moss-connector-mongodb/tests/test_mongodb.py
+++ b/packages/moss-data-connector/moss-connector-mongodb/tests/test_mongodb.py
@@ -15,7 +15,6 @@ import pytest
 pytest.importorskip("pymongo")
 
 from moss import DocumentInfo  # noqa: E402
-
 from moss_connector_mongodb import MongoDBConnector, ingest  # noqa: E402
 
 

--- a/packages/moss-data-connector/moss-connector-sqlite/pyproject.toml
+++ b/packages/moss-data-connector/moss-connector-sqlite/pyproject.toml
@@ -51,5 +51,8 @@ target-version = "py310"
 [tool.ruff.lint]
 select = ["E", "W", "F", "I", "B", "UP"]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/test_integration_sqlite_moss.py" = ["E501"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/packages/moss-data-connector/moss-connector-sqlite/src/connector.py
+++ b/packages/moss-data-connector/moss-connector-sqlite/src/connector.py
@@ -6,7 +6,8 @@ Uses only the stdlib so it doubles as a zero-dep test fixture.
 from __future__ import annotations
 
 import sqlite3
-from typing import Any, Callable, Iterator
+from collections.abc import Callable, Iterator
+from typing import Any
 
 from moss import DocumentInfo
 

--- a/packages/moss-data-connector/moss-connector-sqlite/tests/test_integration_sqlite_moss.py
+++ b/packages/moss-data-connector/moss-connector-sqlite/tests/test_integration_sqlite_moss.py
@@ -38,7 +38,6 @@ except ImportError:
     pass  # dotenv is optional; env vars can also be set directly.
 
 from moss import DocumentInfo, MossClient, QueryOptions  # noqa: E402
-
 from moss_connector_sqlite import SQLiteConnector, ingest  # noqa: E402
 
 PROJECT_ID = os.getenv("MOSS_PROJECT_ID")

--- a/packages/moss-data-connector/moss-connector-sqlite/tests/test_sqlite.py
+++ b/packages/moss-data-connector/moss-connector-sqlite/tests/test_sqlite.py
@@ -13,9 +13,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
-
 from moss import DocumentInfo
-
 from moss_connector_sqlite import SQLiteConnector, ingest
 
 

--- a/packages/pipecat-moss/examples/moss-create-index-demo.py
+++ b/packages/pipecat-moss/examples/moss-create-index-demo.py
@@ -2,8 +2,8 @@ import asyncio
 import os
 
 from dotenv import load_dotenv
-from moss import DocumentInfo, MossClient
 from loguru import logger
+from moss import DocumentInfo, MossClient
 
 load_dotenv()
 

--- a/packages/pipecat-moss/examples/moss-retrieval-demo.py
+++ b/packages/pipecat-moss/examples/moss-retrieval-demo.py
@@ -48,7 +48,6 @@ logger.debug("All components loaded successfully!")
 
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     """Run the customer support bot pipeline."""
-
     # Initialize stt, tts, llm services
     logger.debug("Starting customer support bot")
     stt = DeepgramSTTService(api_key=os.getenv("DEEPGRAM_API_KEY"))

--- a/packages/pipecat-moss/pyproject.toml
+++ b/packages/pipecat-moss/pyproject.toml
@@ -43,6 +43,10 @@ ignore = [
     "D104", # Missing docstring in public package
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"examples/*.py" = ["E501"]
+"src/pipecat_moss/moss_index_processor.py" = ["E501"]
+
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 

--- a/packages/pipecat-moss/src/pipecat_moss/moss_index_processor.py
+++ b/packages/pipecat-moss/src/pipecat_moss/moss_index_processor.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
-from moss import MossClient, QueryOptions, SearchResult
 from loguru import logger
+from moss import MossClient, QueryOptions, SearchResult
 from pipecat.frames.frames import (
     ErrorFrame,
     Frame,

--- a/packages/pipecat-moss/src/pipecat_moss/moss_retrieval_service.py
+++ b/packages/pipecat-moss/src/pipecat_moss/moss_retrieval_service.py
@@ -8,8 +8,8 @@
 
 from __future__ import annotations
 
-from moss import MossClient
 from loguru import logger
+from moss import MossClient
 
 from .moss_index_processor import MossIndexProcessor
 

--- a/packages/vapi-moss/pyproject.toml
+++ b/packages/vapi-moss/pyproject.toml
@@ -34,6 +34,9 @@ ignore = [
     "D104", # Missing docstring in public package
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["D101", "D102", "D103", "D107"]
+
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 

--- a/packages/vapi-moss/src/vapi_moss/signature.py
+++ b/packages/vapi-moss/src/vapi_moss/signature.py
@@ -8,8 +8,8 @@
 
 from __future__ import annotations
 
-import hmac
 import hashlib
+import hmac
 
 __all__ = ["verify_vapi_signature"]
 

--- a/packages/vapi-moss/tests/test_search.py
+++ b/packages/vapi-moss/tests/test_search.py
@@ -1,11 +1,10 @@
 """Tests for MossVapiSearch result formatting and guards."""
 
 from dataclasses import dataclass
-from typing import Any
 
 import pytest
 
-from vapi_moss.search import MossVapiSearch, VapiSearchResult
+from vapi_moss.search import MossVapiSearch
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Stacked on top of [#235](https://github.com/usemoss/moss/pull/235). This PR does two things:

1. **Cleans up the lint errors that surfaced** when #235 fixed the broken CI lint paths.
2. **Globalizes the Python lint sweep** from a hardcoded subdir list to `ruff check .` (whole repo).

JS lint coverage is left at its existing scope (`examples/javascript` + `apps/next-js`); proper JS coverage requires switching the repo to pnpm/npm workspaces and is filed as a follow-up.

**Merge order:** this PR -> #235 -> `main`.

### CI scope changes

**Python (`python-lint`):** `ruff check examples/python apps/pipecat-moss apps/livekit-moss-vercel` -> **`ruff check . --extend-exclude '**/*.ipynb'`** (whole repo, with notebooks skipped).

Newly covered: `benchmarks/`, all of `apps/`, all of `examples/cookbook/`, all of `examples/voice-agents/`, all of `packages/`, all of `moss-live-labs/`, `sdks/python/`, and anything added in the future under those roots. Each subdir's own `pyproject.toml` continues to govern its own rules.

**JavaScript (`javascript-lint`):** unchanged scope (`examples/javascript` + `apps/next-js`). Proper coverage deferred to a workspaces refactor.

**Notebooks (`*.ipynb`):** explicitly excluded from the Python sweep. Notebook lint debt is tracked separately.

### Source-code changes (zero runtime behavior modified)

**JS (1 file):** `apps/next-js/app/page.tsx`: `useRef(impureExpr)` -> `useState(() => impureExpr)` to satisfy `react-hooks/purity`. Lazy initializer runs exactly once; `indexName` is only read elsewhere so dropping `.current` is behavior-equivalent. Plus three `// eslint-disable-next-line react-hooks/set-state-in-effect` comments on legitimate effects.

**Python source edits (3 files):**
- `apps/agora-moss/llm_proxy.py`: one-line docstring on `chat_completions`.
- `examples/cookbook/daytona/log_agent.py`: removed a dead `prompt = ChatPromptTemplate.from_messages(...)` block (never read; `create_agent(...)` uses `system_prompt=_SYSTEM_PROMPT`) plus its now-unused imports.
- `moss-live-labs/examples/advanced-voice-agent/moss-utils/create_index.py`: `# noqa: E402` on a deliberate post-`load_dotenv()` import.

**`ruff check --fix` auto-cleanup (~30 files):** import sorting (`I001`), unused imports (`F401`), empty f-strings (`F541` -> regular strings), typing modernization (`UP035`/`UP045`: `typing.Callable/Iterator` -> `collections.abc.Callable/Iterator`, `Optional[X]` -> `X | None`). All affected packages declare `python>=3.10`. Each removed import was greped to confirm zero remaining references.

**Benchmark cleanup (5 files in `benchmarks/`, surfaced by `ruff check .`):**
- 11 `# noqa: E402` on imports that intentionally come after `load_dotenv()`.
- 2 unused imports removed (`os` in `bench_chroma.py`, `sys` in `bench_pinecone.py`).
- 2 empty f-strings demoted to regular strings.

**Per-file ignores in 6 `pyproject.toml`s (lint config only, no source code touched):**
- `packages/vapi-moss/`: skip `D101/D102/D103/D107` under `tests/**`.
- `apps/agora-moss/`: cover `test_*.py` at root + `E501` on `start_agent.py`.
- `examples/cookbook/daytona/`, `examples/cookbook/moss-cognee-daytona/`: `E501` on long-line files.
- `packages/pipecat-moss/`: `E501` on sample-data files + one src file.
- `packages/moss-data-connector/moss-connector-{mongodb,sqlite}/`: `E501` on integration test files.

### Verification

- `python3 -m py_compile` on every modified `.py` file: exit 0.
- `tsc --noEmit` on `apps/next-js/app/page.tsx`: no syntax errors.
- `pytest -v` in `examples/cookbook/langchain/`: 5 passed.
- `ruff check . --extend-exclude '**/*.ipynb'` locally: All checks passed.
- All CI jobs green on the prior commit before the JS revert.

### Deferred to follow-up PRs

- **JS lint global sweep** -- proper coverage requires pnpm/npm workspaces (single root install, `pnpm -r run lint`, consolidated lockfiles). 1-2 day refactor.
- Fix `apps/moss-bun` `type-check` script (`bun check` -> `tsc --noEmit`, add `typescript` devDep).
- Fix `apps/livekit-moss-vercel/agent-react` `lint` script (`next lint` was removed in Next 15+).
- Add missing `eslint` devDependency to `moss-live-labs/examples/image-search/setup-js`.

## Test plan

- [x] CI green on prior commits (Python lint, all 5 python-sdk-test matrix entries, cookbook-langchain-test, next-js-test, vercel-sdk-test, vitepress-plugin-test).
- [ ] After this lands and #235 rebases, CI on #235 stays green and ready to merge into `main`.