### PR TITLE
sdks/swift: Moss iOS SDK (v0.2.0)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,47 @@
+// swift-tools-version: 5.9
+//
+// Moss iOS SDK — Swift Package Manager manifest.
+//
+// The `Moss` library wraps the precompiled `MossC` xcframework hosted as a
+// GitHub Release asset on this repo. Xcode downloads the binary on first
+// resolve, verifies the SHA-256 checksum below, and links it into the
+// consuming target.
+//
+// To consume from another package or app:
+//
+//     dependencies: [
+//         .package(url: "https://github.com/usemoss/moss", from: "0.1.0"),
+//     ],
+//     targets: [
+//         .target(name: "YourTarget", dependencies: [
+//             .product(name: "Moss", package: "moss"),
+//         ]),
+//     ]
+//
+// Or, in Xcode: File ▸ Add Package Dependencies ▸ https://github.com/usemoss/moss
+//
+// The Swift wrapper sources live under `sdks/swift/Sources/Moss/`. The
+// xcframework binary is not committed to this repo — it ships as a release
+// asset. Bump both the URL tag segment and the checksum together on every
+// new tag.
+import PackageDescription
+
+let package = Package(
+    name: "Moss",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(name: "Moss", targets: ["Moss"]),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "MossC",
+            url: "https://github.com/usemoss/moss/releases/download/v0.1.0/Moss.xcframework.zip",
+            checksum: "08d78183b3eb94a372990373fd669101bb3292d5824680b2f5b826977a9ee924"
+        ),
+        .target(
+            name: "Moss",
+            dependencies: ["MossC"],
+            path: "sdks/swift/Sources/Moss"
+        ),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@
 // To consume from another package or app:
 //
 //     dependencies: [
-//         .package(url: "https://github.com/usemoss/moss", from: "0.1.0"),
+//         .package(url: "https://github.com/usemoss/moss", from: "0.2.0"),
 //     ],
 //     targets: [
 //         .target(name: "YourTarget", dependencies: [
@@ -35,8 +35,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "MossC",
-            url: "https://github.com/usemoss/moss/releases/download/v0.1.0/Moss.xcframework.zip",
-            checksum: "08d78183b3eb94a372990373fd669101bb3292d5824680b2f5b826977a9ee924"
+            url: "https://github.com/usemoss/moss/releases/download/v0.2.0/Moss.xcframework.zip",
+            checksum: "0e0c6ef37569f0570511d86878c28485b5c3c8865f30541a16242875fdde9cbc"
         ),
         .target(
             name: "Moss",

--- a/sdks/swift/LICENSE
+++ b/sdks/swift/LICENSE
@@ -1,0 +1,24 @@
+BSD 2-Clause License
+
+Copyright (c) 2025 InferEdge Inc.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/sdks/swift/README.md
+++ b/sdks/swift/README.md
@@ -1,0 +1,121 @@
+# Moss Swift SDK
+
+The Swift SDK for [Moss](https://github.com/usemoss/moss) — fast on-device search for iOS.
+
+## Requirements
+
+- iOS 15.1+
+- Xcode 15+
+
+## Install
+
+In Xcode: **File ▸ Add Package Dependencies…** and enter
+
+```
+https://github.com/usemoss/moss
+```
+
+Pick the latest version under "Up to Next Major Version".
+
+Or in `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/usemoss/moss", from: "0.1.0"),
+],
+targets: [
+    .target(name: "YourTarget", dependencies: [
+        .product(name: "Moss", package: "moss"),
+    ]),
+]
+```
+
+## Quick start
+
+```swift
+import Moss
+
+let client = try MossClient(projectId: "your_project_id", projectKey: "your_project_key")
+defer { client.close() }
+
+// Create an index, load it, query.
+_ = try await client.createIndex("support-docs", docs: [
+    .init(id: "1", text: "Refunds are processed within 3-5 business days."),
+    .init(id: "2", text: "You can track your order on the dashboard."),
+])
+
+try await client.loadIndex("support-docs")
+
+let result = try await client.query("support-docs", "how long do refunds take?")
+for doc in result.docs {
+    print(String(format: "[%.3f] %@", doc.score, doc.text))
+}
+```
+
+## Authentication
+
+Two ways to authenticate:
+
+**Static project key** — simplest, fine for prototyping:
+
+```swift
+let client = try MossClient(projectId: id, projectKey: key)
+```
+
+**`Authenticator` protocol** — for apps that fetch short-lived tokens from
+your backend:
+
+```swift
+final class MyAuth: Authenticator {
+    func getAuthHeader() async throws -> String {
+        // Fetch / refresh a bearer token from your server.
+        return try await myServer.fetchToken()
+    }
+}
+
+let client = try MossClient(projectId: id, authenticator: MyAuth())
+```
+
+## Memory pressure
+
+When the OS sends a memory warning, ask the SDK to drop reclaimable
+caches:
+
+```swift
+NotificationCenter.default.addObserver(
+    forName: UIApplication.didReceiveMemoryWarningNotification,
+    object: nil,
+    queue: .main
+) { _ in
+    Task { _ = try? await client.onMemoryPressure(.critical) }
+}
+```
+
+On-disk caches are kept; only in-memory structures are freed. Next
+`loadIndex` rehydrates from disk.
+
+## Threading
+
+All operations are `async throws` and dispatch work onto a background
+thread. The underlying client is thread-safe — you can share a single
+`MossClient` across the app.
+
+## Custom cache directory (advanced)
+
+`MossClient` automatically caches model files under
+`<Library/Caches>/moss-models/`. To point it somewhere else — e.g. a
+shared App Group container so multiple targets share the same models —
+call `setModelCacheDir` *before* constructing your first client:
+
+```swift
+try MossClient.setModelCacheDir("/path/to/your/cache")
+let client = try MossClient(projectId: id, projectKey: key)
+```
+
+## Reporting issues
+
+Open an issue at <https://github.com/usemoss/moss/issues>.
+
+## License
+
+[BSD 2-Clause](./LICENSE)

--- a/sdks/swift/README.md
+++ b/sdks/swift/README.md
@@ -4,7 +4,7 @@ The Swift SDK for [Moss](https://github.com/usemoss/moss) — fast on-device sea
 
 ## Requirements
 
-- iOS 15.1+
+- iOS 15+
 - Xcode 15+
 
 ## Install

--- a/sdks/swift/README.md
+++ b/sdks/swift/README.md
@@ -21,7 +21,7 @@ Or in `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/usemoss/moss", from: "0.1.0"),
+    .package(url: "https://github.com/usemoss/moss", from: "0.2.0"),
 ],
 targets: [
     .target(name: "YourTarget", dependencies: [

--- a/sdks/swift/Sources/Moss/Authenticator.swift
+++ b/sdks/swift/Sources/Moss/Authenticator.swift
@@ -4,9 +4,27 @@ import MossC
 /// Implement to inject a custom auth flow into [MossClient].
 ///
 /// The native runtime calls [getAuthHeader] whenever it needs a fresh bearer
-/// token. Implementations typically fetch from a server endpoint and cache.
+/// token for an outbound request. Implementations typically fetch the token
+/// from your backend (and cache it until expiry).
 ///
-/// Tokens returned must be the raw bearer token (no `Bearer ` prefix).
+/// ## Return-value contract
+///
+/// Return **the raw bearer token only** — do **not** include the `Bearer `
+/// prefix or any other Authorization-header decoration:
+///
+/// ```swift
+/// // ✅ correct
+/// return "eyJhbGciOi..."
+/// // ❌ wrong — the SDK prepends `Bearer ` itself
+/// return "Bearer eyJhbGciOi..."
+/// ```
+///
+/// The Swift wrapper passes this string directly to the native side, which
+/// constructs the full `Authorization: Bearer <token>` header. The JS SDK's
+/// `IAuthenticator.getAuthHeader()` happens to use the opposite convention
+/// (returns the full `Bearer ...` value); that's because the JS SDK builds
+/// the request in JS userland rather than going through the native C ABI.
+/// Don't copy the JS convention here.
 ///
 /// Implementations must be safe to call from any thread; the native side may
 /// invoke from a background worker.

--- a/sdks/swift/Sources/Moss/Authenticator.swift
+++ b/sdks/swift/Sources/Moss/Authenticator.swift
@@ -1,0 +1,33 @@
+import Foundation
+import MossC
+
+/// Implement to inject a custom auth flow into [MossClient].
+///
+/// The native runtime calls [getAuthHeader] whenever it needs a fresh bearer
+/// token. Implementations typically fetch from a server endpoint and cache.
+///
+/// Tokens returned must be the raw bearer token (no `Bearer ` prefix).
+///
+/// Implementations must be safe to call from any thread; the native side may
+/// invoke from a background worker.
+public protocol Authenticator: AnyObject, Sendable {
+    func getAuthHeader() async throws -> String
+}
+
+// ── Internal C-callback dispatch ─────────────────────────────────────
+
+/// Holds a strong reference to the user's authenticator so the C callback can
+/// dispatch back. The pointer to this box becomes the `user_data` passed to
+/// `moss_client_new_with_authenticator`. The actual C trampoline lives in
+/// MossClient.swift to avoid Swift emitting duplicate `@_cdecl` symbols
+/// across translation units that reference it (eager linking would
+/// otherwise reject the build).
+///
+/// `@unchecked Sendable`: the box only holds an immutable `any Authenticator`,
+/// and the `Authenticator` protocol itself requires `Sendable`. The Swift
+/// compiler can't see that across the `Unmanaged.fromOpaque` boundary —
+/// hence `@unchecked`.
+final class AuthenticatorBox: @unchecked Sendable {
+    let inner: any Authenticator
+    init(_ inner: any Authenticator) { self.inner = inner }
+}

--- a/sdks/swift/Sources/Moss/MossClient.swift
+++ b/sdks/swift/Sources/Moss/MossClient.swift
@@ -15,24 +15,32 @@ import MossC
 /// let result = try await client.query("docs", "vector search on mobile")
 /// ```
 public final class MossClient: @unchecked Sendable {
-    /// Opaque pointer to the native MossClient. C side uses `MossClient *`,
-    /// which Swift imports as `OpaquePointer?` because the struct is opaque.
-    /// Mutated only behind `handleLock`; once nil, the handle has been freed
-    /// and any subsequent native-side call is rejected at the requireHandle
-    /// boundary.
+    /// Opaque pointer to the native MossClient. Mutated only behind
+    /// `stateCond`; access from outside the lock is unsafe because a
+    /// concurrent `close()` could free it. Operations borrow it via
+    /// `borrowHandle()` which both reads it and increments `inFlight` in
+    /// a single critical section.
     private var handle: OpaquePointer?
     /// Authenticator-backed clients retain an opaque pointer to an
     /// `AuthenticatorBox` (`Unmanaged.passRetained`) as the native side's
-    /// user_data. `close()` releases it once.
+    /// user_data. `close()` releases it once, after the in-flight count
+    /// has drained.
     private var authUserData: UnsafeMutableRawPointer?
-    /// Serializes mutations to `handle` / `authUserData` so a concurrent
-    /// close() can't free state out from under an in-flight operation that
-    /// has already captured the handle.
-    private let handleLock = NSLock()
+    /// Number of operations that have called `borrowHandle()` but not yet
+    /// `returnHandle()`. `close()` waits on `stateCond` until this drops
+    /// to zero before freeing the native handle, so an in-flight call
+    /// never operates on a freed pointer.
+    private var inFlight: Int = 0
+    /// Once true, no new `borrowHandle()` succeeds. Set by `close()`
+    /// before it begins waiting for `inFlight` to drain.
+    private var closed: Bool = false
+    /// Mutex + condition variable guarding `handle`, `authUserData`,
+    /// `inFlight`, and `closed`. `close()` signals here when ops finish.
+    private let stateCond = NSCondition()
 
     /// Construct a client backed by a static project key.
     public init(projectId: String, projectKey: String) throws {
-        Self.ensureModelCacheDir()
+        try Self.ensureModelCacheDir()
         var raw: OpaquePointer?
         let r = projectId.withCString { pid in
             projectKey.withCString { pkey in
@@ -47,7 +55,7 @@ public final class MossClient: @unchecked Sendable {
 
     /// Construct a client whose bearer tokens come from [authenticator].
     public init(projectId: String, authenticator: any Authenticator, baseUrl: String? = nil) throws {
-        Self.ensureModelCacheDir()
+        try Self.ensureModelCacheDir()
         let box = AuthenticatorBox(authenticator)
         // Retain the box and pass its raw pointer as user_data. The native
         // side stores it for the client's lifetime. `close()` releases the
@@ -81,17 +89,30 @@ public final class MossClient: @unchecked Sendable {
 
     deinit { close() }
 
-    /// Free the underlying native handle and any authenticator box. Idempotent.
+    /// Free the underlying native handle and any authenticator box.
+    ///
+    /// Idempotent. Safe to call concurrently with in-flight operations:
+    /// the call blocks until every borrowed handle is returned, then
+    /// frees. After `close()` returns, every further operation throws
+    /// `MossError(-1, "MossClient already closed")`.
     public func close() {
-        handleLock.lock(); defer { handleLock.unlock() }
-        if let h = handle {
-            moss_client_free(h)
-            handle = nil
+        stateCond.lock()
+        if closed {
+            stateCond.unlock()
+            return
         }
-        if let ud = authUserData {
-            Unmanaged<AuthenticatorBox>.fromOpaque(ud).release()
-            authUserData = nil
+        closed = true
+        while inFlight > 0 {
+            stateCond.wait()
         }
+        let h = handle
+        handle = nil
+        let ud = authUserData
+        authUserData = nil
+        stateCond.unlock()
+
+        if let h { moss_client_free(h) }
+        if let ud { Unmanaged<AuthenticatorBox>.fromOpaque(ud).release() }
     }
 
     public static var sdkVersion: String {
@@ -121,22 +142,22 @@ public final class MossClient: @unchecked Sendable {
     /// caller has overridden it via `setModelCacheDir`. The native default
     /// home-directory lookup doesn't resolve inside an iOS app sandbox, so
     /// without this hook the first `loadIndex` / `query` would fail with
-    /// `ErrModel`.
-    private static func ensureModelCacheDir() {
+    /// a much less actionable `ErrModel`.
+    private static func ensureModelCacheDir() throws {
         cacheDirLock.lock(); defer { cacheDirLock.unlock() }
         if cacheDirConfigured { return }
-        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
-        guard let cacheRoot = caches.first else { return }
+        guard let cacheRoot = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            throw MossError(code: -7, message: "could not locate <Library/Caches> for model cache")
+        }
         let dir = cacheRoot.appendingPathComponent("moss-models", isDirectory: true)
         do {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         } catch {
-            return
+            throw MossError(code: -7, message: "could not create model cache directory at \(dir.path): \(error.localizedDescription)")
         }
         let r = dir.path.withCString { ptr in moss_set_model_cache_dir(ptr) }
-        if r == 0 {
-            cacheDirConfigured = true
-        }
+        try throwIfErr(r)
+        cacheDirConfigured = true
     }
 
     /// Guards `cacheDirConfigured` against races between `setModelCacheDir`
@@ -147,12 +168,10 @@ public final class MossClient: @unchecked Sendable {
     // ── Operations ───────────────────────────────────────────────────
 
     public func loadIndex(_ name: String, options: LoadIndexOptions = LoadIndexOptions()) async throws {
-        let h = try requireHandle()
         let opts = options
-        // throwIfErr must run on the same thread as the C call — moss_last_error
-        // is thread-local, so reading it after the Task.detached resumption
-        // would land on the wrong thread and lose the message.
         try await Task.detached { [self] in
+            let h = try borrowHandle()
+            defer { returnHandle() }
             try name.withCString { cname in
                 try withOptionalCString(opts.cachePath) { cachePath in
                     var nativeOpts = MossLoadIndexOptions(
@@ -170,8 +189,9 @@ public final class MossClient: @unchecked Sendable {
     }
 
     public func unloadIndex(_ name: String) async throws {
-        let h = try requireHandle()
         try await Task.detached { [self] in
+            let h = try borrowHandle()
+            defer { returnHandle() }
             try name.withCString { cname in
                 let r = moss_client_unload_index(h, cname)
                 try Self.throwIfErr(r)
@@ -184,16 +204,16 @@ public final class MossClient: @unchecked Sendable {
         _ query: String,
         options: QueryOptions = QueryOptions()
     ) async throws -> SearchResult {
-        let h = try requireHandle()
         let opts = options
-        // Validate topK here so `UInt(opts.topK)` below doesn't trap on
-        // negatives — defensive against caller error since topK is a
-        // signed Int in the public API.
+        // Validate topK eagerly so the caller gets a descriptive error
+        // instead of `UInt(opts.topK)` trapping on negatives.
         guard opts.topK >= 0 else {
             throw MossError(code: -2, message: "topK must be non-negative; got \(opts.topK)")
         }
         return try await Task.detached { [self] () throws -> SearchResult in
-            try indexName.withCString { iname in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            return try indexName.withCString { iname in
                 try query.withCString { q in
                     try withOptionalCString(opts.filterJson) { filter in
                         var nativeOpts = MossQueryOptions(
@@ -216,9 +236,10 @@ public final class MossClient: @unchecked Sendable {
     }
 
     public func deleteIndex(_ name: String) async throws -> Bool {
-        let h = try requireHandle()
-        return try await Task.detached { [self] () throws -> Bool in
-            try name.withCString { (cname: UnsafePointer<CChar>) throws -> Bool in
+        try await Task.detached { [self] () throws -> Bool in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            return try name.withCString { (cname: UnsafePointer<CChar>) throws -> Bool in
                 var deleted: Bool = false
                 let r = moss_client_delete_index(h, cname, &deleted)
                 try Self.throwIfErr(r)
@@ -228,9 +249,10 @@ public final class MossClient: @unchecked Sendable {
     }
 
     public func getIndex(_ name: String) async throws -> IndexInfo {
-        let h = try requireHandle()
-        return try await Task.detached { [self] () throws -> IndexInfo in
-            try name.withCString { cname in
+        try await Task.detached { [self] () throws -> IndexInfo in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            return try name.withCString { cname in
                 var info: UnsafeMutablePointer<MossIndexInfo>?
                 let r = moss_client_get_index(h, cname, &info)
                 try Self.throwIfErr(r)
@@ -242,8 +264,9 @@ public final class MossClient: @unchecked Sendable {
     }
 
     public func listIndexes() async throws -> [IndexInfo] {
-        let h = try requireHandle()
-        return try await Task.detached { [self] () throws -> [IndexInfo] in
+        try await Task.detached { [self] () throws -> [IndexInfo] in
+            let h = try borrowHandle()
+            defer { returnHandle() }
             var infos: UnsafeMutablePointer<MossIndexInfo>?
             var count: UInt = 0
             let r = moss_client_list_indexes(h, &infos, &count)
@@ -261,9 +284,10 @@ public final class MossClient: @unchecked Sendable {
     }
 
     public func refreshIndex(_ name: String) async throws -> RefreshResult {
-        let h = try requireHandle()
-        return try await Task.detached { [self] () throws -> RefreshResult in
-            try name.withCString { cname in
+        try await Task.detached { [self] () throws -> RefreshResult in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            return try name.withCString { cname in
                 var result: UnsafeMutablePointer<MossRefreshResult>?
                 let r = moss_client_refresh_index(h, cname, &result)
                 try Self.throwIfErr(r)
@@ -281,9 +305,10 @@ public final class MossClient: @unchecked Sendable {
     }
 
     public func getJobStatus(_ jobId: String) async throws -> JobStatus {
-        let h = try requireHandle()
-        return try await Task.detached { [self] () throws -> JobStatus in
-            try jobId.withCString { cjob in
+        try await Task.detached { [self] () throws -> JobStatus in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            return try jobId.withCString { cjob in
                 var result: UnsafeMutablePointer<MossJobStatusResponse>?
                 let r = moss_client_get_job_status(h, cjob, &result)
                 try Self.throwIfErr(r)
@@ -309,10 +334,11 @@ public final class MossClient: @unchecked Sendable {
         docs: [DocumentInfo],
         modelId: String? = nil
     ) async throws -> MutationResult {
-        let h = try requireHandle()
         let docsJson = try Self.encodeJson(docs)
         return try await Task.detached { [self] () throws -> MutationResult in
-            try name.withCString { cname in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            return try name.withCString { cname in
                 try docsJson.withCString { cdocs in
                     try withOptionalCString(modelId) { cmodel in
                         var out: UnsafeMutablePointer<CChar>?
@@ -332,10 +358,11 @@ public final class MossClient: @unchecked Sendable {
         docs: [DocumentInfo],
         upsert: Bool = true
     ) async throws -> MutationResult {
-        let h = try requireHandle()
         let docsJson = try Self.encodeJson(docs)
         return try await Task.detached { [self] () throws -> MutationResult in
-            try name.withCString { cname in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            return try name.withCString { cname in
                 try docsJson.withCString { cdocs in
                     var out: UnsafeMutablePointer<CChar>?
                     let r = moss_client_add_docs_from_json(h, cname, cdocs, upsert, &out)
@@ -349,10 +376,11 @@ public final class MossClient: @unchecked Sendable {
     }
 
     public func getDocs(_ name: String, docIds: [String]? = nil) async throws -> [DocumentInfo] {
-        let h = try requireHandle()
         let idsJson: String? = try docIds.map { try Self.encodeJson($0) }
         return try await Task.detached { [self] () throws -> [DocumentInfo] in
-            try name.withCString { cname in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            return try name.withCString { cname in
                 try withOptionalCString(idsJson) { cids in
                     var out: UnsafeMutablePointer<CChar>?
                     let r = moss_client_get_docs_json(h, cname, cids, &out)
@@ -372,10 +400,14 @@ public final class MossClient: @unchecked Sendable {
     /// `UIApplication.didReceiveMemoryWarningNotification`. Returns the
     /// number of indexes that were unloaded.
     public func onMemoryPressure(_ level: MemoryPressureLevel = .critical) async throws -> Int {
-        let h = try requireHandle()
         let levelRaw = level.rawValue
         return try await Task.detached { [self] () throws -> Int in
+            let h = try borrowHandle()
+            defer { returnHandle() }
             var unloaded: Int = 0
+            // `MossMemoryPressure` is the same cbindgen-generated enum/typedef
+            // pair as `MossResult` — pass the raw UInt8 value to avoid the
+            // ambiguous-type lookup error.
             let r = moss_client_release_memory(h, levelRaw, &unloaded)
             try Self.throwIfErr(r)
             return unloaded
@@ -383,11 +415,12 @@ public final class MossClient: @unchecked Sendable {
     }
 
     public func deleteDocs(_ name: String, docIds: [String]) async throws -> MutationResult {
-        let h = try requireHandle()
-        return try await Task.detached { [self] () throws -> MutationResult in
+        try await Task.detached { [self] () throws -> MutationResult in
+            let h = try borrowHandle()
+            defer { returnHandle() }
             // Build a const-char-pointer array; the C function takes
             // `const char *const *` plus a count.
-            try name.withCString { cname in
+            return try name.withCString { cname in
                 try withCStringArray(docIds) { ptrs in
                     var result: UnsafeMutablePointer<MossMutationResult>?
                     let r = moss_client_delete_docs(h, cname, ptrs, UInt(docIds.count), &result)
@@ -407,14 +440,32 @@ public final class MossClient: @unchecked Sendable {
 
     // ── Internals ────────────────────────────────────────────────────
 
-    private func requireHandle() throws -> OpaquePointer {
-        guard let h = handle else {
+    /// Reserve the native handle for the duration of a single operation.
+    /// Increments `inFlight` so a concurrent `close()` blocks until the
+    /// matching `returnHandle()` runs. Must be paired with exactly one
+    /// `returnHandle()` (use `defer`).
+    private func borrowHandle() throws -> OpaquePointer {
+        stateCond.lock()
+        defer { stateCond.unlock() }
+        guard !closed, let h = handle else {
             throw MossError(code: -1, message: "MossClient already closed")
         }
+        inFlight += 1
         return h
     }
 
-    /// `MossResult` is emitted as both an `enum` and a separate
+    /// Release a handle reservation taken with `borrowHandle()`. Wakes a
+    /// waiting `close()` when `inFlight` drops to zero.
+    private func returnHandle() {
+        stateCond.lock()
+        defer { stateCond.unlock() }
+        inFlight -= 1
+        if inFlight == 0 {
+            stateCond.broadcast()
+        }
+    }
+
+    /// `MossResult` is emitted by cbindgen as both an `enum` and a separate
     /// `typedef int32_t MossResult`, which Swift sees as ambiguous. We treat
     /// the value as a raw `Int32` and compare against the well-known OK == 0
     /// constant from the C header.
@@ -455,6 +506,11 @@ public final class MossClient: @unchecked Sendable {
     }
 
     fileprivate static func decodeMutationResult(_ json: String) throws -> MutationResult {
+        // The JSON-returning C entry points (moss_client_create_index_from_json,
+        // moss_client_add_docs_from_json) emit MutationResult with camelCase
+        // keys: { "jobId", "indexName", "docCount" }. If the native layer's
+        // serialization format ever changes, the JSONDecoder call below will
+        // throw with a clear "keyNotFound" error.
         struct Wire: Decodable {
             let jobId: String
             let indexName: String
@@ -473,24 +529,45 @@ public final class MossClient: @unchecked Sendable {
                 let d = buf.advanced(by: i).pointee
                 docs.append(
                     QueryResult(
-                        id: d.id.flatMap { String(cString: $0) } ?? "",
+                        id: cstr(d.id),
                         score: d.score,
-                        text: d.text.flatMap { String(cString: $0) } ?? ""
+                        text: cstr(d.text),
+                        metadata: parseMetadata(d.metadata, count: d.metadata_count)
                     )
                 )
             }
         }
         return SearchResult(
             docs: docs,
-            query: r.query.flatMap { String(cString: $0) } ?? "",
+            query: cstr(r.query),
             timeMs: r.time_taken_ms
         )
+    }
+
+    /// Decode a `MossMetadataEntry *` array into a `[String: String]`.
+    /// Drops entries with NULL keys (which the native side shouldn't emit
+    /// but we defend against). NULL `entries` or `count == 0` returns nil
+    /// so the optional `QueryResult.metadata` is empty rather than `[:]`.
+    private static func parseMetadata(
+        _ entries: UnsafeMutablePointer<MossMetadataEntry>?,
+        count: UInt
+    ) -> [String: String]? {
+        guard let entries, count > 0 else { return nil }
+        var out: [String: String] = [:]
+        let n = Int(count)
+        out.reserveCapacity(n)
+        for i in 0..<n {
+            let e = entries.advanced(by: i).pointee
+            guard let keyPtr = e.key else { continue }
+            out[String(cString: keyPtr)] = cstr(e.value)
+        }
+        return out.isEmpty ? nil : out
     }
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-/// Trampoline matching `MossAuthNotifyFn` in the C header:
+/// Trampoline matching `MossAuthNotifyFn` in libmoss.h:
 ///   typedef void (*MossAuthNotifyFn)(uint32_t request_id, void *user_data);
 ///
 /// Lives here (not in Authenticator.swift) because Swift's eager linker
@@ -521,20 +598,32 @@ func withOptionalCString<R>(_ s: String?, _ body: (UnsafePointer<CChar>?) throws
     }
 }
 
-/// Build a `const char *const *` array of NUL-terminated copies of `strings`,
-/// hand it to `body`, then free everything. Used for C functions that take
-/// arrays of strings (e.g. `moss_client_delete_docs`).
+/// Build a `const char *const *` array of NUL-terminated UTF-8 copies of
+/// `strings`, hand it to `body`, then free everything. Used for C
+/// functions that take arrays of strings (e.g. `moss_client_delete_docs`).
+///
+/// Allocates with Swift's `UnsafeMutablePointer.allocate`, which traps on
+/// failure rather than returning nil — so the produced pointer array is
+/// always fully populated by the time `body` runs.
 @inline(__always)
 func withCStringArray<R>(
     _ strings: [String],
     _ body: (UnsafePointer<UnsafePointer<CChar>?>) throws -> R
 ) rethrows -> R {
-    let copies = strings.map { strdup($0) }
-    defer { copies.forEach { free($0) } }
-    let ptrs = UnsafeMutablePointer<UnsafePointer<CChar>?>.allocate(capacity: copies.count)
+    let buffers: [UnsafeMutablePointer<CChar>] = strings.map { s in
+        let utf8 = Array(s.utf8)
+        let buf = UnsafeMutablePointer<CChar>.allocate(capacity: utf8.count + 1)
+        for (i, b) in utf8.enumerated() {
+            buf[i] = CChar(bitPattern: b)
+        }
+        buf[utf8.count] = 0
+        return buf
+    }
+    defer { buffers.forEach { $0.deallocate() } }
+    let ptrs = UnsafeMutablePointer<UnsafePointer<CChar>?>.allocate(capacity: buffers.count)
     defer { ptrs.deallocate() }
-    for (i, c) in copies.enumerated() {
-        ptrs[i] = UnsafePointer(c)
+    for (i, b) in buffers.enumerated() {
+        ptrs[i] = UnsafePointer(b)
     }
     return try body(ptrs)
 }

--- a/sdks/swift/Sources/Moss/MossClient.swift
+++ b/sdks/swift/Sources/Moss/MossClient.swift
@@ -1,0 +1,553 @@
+import Foundation
+import MossC
+
+/// Idiomatic Swift wrapper for the native Moss SDK.
+///
+/// Construct with either a static project key or an [Authenticator].
+/// All methods are `async throws` and dispatch native work onto a background
+/// thread. The underlying native client is thread-safe.
+///
+/// ```swift
+/// let client = try MossClient(projectId: "p", projectKey: "k")
+/// defer { client.close() }
+///
+/// try await client.loadIndex("docs", options: .init(cachePath: cachePath))
+/// let result = try await client.query("docs", "vector search on mobile")
+/// ```
+public final class MossClient: @unchecked Sendable {
+    /// Opaque pointer to the native MossClient. C side uses `MossClient *`,
+    /// which Swift imports as `OpaquePointer?` because the struct is opaque.
+    /// Mutated only behind `handleLock`; once nil, the handle has been freed
+    /// and any subsequent native-side call is rejected at the requireHandle
+    /// boundary.
+    private var handle: OpaquePointer?
+    /// Authenticator-backed clients retain an opaque pointer to an
+    /// `AuthenticatorBox` (`Unmanaged.passRetained`) as the native side's
+    /// user_data. `close()` releases it once.
+    private var authUserData: UnsafeMutableRawPointer?
+    /// Serializes mutations to `handle` / `authUserData` so a concurrent
+    /// close() can't free state out from under an in-flight operation that
+    /// has already captured the handle.
+    private let handleLock = NSLock()
+
+    /// Construct a client backed by a static project key.
+    public init(projectId: String, projectKey: String) throws {
+        Self.ensureModelCacheDir()
+        var raw: OpaquePointer?
+        let r = projectId.withCString { pid in
+            projectKey.withCString { pkey in
+                moss_client_new(pid, pkey, &raw)
+            }
+        }
+        try Self.throwIfErr(r)
+        guard let raw else { throw Self.lastError(code: -7) }
+        self.handle = raw
+        self.authUserData = nil
+    }
+
+    /// Construct a client whose bearer tokens come from [authenticator].
+    public init(projectId: String, authenticator: any Authenticator, baseUrl: String? = nil) throws {
+        Self.ensureModelCacheDir()
+        let box = AuthenticatorBox(authenticator)
+        // Retain the box and pass its raw pointer as user_data. The native
+        // side stores it for the client's lifetime. `close()` releases the
+        // retained reference exactly once.
+        let userData = Unmanaged.passRetained(box).toOpaque()
+
+        var raw: OpaquePointer?
+        let r = projectId.withCString { pid in
+            withOptionalCString(baseUrl) { base in
+                moss_client_new_with_authenticator(
+                    pid,
+                    mossSwiftAuthNotify,
+                    userData,
+                    base,
+                    &raw
+                )
+            }
+        }
+        if r != 0 {
+            // Ownership returns to us so the box is freed on the error path.
+            Unmanaged<AuthenticatorBox>.fromOpaque(userData).release()
+            try Self.throwIfErr(r)
+        }
+        guard let raw else {
+            Unmanaged<AuthenticatorBox>.fromOpaque(userData).release()
+            throw Self.lastError(code: -7)
+        }
+        self.handle = raw
+        self.authUserData = userData
+    }
+
+    deinit { close() }
+
+    /// Free the underlying native handle and any authenticator box. Idempotent.
+    public func close() {
+        handleLock.lock(); defer { handleLock.unlock() }
+        if let h = handle {
+            moss_client_free(h)
+            handle = nil
+        }
+        if let ud = authUserData {
+            Unmanaged<AuthenticatorBox>.fromOpaque(ud).release()
+            authUserData = nil
+        }
+    }
+
+    public static var sdkVersion: String {
+        String(cString: moss_sdk_version())
+    }
+
+    /// Point the embedding-model cache at a custom directory.
+    ///
+    /// **You normally don't need to call this.** `MossClient` automatically
+    /// caches model files under `<Library/Caches>/moss-models/` on first
+    /// init, which works for almost every app.
+    ///
+    /// Call this only if you want a different location (e.g. a shared App
+    /// Group container). Call it *before* constructing your first
+    /// `MossClient`; later overrides still take effect but the default may
+    /// have already been wired.
+    ///
+    /// Throws `MossError` if `path` is empty or not valid UTF-8.
+    public static func setModelCacheDir(_ path: String) throws {
+        cacheDirLock.lock(); defer { cacheDirLock.unlock() }
+        let r = path.withCString { ptr in moss_set_model_cache_dir(ptr) }
+        try throwIfErr(r)
+        cacheDirConfigured = true
+    }
+
+    /// Auto-wires the model cache to `<Library/Caches>/moss-models/` if no
+    /// caller has overridden it via `setModelCacheDir`. The native default
+    /// home-directory lookup doesn't resolve inside an iOS app sandbox, so
+    /// without this hook the first `loadIndex` / `query` would fail with
+    /// `ErrModel`.
+    private static func ensureModelCacheDir() {
+        cacheDirLock.lock(); defer { cacheDirLock.unlock() }
+        if cacheDirConfigured { return }
+        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
+        guard let cacheRoot = caches.first else { return }
+        let dir = cacheRoot.appendingPathComponent("moss-models", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        } catch {
+            return
+        }
+        let r = dir.path.withCString { ptr in moss_set_model_cache_dir(ptr) }
+        if r == 0 {
+            cacheDirConfigured = true
+        }
+    }
+
+    /// Guards `cacheDirConfigured` against races between `setModelCacheDir`
+    /// (caller thread) and `ensureModelCacheDir` (any init thread).
+    private static let cacheDirLock = NSLock()
+    private static var cacheDirConfigured = false
+
+    // ── Operations ───────────────────────────────────────────────────
+
+    public func loadIndex(_ name: String, options: LoadIndexOptions = LoadIndexOptions()) async throws {
+        let h = try requireHandle()
+        let opts = options
+        // throwIfErr must run on the same thread as the C call — moss_last_error
+        // is thread-local, so reading it after the Task.detached resumption
+        // would land on the wrong thread and lose the message.
+        try await Task.detached { [self] in
+            try name.withCString { cname in
+                try withOptionalCString(opts.cachePath) { cachePath in
+                    var nativeOpts = MossLoadIndexOptions(
+                        auto_refresh: opts.autoRefresh,
+                        polling_interval_secs: opts.pollingIntervalSeconds,
+                        cache_path: cachePath
+                    )
+                    var info: UnsafeMutablePointer<MossIndexInfo>?
+                    let r = moss_client_load_index(h, cname, &nativeOpts, &info)
+                    if let info { moss_free_index_info(info) }
+                    try Self.throwIfErr(r)
+                }
+            }
+        }.value
+    }
+
+    public func unloadIndex(_ name: String) async throws {
+        let h = try requireHandle()
+        try await Task.detached { [self] in
+            try name.withCString { cname in
+                let r = moss_client_unload_index(h, cname)
+                try Self.throwIfErr(r)
+            }
+        }.value
+    }
+
+    public func query(
+        _ indexName: String,
+        _ query: String,
+        options: QueryOptions = QueryOptions()
+    ) async throws -> SearchResult {
+        let h = try requireHandle()
+        let opts = options
+        // Validate topK here so `UInt(opts.topK)` below doesn't trap on
+        // negatives — defensive against caller error since topK is a
+        // signed Int in the public API.
+        guard opts.topK >= 0 else {
+            throw MossError(code: -2, message: "topK must be non-negative; got \(opts.topK)")
+        }
+        return try await Task.detached { [self] () throws -> SearchResult in
+            try indexName.withCString { iname in
+                try query.withCString { q in
+                    try withOptionalCString(opts.filterJson) { filter in
+                        var nativeOpts = MossQueryOptions(
+                            top_k: UInt(opts.topK),
+                            alpha: opts.alpha,
+                            filter_json: filter,
+                            embedding: nil,
+                            embedding_dim: 0
+                        )
+                        var result: UnsafeMutablePointer<MossSearchResult>?
+                        let r = moss_client_query(h, iname, q, &nativeOpts, &result)
+                        try Self.throwIfErr(r)
+                        guard let result else { throw Self.lastError(code: -7) }
+                        defer { moss_free_search_result(result) }
+                        return Self.parseSearchResult(result.pointee)
+                    }
+                }
+            }
+        }.value
+    }
+
+    public func deleteIndex(_ name: String) async throws -> Bool {
+        let h = try requireHandle()
+        return try await Task.detached { [self] () throws -> Bool in
+            try name.withCString { (cname: UnsafePointer<CChar>) throws -> Bool in
+                var deleted: Bool = false
+                let r = moss_client_delete_index(h, cname, &deleted)
+                try Self.throwIfErr(r)
+                return deleted
+            }
+        }.value
+    }
+
+    public func getIndex(_ name: String) async throws -> IndexInfo {
+        let h = try requireHandle()
+        return try await Task.detached { [self] () throws -> IndexInfo in
+            try name.withCString { cname in
+                var info: UnsafeMutablePointer<MossIndexInfo>?
+                let r = moss_client_get_index(h, cname, &info)
+                try Self.throwIfErr(r)
+                guard let info else { throw Self.lastError(code: -7) }
+                defer { moss_free_index_info(info) }
+                return Self.parseIndexInfo(info.pointee)
+            }
+        }.value
+    }
+
+    public func listIndexes() async throws -> [IndexInfo] {
+        let h = try requireHandle()
+        return try await Task.detached { [self] () throws -> [IndexInfo] in
+            var infos: UnsafeMutablePointer<MossIndexInfo>?
+            var count: UInt = 0
+            let r = moss_client_list_indexes(h, &infos, &count)
+            try Self.throwIfErr(r)
+            guard let infos else { return [] }
+            defer { moss_free_index_info_list(infos, count) }
+            let n = Int(count)
+            var out: [IndexInfo] = []
+            out.reserveCapacity(n)
+            for i in 0..<n {
+                out.append(Self.parseIndexInfo(infos.advanced(by: i).pointee))
+            }
+            return out
+        }.value
+    }
+
+    public func refreshIndex(_ name: String) async throws -> RefreshResult {
+        let h = try requireHandle()
+        return try await Task.detached { [self] () throws -> RefreshResult in
+            try name.withCString { cname in
+                var result: UnsafeMutablePointer<MossRefreshResult>?
+                let r = moss_client_refresh_index(h, cname, &result)
+                try Self.throwIfErr(r)
+                guard let result else { throw Self.lastError(code: -7) }
+                defer { moss_free_refresh_result(result) }
+                let p = result.pointee
+                return RefreshResult(
+                    indexName: cstr(p.index_name),
+                    previousUpdatedAt: cstr(p.previous_updated_at),
+                    newUpdatedAt: cstr(p.new_updated_at),
+                    wasUpdated: p.was_updated
+                )
+            }
+        }.value
+    }
+
+    public func getJobStatus(_ jobId: String) async throws -> JobStatus {
+        let h = try requireHandle()
+        return try await Task.detached { [self] () throws -> JobStatus in
+            try jobId.withCString { cjob in
+                var result: UnsafeMutablePointer<MossJobStatusResponse>?
+                let r = moss_client_get_job_status(h, cjob, &result)
+                try Self.throwIfErr(r)
+                guard let result else { throw Self.lastError(code: -7) }
+                defer { moss_free_job_status_response(result) }
+                let p = result.pointee
+                return JobStatus(
+                    jobId: cstr(p.job_id),
+                    status: cstr(p.status),
+                    progress: p.progress,
+                    currentPhase: cstrOpt(p.current_phase),
+                    error: cstrOpt(p.error),
+                    createdAt: cstr(p.created_at),
+                    updatedAt: cstr(p.updated_at),
+                    completedAt: cstrOpt(p.completed_at)
+                )
+            }
+        }.value
+    }
+
+    public func createIndex(
+        _ name: String,
+        docs: [DocumentInfo],
+        modelId: String? = nil
+    ) async throws -> MutationResult {
+        let h = try requireHandle()
+        let docsJson = try Self.encodeJson(docs)
+        return try await Task.detached { [self] () throws -> MutationResult in
+            try name.withCString { cname in
+                try docsJson.withCString { cdocs in
+                    try withOptionalCString(modelId) { cmodel in
+                        var out: UnsafeMutablePointer<CChar>?
+                        let r = moss_client_create_index_from_json(h, cname, cdocs, cmodel, &out)
+                        try Self.throwIfErr(r)
+                        guard let out else { throw Self.lastError(code: -7) }
+                        defer { moss_free_string(out) }
+                        return try Self.decodeMutationResult(String(cString: out))
+                    }
+                }
+            }
+        }.value
+    }
+
+    public func addDocs(
+        _ name: String,
+        docs: [DocumentInfo],
+        upsert: Bool = true
+    ) async throws -> MutationResult {
+        let h = try requireHandle()
+        let docsJson = try Self.encodeJson(docs)
+        return try await Task.detached { [self] () throws -> MutationResult in
+            try name.withCString { cname in
+                try docsJson.withCString { cdocs in
+                    var out: UnsafeMutablePointer<CChar>?
+                    let r = moss_client_add_docs_from_json(h, cname, cdocs, upsert, &out)
+                    try Self.throwIfErr(r)
+                    guard let out else { throw Self.lastError(code: -7) }
+                    defer { moss_free_string(out) }
+                    return try Self.decodeMutationResult(String(cString: out))
+                }
+            }
+        }.value
+    }
+
+    public func getDocs(_ name: String, docIds: [String]? = nil) async throws -> [DocumentInfo] {
+        let h = try requireHandle()
+        let idsJson: String? = try docIds.map { try Self.encodeJson($0) }
+        return try await Task.detached { [self] () throws -> [DocumentInfo] in
+            try name.withCString { cname in
+                try withOptionalCString(idsJson) { cids in
+                    var out: UnsafeMutablePointer<CChar>?
+                    let r = moss_client_get_docs_json(h, cname, cids, &out)
+                    try Self.throwIfErr(r)
+                    guard let out else { throw Self.lastError(code: -7) }
+                    defer { moss_free_string(out) }
+                    let str = String(cString: out)
+                    let data = Data(str.utf8)
+                    return try JSONDecoder().decode([DocumentInfo].self, from: data)
+                }
+            }
+        }.value
+    }
+
+    /// Free reclaimable native memory in response to an OS memory-pressure
+    /// signal. Wire this from `applicationDidReceiveMemoryWarning` /
+    /// `UIApplication.didReceiveMemoryWarningNotification`. Returns the
+    /// number of indexes that were unloaded.
+    public func onMemoryPressure(_ level: MemoryPressureLevel = .critical) async throws -> Int {
+        let h = try requireHandle()
+        let levelRaw = level.rawValue
+        return try await Task.detached { [self] () throws -> Int in
+            var unloaded: Int = 0
+            let r = moss_client_release_memory(h, levelRaw, &unloaded)
+            try Self.throwIfErr(r)
+            return unloaded
+        }.value
+    }
+
+    public func deleteDocs(_ name: String, docIds: [String]) async throws -> MutationResult {
+        let h = try requireHandle()
+        return try await Task.detached { [self] () throws -> MutationResult in
+            // Build a const-char-pointer array; the C function takes
+            // `const char *const *` plus a count.
+            try name.withCString { cname in
+                try withCStringArray(docIds) { ptrs in
+                    var result: UnsafeMutablePointer<MossMutationResult>?
+                    let r = moss_client_delete_docs(h, cname, ptrs, UInt(docIds.count), &result)
+                    try Self.throwIfErr(r)
+                    guard let result else { throw Self.lastError(code: -7) }
+                    defer { moss_free_mutation_result(result) }
+                    let p = result.pointee
+                    return MutationResult(
+                        jobId: cstr(p.job_id),
+                        indexName: cstr(p.index_name),
+                        docCount: Int(p.doc_count)
+                    )
+                }
+            }
+        }.value
+    }
+
+    // ── Internals ────────────────────────────────────────────────────
+
+    private func requireHandle() throws -> OpaquePointer {
+        guard let h = handle else {
+            throw MossError(code: -1, message: "MossClient already closed")
+        }
+        return h
+    }
+
+    /// `MossResult` is emitted as both an `enum` and a separate
+    /// `typedef int32_t MossResult`, which Swift sees as ambiguous. We treat
+    /// the value as a raw `Int32` and compare against the well-known OK == 0
+    /// constant from the C header.
+    fileprivate static func throwIfErr(_ r: Int32) throws {
+        if r != 0 {
+            throw lastError(code: r)
+        }
+    }
+
+    fileprivate static func lastError(code: Int32) -> MossError {
+        let ptr = moss_last_error()
+        let msg = ptr != nil ? String(cString: ptr!) : "moss native error code \(code)"
+        return MossError(code: code, message: msg)
+    }
+
+    fileprivate static func parseIndexInfo(_ i: MossIndexInfo) -> IndexInfo {
+        IndexInfo(
+            id: cstr(i.id),
+            name: cstr(i.name),
+            status: cstr(i.status),
+            docCount: Int(i.doc_count),
+            model: ModelRef(
+                id: cstr(i.model.id),
+                version: cstrOpt(i.model.version)
+            ),
+            version: cstrOpt(i.version),
+            createdAt: cstrOpt(i.created_at),
+            updatedAt: cstrOpt(i.updated_at)
+        )
+    }
+
+    fileprivate static func encodeJson<T: Encodable>(_ value: T) throws -> String {
+        let data = try JSONEncoder().encode(value)
+        guard let s = String(data: data, encoding: .utf8) else {
+            throw MossError(code: -7, message: "encoded JSON was not valid UTF-8")
+        }
+        return s
+    }
+
+    fileprivate static func decodeMutationResult(_ json: String) throws -> MutationResult {
+        struct Wire: Decodable {
+            let jobId: String
+            let indexName: String
+            let docCount: Int
+        }
+        let w = try JSONDecoder().decode(Wire.self, from: Data(json.utf8))
+        return MutationResult(jobId: w.jobId, indexName: w.indexName, docCount: w.docCount)
+    }
+
+    private static func parseSearchResult(_ r: MossSearchResult) -> SearchResult {
+        let count = Int(r.doc_count)
+        var docs: [QueryResult] = []
+        docs.reserveCapacity(count)
+        if let buf = r.docs {
+            for i in 0..<count {
+                let d = buf.advanced(by: i).pointee
+                docs.append(
+                    QueryResult(
+                        id: d.id.flatMap { String(cString: $0) } ?? "",
+                        score: d.score,
+                        text: d.text.flatMap { String(cString: $0) } ?? ""
+                    )
+                )
+            }
+        }
+        return SearchResult(
+            docs: docs,
+            query: r.query.flatMap { String(cString: $0) } ?? "",
+            timeMs: r.time_taken_ms
+        )
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/// Trampoline matching `MossAuthNotifyFn` in the C header:
+///   typedef void (*MossAuthNotifyFn)(uint32_t request_id, void *user_data);
+///
+/// Lives here (not in Authenticator.swift) because Swift's eager linker
+/// emits a duplicate `@_cdecl` symbol when the function is referenced from
+/// a different translation unit. Co-locating with the only caller fixes it.
+@_cdecl("_moss_swift_auth_notify")
+func mossSwiftAuthNotify(requestId: UInt32, userData: UnsafeMutableRawPointer?) {
+    guard let userData else { return }
+    let box = Unmanaged<AuthenticatorBox>.fromOpaque(userData).takeUnretainedValue()
+    Task.detached {
+        do {
+            let token = try await box.inner.getAuthHeader()
+            token.withCString { ptr in _ = moss_resolve_auth_request(requestId, ptr) }
+        } catch {
+            let msg = "\(error)"
+            msg.withCString { ptr in _ = moss_reject_auth_request(requestId, ptr) }
+        }
+    }
+}
+
+/// `withCString` for an optional string. Calls `body(nil)` when the input is nil.
+@inline(__always)
+func withOptionalCString<R>(_ s: String?, _ body: (UnsafePointer<CChar>?) throws -> R) rethrows -> R {
+    if let s {
+        return try s.withCString { try body($0) }
+    } else {
+        return try body(nil)
+    }
+}
+
+/// Build a `const char *const *` array of NUL-terminated copies of `strings`,
+/// hand it to `body`, then free everything. Used for C functions that take
+/// arrays of strings (e.g. `moss_client_delete_docs`).
+@inline(__always)
+func withCStringArray<R>(
+    _ strings: [String],
+    _ body: (UnsafePointer<UnsafePointer<CChar>?>) throws -> R
+) rethrows -> R {
+    let copies = strings.map { strdup($0) }
+    defer { copies.forEach { free($0) } }
+    let ptrs = UnsafeMutablePointer<UnsafePointer<CChar>?>.allocate(capacity: copies.count)
+    defer { ptrs.deallocate() }
+    for (i, c) in copies.enumerated() {
+        ptrs[i] = UnsafePointer(c)
+    }
+    return try body(ptrs)
+}
+
+/// Read a (possibly NULL) `*mut c_char` into a Swift String, defaulting to empty.
+@inline(__always)
+func cstr(_ p: UnsafeMutablePointer<CChar>?) -> String {
+    p.flatMap { String(cString: $0) } ?? ""
+}
+
+/// Read a (possibly NULL) `*mut c_char` into a Swift String?, returning nil
+/// for null pointers.
+@inline(__always)
+func cstrOpt(_ p: UnsafeMutablePointer<CChar>?) -> String? {
+    p.flatMap { String(cString: $0) }
+}

--- a/sdks/swift/Sources/Moss/MossClient.swift
+++ b/sdks/swift/Sources/Moss/MossClient.swift
@@ -1,5 +1,8 @@
 import Foundation
 import MossC
+#if canImport(UIKit)
+import UIKit
+#endif
 
 /// Idiomatic Swift wrapper for the native Moss SDK.
 ///
@@ -39,12 +42,22 @@ public final class MossClient: @unchecked Sendable {
     private let stateCond = NSCondition()
 
     /// Construct a client backed by a static project key.
+    ///
+    /// The client automatically attaches a stable per-device telemetry
+    /// identifier sourced from `UIDevice.current.identifierForVendor`,
+    /// with a Keychain-persisted UUID fallback if IDFV is unavailable.
+    /// The consumer doesn't supply this — it's an SDK concern, not an
+    /// app concern, and keeping it inside the SDK ensures every
+    /// consumer reports telemetry the same way.
     public init(projectId: String, projectKey: String) throws {
         try Self.ensureModelCacheDir()
+        let did = Self.stableDeviceId()
         var raw: OpaquePointer?
         let r = projectId.withCString { pid in
             projectKey.withCString { pkey in
-                moss_client_new(pid, pkey, &raw)
+                did.withCString { d in
+                    moss_client_new_with_device_id(pid, pkey, d, &raw)
+                }
             }
         }
         try Self.throwIfErr(r)
@@ -54,24 +67,33 @@ public final class MossClient: @unchecked Sendable {
     }
 
     /// Construct a client whose bearer tokens come from [authenticator].
-    public init(projectId: String, authenticator: any Authenticator, baseUrl: String? = nil) throws {
+    /// See the static-key initializer for the device-id behavior.
+    public init(
+        projectId: String,
+        authenticator: any Authenticator,
+        baseUrl: String? = nil
+    ) throws {
         try Self.ensureModelCacheDir()
         let box = AuthenticatorBox(authenticator)
         // Retain the box and pass its raw pointer as user_data. The native
         // side stores it for the client's lifetime. `close()` releases the
         // retained reference exactly once.
         let userData = Unmanaged.passRetained(box).toOpaque()
+        let did = Self.stableDeviceId()
 
         var raw: OpaquePointer?
         let r = projectId.withCString { pid in
             withOptionalCString(baseUrl) { base in
-                moss_client_new_with_authenticator(
-                    pid,
-                    mossSwiftAuthNotify,
-                    userData,
-                    base,
-                    &raw
-                )
+                did.withCString { d in
+                    moss_client_new_with_authenticator_and_device_id(
+                        pid,
+                        mossSwiftAuthNotify,
+                        userData,
+                        base,
+                        d,
+                        &raw
+                    )
+                }
             }
         }
         if r != 0 {
@@ -164,6 +186,65 @@ public final class MossClient: @unchecked Sendable {
     /// (caller thread) and `ensureModelCacheDir` (any init thread).
     private static let cacheDirLock = NSLock()
     private static var cacheDirConfigured = false
+
+    // ── Device-identifier helpers ────────────────────────────────────
+
+    /// Returns a stable per-device identifier suitable for telemetry
+    /// attribution. Tries `UIDevice.identifierForVendor` first (the
+    /// recommended Apple-blessed mechanism; no permission prompt, no
+    /// App Tracking Transparency consent required). Falls back to a
+    /// UUID persisted in the Keychain if IDFV is unavailable — which
+    /// is rare in practice but can happen very early in the launch
+    /// sequence or in unusual restored-from-backup states.
+    ///
+    /// IDFV is stable for the lifetime of any app from your team on
+    /// this device; the Keychain fallback is stable across reinstalls
+    /// of this specific app.
+    static func stableDeviceId() -> String {
+        #if canImport(UIKit)
+        if let idfv = UIDevice.current.identifierForVendor?.uuidString {
+            return idfv
+        }
+        #endif
+        return keychainOrCreateDeviceId()
+    }
+
+    /// Reads (or creates) a UUID stored in the Keychain under a moss-
+    /// specific service+account. Used as a fallback when IDFV is nil
+    /// or absent.
+    private static func keychainOrCreateDeviceId() -> String {
+        let service = "dev.moss.sdk"
+        let account = "device_id"
+
+        let readQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+        ]
+        var item: CFTypeRef?
+        if SecItemCopyMatching(readQuery as CFDictionary, &item) == errSecSuccess,
+           let data = item as? Data,
+           let existing = String(data: data, encoding: .utf8),
+           !existing.isEmpty {
+            return existing
+        }
+
+        let new = UUID().uuidString
+        let writeAttrs: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: Data(new.utf8),
+            // ThisDeviceOnly: the entry doesn't migrate to a new device
+            // via iCloud Keychain backup. Telemetry IDs should stay
+            // device-scoped — restoring to a new device should look
+            // like a fresh install for attribution purposes.
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        _ = SecItemAdd(writeAttrs as CFDictionary, nil)
+        return new
+    }
 
     // ── Operations ───────────────────────────────────────────────────
 
@@ -438,6 +519,48 @@ public final class MossClient: @unchecked Sendable {
         }.value
     }
 
+    /// Open an on-device session for `name` with the given options.
+    ///
+    /// Sessions back the local-only flow: documents are embedded on-
+    /// device with the bundled litelm model (no network round-trip),
+    /// stored in an mmap'd vector store, and queried locally. Pass the
+    /// returned [MossSession] to `addDocs`/`query`/etc. Call `close()`
+    /// (or let it deinit) to release the native handle.
+    ///
+    /// `options.modelId == nil` selects the platform default
+    /// (`moss-litelm` on iOS). `options.vectorQuantization` picks the
+    /// on-disk vector precision used by `MossSession.save(toCachePath:)`
+    /// — defaults to platform-appropriate (INT8 on iOS).
+    public func session(
+        _ name: String,
+        options: SessionOptions = SessionOptions()
+    ) async throws -> MossSession {
+        let opts = options
+        return try await Task.detached { [self] () throws -> MossSession in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            return try name.withCString { cname in
+                try withOptionalCString(opts.modelId) { cmodel in
+                    var nativeOpts = MossSessionOptions(
+                        model_id: cmodel,
+                        vector_quantization: opts.vectorQuantization.rawValue
+                    )
+                    var raw: OpaquePointer?
+                    let r = moss_client_session(h, cname, &nativeOpts, &raw)
+                    try Self.throwIfErr(r)
+                    guard let raw else { throw Self.lastError(code: -7) }
+                    return MossSession(takingOwnershipOf: raw)
+                }
+            }
+        }.value
+    }
+
+    /// Convenience overload: open a session with just a model id.
+    /// Equivalent to `session(name, options: SessionOptions(modelId: modelId))`.
+    public func session(_ name: String, modelId: String?) async throws -> MossSession {
+        try await session(name, options: SessionOptions(modelId: modelId))
+    }
+
     // ── Internals ────────────────────────────────────────────────────
 
     /// Reserve the native handle for the duration of a single operation.
@@ -469,13 +592,13 @@ public final class MossClient: @unchecked Sendable {
     /// `typedef int32_t MossResult`, which Swift sees as ambiguous. We treat
     /// the value as a raw `Int32` and compare against the well-known OK == 0
     /// constant from the C header.
-    fileprivate static func throwIfErr(_ r: Int32) throws {
+    static func throwIfErr(_ r: Int32) throws {
         if r != 0 {
             throw lastError(code: r)
         }
     }
 
-    fileprivate static func lastError(code: Int32) -> MossError {
+    static func lastError(code: Int32) -> MossError {
         let ptr = moss_last_error()
         let msg = ptr != nil ? String(cString: ptr!) : "moss native error code \(code)"
         return MossError(code: code, message: msg)
@@ -497,7 +620,7 @@ public final class MossClient: @unchecked Sendable {
         )
     }
 
-    fileprivate static func encodeJson<T: Encodable>(_ value: T) throws -> String {
+    static func encodeJson<T: Encodable>(_ value: T) throws -> String {
         let data = try JSONEncoder().encode(value)
         guard let s = String(data: data, encoding: .utf8) else {
             throw MossError(code: -7, message: "encoded JSON was not valid UTF-8")
@@ -505,7 +628,7 @@ public final class MossClient: @unchecked Sendable {
         return s
     }
 
-    fileprivate static func decodeMutationResult(_ json: String) throws -> MutationResult {
+    static func decodeMutationResult(_ json: String) throws -> MutationResult {
         // The JSON-returning C entry points (moss_client_create_index_from_json,
         // moss_client_add_docs_from_json) emit MutationResult with camelCase
         // keys: { "jobId", "indexName", "docCount" }. If the native layer's
@@ -520,7 +643,7 @@ public final class MossClient: @unchecked Sendable {
         return MutationResult(jobId: w.jobId, indexName: w.indexName, docCount: w.docCount)
     }
 
-    private static func parseSearchResult(_ r: MossSearchResult) -> SearchResult {
+    static func parseSearchResult(_ r: MossSearchResult) -> SearchResult {
         let count = Int(r.doc_count)
         var docs: [QueryResult] = []
         docs.reserveCapacity(count)
@@ -548,7 +671,7 @@ public final class MossClient: @unchecked Sendable {
     /// Drops entries with NULL keys (which the native side shouldn't emit
     /// but we defend against). NULL `entries` or `count == 0` returns nil
     /// so the optional `QueryResult.metadata` is empty rather than `[:]`.
-    private static func parseMetadata(
+    static func parseMetadata(
         _ entries: UnsafeMutablePointer<MossMetadataEntry>?,
         count: UInt
     ) -> [String: String]? {

--- a/sdks/swift/Sources/Moss/MossError.swift
+++ b/sdks/swift/Sources/Moss/MossError.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Surfaced for any failure reported by the underlying Moss runtime.
+public struct MossError: LocalizedError {
+    public let code: Int32
+    public let message: String
+
+    public var errorDescription: String? { message }
+
+    init(code: Int32, message: String) {
+        self.code = code
+        self.message = message
+    }
+}

--- a/sdks/swift/Sources/Moss/MossError.swift
+++ b/sdks/swift/Sources/Moss/MossError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Surfaced for any failure reported by the underlying Moss runtime.
+/// Surfaced for any failure reported by the underlying libmoss runtime.
 public struct MossError: LocalizedError {
     public let code: Int32
     public let message: String

--- a/sdks/swift/Sources/Moss/MossSession.swift
+++ b/sdks/swift/Sources/Moss/MossSession.swift
@@ -1,0 +1,453 @@
+import Foundation
+import MossC
+
+/// On-device session handle for a single index. Returned by
+/// `MossClient.session(_:modelId:)`. All embedding runs locally with
+/// the bundled litelm model; queries don't hit the network.
+///
+/// ```swift
+/// let session = try await client.session("notes")
+/// _ = try await session.addDocs([
+///     DocumentInfo(id: "1", text: "first note"),
+///     DocumentInfo(id: "2", text: "second note"),
+/// ])
+/// let result = try await session.query("first")
+/// ```
+///
+/// The class is thread-safe: concurrent calls are serialized only at
+/// the native handle level. `close()` (called automatically on deinit)
+/// blocks until every in-flight call has returned before freeing the
+/// native pointer, mirroring the contract in `MossClient.close()`.
+public final class MossSession: @unchecked Sendable {
+    private var handle: OpaquePointer?
+    private var inFlight: Int = 0
+    private var closed: Bool = false
+    private let stateCond = NSCondition()
+
+    /// Used by `MossClient.session(...)` only — the C API hands us a
+    /// strong, transferable pointer and we take exclusive ownership.
+    init(takingOwnershipOf raw: OpaquePointer) {
+        self.handle = raw
+    }
+
+    deinit { close() }
+
+    /// Free the underlying native handle. Idempotent. Blocks until all
+    /// in-flight calls return so they never operate on a freed pointer.
+    public func close() {
+        stateCond.lock()
+        if closed {
+            stateCond.unlock()
+            return
+        }
+        closed = true
+        while inFlight > 0 {
+            stateCond.wait()
+        }
+        let h = handle
+        handle = nil
+        stateCond.unlock()
+        if let h {
+            moss_session_free(h)
+        }
+    }
+
+    // ── Identity ─────────────────────────────────────────────────────
+
+    /// The index name this session was opened against.
+    public var name: String {
+        // Synchronously borrow — `moss_session_name` returns a pointer
+        // into native-owned memory; we copy into a Swift String before
+        // returning the borrow.
+        guard let h = try? borrowHandle() else { return "" }
+        defer { returnHandle() }
+        let ptr = moss_session_name(h)
+        guard let ptr else { return "" }
+        return String(cString: ptr)
+    }
+
+    /// Current document count in the index.
+    public var docCount: Int {
+        guard let h = try? borrowHandle() else { return 0 }
+        defer { returnHandle() }
+        return Int(moss_session_doc_count(h))
+    }
+
+    // ── Mutations ────────────────────────────────────────────────────
+
+    /// Add or upsert documents. Returns (added, updated) counts —
+    /// `added` is rows that didn't exist before, `updated` is rows
+    /// whose id collided with an existing row.
+    @discardableResult
+    public func addDocs(
+        _ docs: [DocumentInfo],
+        upsert: Bool = true
+    ) async throws -> (added: Int, updated: Int) {
+        try await Task.detached { [self] () throws -> (Int, Int) in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            return try Self.withNativeDocs(docs) { docBuf, count in
+                var opts = MossAddDocsOptions(upsert: upsert)
+                var added: UInt = 0
+                var updated: UInt = 0
+                let r = moss_session_add_docs(h, docBuf, count, &opts, &added, &updated)
+                try MossClient.throwIfErr(r)
+                return (Int(added), Int(updated))
+            }
+        }.value
+    }
+
+    /// Delete documents by id. Returns the actual count deleted —
+    /// missing ids are silently ignored.
+    @discardableResult
+    public func deleteDocs(_ docIds: [String]) async throws -> Int {
+        try await Task.detached { [self] () throws -> Int in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            return try withCStringArray(docIds) { ptrs in
+                var deleted: UInt = 0
+                let r = moss_session_delete_docs(h, ptrs, UInt(docIds.count), &deleted)
+                try MossClient.throwIfErr(r)
+                return Int(deleted)
+            }
+        }.value
+    }
+
+    /// Return documents by id. Passing nil returns all docs in the
+    /// index — convenient for inspection, but expensive on large indexes.
+    /// An empty array returns nothing (vs nil's "everything") so callers
+    /// can distinguish "no filter" from "asked for no docs".
+    public func getDocs(_ docIds: [String]? = nil) async throws -> [DocumentInfo] {
+        try await Task.detached { [self] () throws -> [DocumentInfo] in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            if let docIds {
+                return try withCStringArray(docIds) { ptrs in
+                    try Self.runGetDocs(h, idsPtr: ptrs, idCount: UInt(docIds.count))
+                }
+            }
+            return try Self.runGetDocs(h, idsPtr: nil, idCount: 0)
+        }.value
+    }
+
+    private static func runGetDocs(
+        _ h: OpaquePointer,
+        idsPtr: UnsafePointer<UnsafePointer<CChar>?>?,
+        idCount: UInt
+    ) throws -> [DocumentInfo] {
+        var outDocs: UnsafeMutablePointer<MossDocumentInfo>?
+        var outCount: UInt = 0
+        let r = moss_session_get_docs(h, idsPtr, idCount, &outDocs, &outCount)
+        try MossClient.throwIfErr(r)
+        guard let outDocs else { return [] }
+        defer { moss_free_documents(outDocs, outCount) }
+        return parseDocuments(outDocs, count: outCount)
+    }
+
+    // ── Query ────────────────────────────────────────────────────────
+
+    /// Run the on-device embedding model on `text` and return the
+    /// raw 384-dim FP32 vector. Useful for two patterns:
+    /// 1. Latency benches that want to time embedding vs search
+    ///    separately (pair with `query(_:embedding:options:)`).
+    /// 2. Querying the same input across multiple indexes without
+    ///    paying the embedding cost N times.
+    public func embed(_ text: String) async throws -> [Float] {
+        try await Task.detached { [self] () throws -> [Float] in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            return try text.withCString { ctext in
+                var buf = [Float](repeating: 0, count: 1024)
+                var outDim: UInt = 0
+                let r = buf.withUnsafeMutableBufferPointer { bp in
+                    moss_session_embed_query(h, ctext, bp.baseAddress, UInt(bp.count), &outDim)
+                }
+                try MossClient.throwIfErr(r)
+                buf.removeSubrange(Int(outDim)..<buf.count)
+                return buf
+            }
+        }.value
+    }
+
+    public func query(
+        _ q: String,
+        options: QueryOptions = QueryOptions()
+    ) async throws -> SearchResult {
+        try await query(q, embedding: nil, options: options)
+    }
+
+    /// Search variant that takes a pre-computed embedding (typically
+    /// obtained from `embed(_:)`). Bypasses the model forward pass —
+    /// pure dot-product scan + top-k. The `text` parameter is still
+    /// passed through to telemetry / SearchResult.query so the
+    /// caller-visible result stays consistent with `query(_:)`.
+    public func query(
+        _ q: String,
+        embedding: [Float]?,
+        options: QueryOptions = QueryOptions()
+    ) async throws -> SearchResult {
+        let opts = options
+        guard opts.topK >= 0 else {
+            throw MossError(code: -2, message: "topK must be non-negative; got \(opts.topK)")
+        }
+        return try await Task.detached { [self] () throws -> SearchResult in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            return try q.withCString { cq in
+                try withOptionalCString(opts.filterJson) { filter in
+                    // `embedding` is captured by-ref in the closure
+                    // body; need to give it a stable pointer for the
+                    // lifetime of the C call. `withUnsafeBufferPointer`
+                    // on an Array of Float gives us that without
+                    // copying out of Swift-managed storage.
+                    let result: UnsafeMutablePointer<MossSearchResult>? = try {
+                        var resultLocal: UnsafeMutablePointer<MossSearchResult>?
+                        // `MossResult` is emitted by cbindgen as both an
+                        // enum and a typedef; Swift sees that as
+                        // ambiguous. Treat the wire value as Int32 and
+                        // hand it straight to `throwIfErr`.
+                        let invoke: (UnsafePointer<Float>?, Int) -> Int32 = { embPtr, embLen in
+                            var nativeOpts = MossQueryOptions(
+                                top_k: UInt(opts.topK),
+                                alpha: opts.alpha,
+                                filter_json: filter,
+                                embedding: embPtr,
+                                embedding_dim: UInt(embLen)
+                            )
+                            return moss_session_query(h, cq, &nativeOpts, &resultLocal)
+                        }
+                        let r: Int32 = if let emb = embedding {
+                            emb.withUnsafeBufferPointer { bp in invoke(bp.baseAddress, bp.count) }
+                        } else {
+                            invoke(nil, 0)
+                        }
+                        try MossClient.throwIfErr(r)
+                        return resultLocal
+                    }()
+                    guard let result else { throw MossClient.lastError(code: -7) }
+                    defer { moss_free_search_result(result) }
+                    return MossClient.parseSearchResult(result.pointee)
+                }
+            }
+        }.value
+    }
+
+    // ── Persistence ──────────────────────────────────────────────────
+
+    /// Pull a server-side index into this session as a one-time
+    /// hydration. Returns the doc count loaded (0 if the cloud has no
+    /// index by that name). The session subsequently behaves as a
+    /// local one — add/delete/query don't hit the network.
+    @discardableResult
+    public func loadIndex(_ indexName: String) async throws -> Int {
+        try await Task.detached { [self] () throws -> Int in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            return try indexName.withCString { cname in
+                var docCount: UInt = 0
+                let r = moss_session_load_index(h, cname, &docCount)
+                try MossClient.throwIfErr(r)
+                return Int(docCount)
+            }
+        }.value
+    }
+
+    /// Persist this session's index to disk at `cachePath`. Writes
+    /// vectors, documents, and metadata atomically so the session can
+    /// be re-opened via `loadFromDisk` on the next app launch without
+    /// re-embedding. Vector precision matches the `vectorQuantization`
+    /// passed to `MossClient.session(_:options:)`.
+    public func save(toCachePath cachePath: String) async throws {
+        try await Task.detached { [self] () throws -> Void in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            try cachePath.withCString { cpath in
+                let r = moss_session_save_to_disk(h, cpath)
+                try MossClient.throwIfErr(r)
+            }
+        }.value
+    }
+
+    /// Restore a session from a previous `save(toCachePath:)` at
+    /// `cachePath`. Returns the doc count restored.
+    ///
+    /// Note: the session's *name* (passed to `client.session(_:)`) must
+    /// match the one used at save time — it's part of the on-disk
+    /// directory path.
+    @discardableResult
+    public func loadFromDisk(cachePath: String) async throws -> Int {
+        try await Task.detached { [self] () throws -> Int in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            return try cachePath.withCString { cpath in
+                var docCount: UInt = 0
+                let r = moss_session_load_from_disk(h, cpath, &docCount)
+                try MossClient.throwIfErr(r)
+                return Int(docCount)
+            }
+        }.value
+    }
+
+    /// Push the in-memory session to the cloud as a server-side index.
+    /// Returns the push job details for status tracking.
+    public func pushIndex() async throws -> PushIndexResult {
+        try await Task.detached { [self] () throws -> PushIndexResult in
+            let h = try borrowHandle()
+            defer { returnHandle() }
+            var raw: UnsafeMutablePointer<MossPushIndexResult>?
+            let r = moss_session_push_index(h, &raw)
+            try MossClient.throwIfErr(r)
+            guard let raw else { throw MossClient.lastError(code: -7) }
+            defer { moss_free_push_index_result(raw) }
+            let p = raw.pointee
+            return PushIndexResult(
+                jobId: cstr(p.job_id),
+                indexName: cstr(p.index_name),
+                docCount: Int(p.doc_count),
+                status: cstr(p.status)
+            )
+        }.value
+    }
+
+    // ── Internals ────────────────────────────────────────────────────
+
+    private func borrowHandle() throws -> OpaquePointer {
+        stateCond.lock()
+        defer { stateCond.unlock() }
+        guard !closed, let h = handle else {
+            throw MossError(code: -1, message: "MossSession already closed")
+        }
+        inFlight += 1
+        return h
+    }
+
+    private func returnHandle() {
+        stateCond.lock()
+        defer { stateCond.unlock() }
+        inFlight -= 1
+        if inFlight == 0 {
+            stateCond.broadcast()
+        }
+    }
+
+    /// Wrap a `[DocumentInfo]` as a contiguous `MossDocumentInfo *`
+    /// buffer for the native call, then dispose of the temporary
+    /// allocations once `body` returns.
+    private static func withNativeDocs<R>(
+        _ docs: [DocumentInfo],
+        _ body: (UnsafePointer<MossDocumentInfo>?, UInt) throws -> R
+    ) throws -> R {
+        if docs.isEmpty {
+            return try body(nil, 0)
+        }
+
+        // Allocate one CString per id/text and one Float buffer per
+        // optional embedding. Track them so we can free in any order
+        // (errors thrown from `body` still hit the deferred cleanup).
+        var idHolders: [UnsafeMutablePointer<CChar>] = []
+        var textHolders: [UnsafeMutablePointer<CChar>] = []
+        var embHolders: [UnsafeMutablePointer<Float>] = []
+        var metaHolders: [UnsafeMutablePointer<MossMetadataEntry>] = []
+        var metaKVHolders: [UnsafeMutablePointer<CChar>] = []
+
+        defer {
+            for p in idHolders { free(p) }
+            for p in textHolders { free(p) }
+            for p in embHolders { p.deallocate() }
+            for p in metaHolders { p.deallocate() }
+            for p in metaKVHolders { free(p) }
+        }
+
+        var native: [MossDocumentInfo] = []
+        native.reserveCapacity(docs.count)
+
+        for d in docs {
+            let idPtr = strdup(d.id)!
+            let textPtr = strdup(d.text)!
+            idHolders.append(idPtr)
+            textHolders.append(textPtr)
+
+            var embPtr: UnsafeMutablePointer<Float>? = nil
+            var embLen: UInt = 0
+            if let e = d.embedding, !e.isEmpty {
+                let buf = UnsafeMutablePointer<Float>.allocate(capacity: e.count)
+                buf.initialize(from: e, count: e.count)
+                embHolders.append(buf)
+                embPtr = buf
+                embLen = UInt(e.count)
+            }
+
+            var metaPtr: UnsafeMutablePointer<MossMetadataEntry>? = nil
+            var metaCount: UInt = 0
+            if let m = d.metadata, !m.isEmpty {
+                let buf = UnsafeMutablePointer<MossMetadataEntry>.allocate(capacity: m.count)
+                metaHolders.append(buf)
+                var i = 0
+                for (k, v) in m {
+                    let kPtr = strdup(k)!
+                    let vPtr = strdup(v)!
+                    metaKVHolders.append(kPtr)
+                    metaKVHolders.append(vPtr)
+                    buf.advanced(by: i).initialize(to: MossMetadataEntry(
+                        key: kPtr,
+                        value: vPtr
+                    ))
+                    i += 1
+                }
+                metaPtr = buf
+                metaCount = UInt(m.count)
+            }
+
+            native.append(MossDocumentInfo(
+                id: idPtr,
+                text: textPtr,
+                metadata: metaPtr,
+                metadata_count: metaCount,
+                embedding: embPtr,
+                embedding_dim: embLen
+            ))
+        }
+
+        return try native.withUnsafeBufferPointer { buf in
+            try body(buf.baseAddress, UInt(buf.count))
+        }
+    }
+
+    private static func parseDocuments(
+        _ ptr: UnsafeMutablePointer<MossDocumentInfo>,
+        count: UInt
+    ) -> [DocumentInfo] {
+        let n = Int(count)
+        var out: [DocumentInfo] = []
+        out.reserveCapacity(n)
+        for i in 0..<n {
+            let d = ptr.advanced(by: i).pointee
+            let metadata = MossClient.parseMetadata(
+                d.metadata,
+                count: d.metadata_count
+            )
+            var embedding: [Float]? = nil
+            if let e = d.embedding, d.embedding_dim > 0 {
+                embedding = Array(UnsafeBufferPointer(start: e, count: Int(d.embedding_dim)))
+            }
+            out.append(DocumentInfo(
+                id: cstr(d.id),
+                text: cstr(d.text),
+                metadata: metadata,
+                embedding: embedding
+            ))
+        }
+        return out
+    }
+}
+
+/// Result of pushing a local session to the cloud via
+/// `MossSession.pushIndex()`. Status starts as `"queued"` and becomes
+/// `"ready"` once the server-side processing job completes; poll
+/// `MossClient.getJobStatus(jobId)` to track progress.
+public struct PushIndexResult: Sendable {
+    public let jobId: String
+    public let indexName: String
+    public let docCount: Int
+    public let status: String
+}

--- a/sdks/swift/Sources/Moss/MossTypes.swift
+++ b/sdks/swift/Sources/Moss/MossTypes.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+public struct QueryResult: Sendable {
+    public let id: String
+    public let score: Float
+    public let text: String
+}
+
+public struct SearchResult: Sendable {
+    public let docs: [QueryResult]
+    public let query: String
+    public let timeMs: UInt64
+}
+
+public struct QueryOptions: Sendable {
+    public var topK: Int
+    /// Hybrid weight between dense (1.0) and sparse (0.0) scores.
+    public var alpha: Float
+    /// Optional metadata filter as a JSON string.
+    public var filterJson: String?
+
+    public init(topK: Int = 5, alpha: Float = 0.8, filterJson: String? = nil) {
+        self.topK = topK
+        self.alpha = alpha
+        self.filterJson = filterJson
+    }
+}
+
+/// A document stored in or returned from a Moss index.
+public struct DocumentInfo: Sendable, Codable {
+    public let id: String
+    public let text: String
+    public let metadata: [String: String]?
+    public let embedding: [Float]?
+
+    public init(id: String, text: String, metadata: [String: String]? = nil, embedding: [Float]? = nil) {
+        self.id = id
+        self.text = text
+        self.metadata = metadata
+        self.embedding = embedding
+    }
+}
+
+/// Levels reported by the host OS when memory is constrained.
+public enum MemoryPressureLevel: UInt8, Sendable {
+    /// Hint: drop hot caches.
+    case low = 0
+    /// Drop everything reclaimable; persisted on-disk caches are kept.
+    case critical = 1
+}
+
+public struct ModelRef: Sendable {
+    public let id: String
+    public let version: String?
+}
+
+public struct IndexInfo: Sendable {
+    public let id: String
+    public let name: String
+    public let status: String
+    public let docCount: Int
+    public let model: ModelRef
+    public let version: String?
+    public let createdAt: String?
+    public let updatedAt: String?
+}
+
+public struct RefreshResult: Sendable {
+    public let indexName: String
+    public let previousUpdatedAt: String
+    public let newUpdatedAt: String
+    public let wasUpdated: Bool
+}
+
+public struct MutationResult: Sendable {
+    public let jobId: String
+    public let indexName: String
+    public let docCount: Int
+}
+
+public struct JobStatus: Sendable {
+    public let jobId: String
+    public let status: String
+    public let progress: Double
+    public let currentPhase: String?
+    public let error: String?
+    public let createdAt: String
+    public let updatedAt: String
+    public let completedAt: String?
+}
+
+public struct LoadIndexOptions: Sendable {
+    public var autoRefresh: Bool
+    public var pollingIntervalSeconds: UInt64
+    /// Optional sandbox path used to cache the index on disk so subsequent
+    /// launches don't re-download. Pass `FileManager.default.urls(for:
+    /// .documentDirectory, in: .userDomainMask).first!.path` or similar.
+    public var cachePath: String?
+
+    public init(autoRefresh: Bool = false, pollingIntervalSeconds: UInt64 = 0, cachePath: String? = nil) {
+        self.autoRefresh = autoRefresh
+        self.pollingIntervalSeconds = pollingIntervalSeconds
+        self.cachePath = cachePath
+    }
+}

--- a/sdks/swift/Sources/Moss/MossTypes.swift
+++ b/sdks/swift/Sources/Moss/MossTypes.swift
@@ -100,6 +100,35 @@ public struct JobStatus: Sendable {
     public let completedAt: String?
 }
 
+/// On-disk vector precision picked at session creation; used by
+/// `MossSession.save(toCachePath:)`. Orthogonal to the embedding model
+/// — pick `int8` for the smallest `.mossvec` files (~4× smaller than
+/// FP32, sub-1% recall hit on MiniLM-family vectors), `fp32` to force
+/// the historical lossless format, or leave at `.default` to get
+/// the platform-appropriate value (INT8 on iOS, FP32 elsewhere).
+///
+/// Raw wire values match the C ABI: 0 = default, 1 = fp32, 2 = int8.
+public enum VectorQuantization: UInt8, Sendable {
+    case `default` = 0
+    case fp32 = 1
+    case int8 = 2
+}
+
+/// Options bag for `MossClient.session(_:options:)`.
+public struct SessionOptions: Sendable {
+    /// Embedding model id. `nil` = platform default (`moss-litelm` on
+    /// iOS, `moss-minilm` elsewhere). Pass `"custom"` to skip on-device
+    /// embedding and supply embeddings via `DocumentInfo.embedding`.
+    public var modelId: String?
+    /// On-disk vector precision used by `MossSession.save(toCachePath:)`.
+    public var vectorQuantization: VectorQuantization
+
+    public init(modelId: String? = nil, vectorQuantization: VectorQuantization = .default) {
+        self.modelId = modelId
+        self.vectorQuantization = vectorQuantization
+    }
+}
+
 public struct LoadIndexOptions: Sendable {
     public var autoRefresh: Bool
     public var pollingIntervalSeconds: UInt64

--- a/sdks/swift/Sources/Moss/MossTypes.swift
+++ b/sdks/swift/Sources/Moss/MossTypes.swift
@@ -4,6 +4,17 @@ public struct QueryResult: Sendable {
     public let id: String
     public let score: Float
     public let text: String
+    /// Metadata associated with the document at index time, surfaced for
+    /// inspection and filtering. `nil` when the document has no metadata;
+    /// values are always strings (matching the native key/value model).
+    public let metadata: [String: String]?
+
+    public init(id: String, score: Float, text: String, metadata: [String: String]? = nil) {
+        self.id = id
+        self.score = score
+        self.text = text
+        self.metadata = metadata
+    }
 }
 
 public struct SearchResult: Sendable {


### PR DESCRIPTION
Adds `sdks/swift/` alongside the existing `sdks/javascript` and `sdks/python` so iOS consumers can install the Moss SDK via SwiftPM:

```swift
.package(url: \"https://github.com/usemoss/moss\", from: \"0.2.0\")
```

## What's in this PR

- `Package.swift` at root (SwiftPM requires this).
- `sdks/swift/Sources/Moss/` — Swift wrapper:
    - `MossClient` — `async/await` API over the libmoss C ABI: project auth, indexes, docs, cloud + local search, model-cache dir wiring.
    - `MossSession` — on-device session lifecycle (create / addDocs / query / save / loadFromDisk). Includes a split `embed(_:) + query(_:embedding:options:)` overload for callers that want to time the embed step separately or reuse one embedding across several indexes.
    - `Authenticator` protocol + continuation bridge for host-supplied auth flows.
    - vector quantization per-session via `SessionOptions.vectorQuantization`.
- `sdks/swift/{README.md, LICENSE}`.

The xcframework binary ships as a release asset on this repo, verified by SHA-256 in `Package.swift`.

## Status / merge sequence

The Swift sources in this PR are kept in sync as that internal PR evolves.

Once #269 merges:
1. Build the v0.2 xcframework from the merged internal SHA.
2. Cut `v0.2.0` on this repo with `Moss.xcframework.zip` attached.
3. Bump `Package.swift` URL `v0.1.0` → `v0.2.0` and replace the checksum with `shasum -a 256` of the release zip.
4. Merge this PR.