### PR TITLE
Updated moss CLI

### DIFF
--- a/packages/moss-cli/src/moss_cli/commands/doc.py
+++ b/packages/moss-cli/src/moss_cli/commands/doc.py
@@ -37,6 +37,7 @@ def add(
     upsert: bool = typer.Option(False, "--upsert", "-u", help="Update existing documents"),
     wait: bool = typer.Option(False, "--wait", "-w", help="Wait for job to complete"),
     poll_interval: float = typer.Option(2.0, "--poll-interval", help="Seconds between status checks"),
+    timeout: Optional[float] = typer.Option(None, "--timeout", help="Max seconds to wait (requires --wait)"),
 ) -> None:
     """Add documents to an index."""
     json_mode = ctx.obj.get("json_output", False)
@@ -57,7 +58,7 @@ def add(
     output.print_mutation_result(result, json_mode=json_mode)
 
     if wait:
-        asyncio.run(wait_for_job(client, result.job_id, poll_interval, json_mode))
+        asyncio.run(wait_for_job(client, result.job_id, poll_interval, json_mode, timeout))
 
 
 @doc_app.command(name="delete")
@@ -70,6 +71,7 @@ def delete(
     ),
     wait: bool = typer.Option(False, "--wait", "-w", help="Wait for job to complete"),
     poll_interval: float = typer.Option(2.0, "--poll-interval", help="Seconds between status checks"),
+    timeout: Optional[float] = typer.Option(None, "--timeout", help="Max seconds to wait (requires --wait)"),
 ) -> None:
     """Delete documents from an index by ID."""
     json_mode = ctx.obj.get("json_output", False)
@@ -89,7 +91,7 @@ def delete(
     output.print_mutation_result(result, json_mode=json_mode)
 
     if wait:
-        asyncio.run(wait_for_job(client, result.job_id, poll_interval, json_mode))
+        asyncio.run(wait_for_job(client, result.job_id, poll_interval, json_mode, timeout))
 
 
 @doc_app.command(name="get")

--- a/packages/moss-cli/src/moss_cli/commands/index.py
+++ b/packages/moss-cli/src/moss_cli/commands/index.py
@@ -37,6 +37,7 @@ def create(
     ),
     wait: bool = typer.Option(False, "--wait", "-w", help="Wait for job to complete"),
     poll_interval: float = typer.Option(2.0, "--poll-interval", help="Seconds between status checks"),
+    timeout: Optional[float] = typer.Option(None, "--timeout", help="Max seconds to wait (requires --wait)"),
 ) -> None:
     """Create a new index with documents."""
     json_mode = ctx.obj.get("json_output", False)
@@ -52,7 +53,7 @@ def create(
     output.print_mutation_result(result, json_mode=json_mode)
 
     if wait:
-        asyncio.run(wait_for_job(client, result.job_id, poll_interval, json_mode))
+        asyncio.run(wait_for_job(client, result.job_id, poll_interval, json_mode, timeout))
 
 
 @index_app.command(name="list")

--- a/packages/moss-cli/src/moss_cli/commands/sync.py
+++ b/packages/moss-cli/src/moss_cli/commands/sync.py
@@ -1,0 +1,142 @@
+"""moss sync — upsert documents from a directory, optionally watching for changes."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Dict, Optional, Set
+
+import typer
+from rich.console import Console
+
+from moss import MossClient, MutationOptions
+
+from .. import output
+from ..config import resolve_credentials
+from ..documents import load_documents
+from ..job_waiter import wait_for_job
+
+console = Console()
+
+
+def _client(ctx: typer.Context) -> MossClient:
+    pid, pkey = resolve_credentials(
+        ctx.obj.get("project_id"), ctx.obj.get("project_key"), ctx.obj.get("profile")
+    )
+    return MossClient(pid, pkey)
+
+
+def _scan(directory: Path, exts: Set[str]) -> Dict[Path, float]:
+    """Return {path: mtime} for all files matching the given extensions."""
+    result: Dict[Path, float] = {}
+    for ext in exts:
+        for p in directory.glob(f"**/*.{ext}"):
+            result[p] = p.stat().st_mtime
+    return result
+
+
+async def _upsert_file(
+    client: MossClient,
+    index_name: str,
+    path: Path,
+    json_mode: bool,
+    wait: bool,
+    poll_interval: float,
+    timeout: Optional[float],
+) -> None:
+    try:
+        docs = load_documents(str(path))
+    except typer.BadParameter as e:
+        output.print_error(f"{path.name}: {e}", json_mode=json_mode)
+        return
+
+    if not docs:
+        return
+
+    if not json_mode:
+        console.print(f"  [cyan]{path.name}[/cyan]: upserting {len(docs)} doc(s)...")
+
+    result = await client.add_docs(index_name, docs, MutationOptions(upsert=True))
+    output.print_mutation_result(result, json_mode=json_mode)
+
+    if wait:
+        await wait_for_job(client, result.job_id, poll_interval, json_mode, timeout)
+
+
+def sync_command(
+    ctx: typer.Context,
+    directory: Path = typer.Argument(..., help="Directory containing document files"),
+    index_name: str = typer.Argument(..., help="Index to upsert documents into"),
+    watch: bool = typer.Option(False, "--watch", "-w", help="Keep watching for file changes"),
+    ext: str = typer.Option("json,jsonl,csv", "--ext", help="Comma-separated file extensions to include"),
+    scan_interval: float = typer.Option(2.0, "--scan-interval", help="Seconds between directory scans (watch mode)"),
+    wait: bool = typer.Option(False, "--wait", help="Wait for each upsert job to complete"),
+    poll_interval: float = typer.Option(2.0, "--poll-interval", help="Seconds between job status checks"),
+    timeout: Optional[float] = typer.Option(None, "--timeout", help="Max seconds to wait per job (requires --wait)"),
+    profile: Optional[str] = typer.Option(None, "--profile", help="Credential profile name"),
+) -> None:
+    """Sync documents from a directory into an index.
+
+    Loads all JSON/JSONL/CSV files in DIRECTORY and upserts their documents into
+    INDEX_NAME. With --watch, re-upserts any file that is added or modified.
+    """
+    json_mode = ctx.obj.get("json_output", False)
+    if profile:
+        ctx.obj["profile"] = profile
+
+    if not directory.exists() or not directory.is_dir():
+        output.print_error(f"Not a directory: {directory}", json_mode=json_mode)
+        raise typer.Exit(1)
+
+    exts = {e.strip().lstrip(".") for e in ext.split(",") if e.strip()}
+    client = _client(ctx)
+
+    async def run() -> None:
+        # --- initial sync ---
+        file_mtimes = _scan(directory, exts)
+
+        if not file_mtimes:
+            if not json_mode:
+                console.print(f"[yellow]No matching files found in {directory}[/yellow]")
+            if not watch:
+                return
+
+        if not json_mode and file_mtimes:
+            console.print(f"Syncing [bold]{len(file_mtimes)}[/bold] file(s) into [cyan]{index_name}[/cyan]...")
+
+        for path in sorted(file_mtimes):
+            await _upsert_file(client, index_name, path, json_mode, wait, poll_interval, timeout)
+
+        if not watch:
+            return
+
+        if not json_mode:
+            console.print(
+                f"\n[green]Watching[/green] [cyan]{directory}[/cyan] — "
+                f"Ctrl+C to stop."
+            )
+
+        try:
+            while True:
+                await asyncio.sleep(scan_interval)
+                new_mtimes = _scan(directory, exts)
+
+                changed = [
+                    p for p, mtime in new_mtimes.items()
+                    if p not in file_mtimes or file_mtimes[p] != mtime
+                ]
+                added = [p for p in new_mtimes if p not in file_mtimes]
+
+                for path in sorted(set(changed) | set(added)):
+                    label = "added" if path in added else "changed"
+                    if not json_mode:
+                        console.print(f"[dim]{label}:[/dim] {path.name}")
+                    await _upsert_file(client, index_name, path, json_mode, wait, poll_interval, timeout)
+
+                file_mtimes = new_mtimes
+
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            if not json_mode:
+                console.print("\n[yellow]Stopped.[/yellow]")
+
+    asyncio.run(run())

--- a/packages/moss-cli/src/moss_cli/commands/validate.py
+++ b/packages/moss-cli/src/moss_cli/commands/validate.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import sys
 from collections import Counter
 from typing import List
 
@@ -11,7 +10,6 @@ import typer
 from rich.console import Console
 
 from ..documents import load_documents
-from ..output import print_error
 
 console = Console()
 

--- a/packages/moss-cli/src/moss_cli/commands/validate.py
+++ b/packages/moss-cli/src/moss_cli/commands/validate.py
@@ -1,0 +1,75 @@
+"""moss validate — check document files without uploading."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter
+from typing import List
+
+import typer
+from rich.console import Console
+
+from ..documents import load_documents
+from ..output import print_error
+
+console = Console()
+
+
+def validate_command(
+    ctx: typer.Context,
+    file: str = typer.Option(
+        ..., "--file", "-f", help="Path to JSON/JSONL/CSV file, or '-' for stdin"
+    ),
+) -> None:
+    """Validate a document file format without uploading."""
+    json_mode = ctx.obj.get("json_output", False)
+
+    try:
+        docs = load_documents(file)
+    except typer.BadParameter as e:
+        _report(json_mode, valid=False, doc_count=0, issues=[str(e)])
+        raise typer.Exit(1)
+    except SystemExit:
+        raise
+    except Exception as e:
+        _report(json_mode, valid=False, doc_count=0, issues=[str(e)])
+        raise typer.Exit(1)
+
+    issues: List[str] = []
+
+    if not docs:
+        issues.append("File contains 0 documents")
+
+    id_counts = Counter(d.id for d in docs)
+    for doc_id, count in id_counts.items():
+        if count > 1:
+            issues.append(f"Duplicate ID '{doc_id}' appears {count} times")
+
+    for i, doc in enumerate(docs):
+        if not doc.text or not doc.text.strip():
+            issues.append(f"Document {i} (id='{doc.id}'): empty text")
+        if doc.metadata is not None and not isinstance(doc.metadata, dict):
+            issues.append(f"Document '{doc.id}': metadata must be an object, got {type(doc.metadata).__name__}")
+        if doc.embedding is not None:
+            emb = doc.embedding
+            if not isinstance(emb, (list, tuple)) or not all(isinstance(x, (int, float)) for x in emb):
+                issues.append(f"Document '{doc.id}': embedding must be a list of numbers")
+
+    _report(json_mode, valid=len(issues) == 0, doc_count=len(docs), issues=issues)
+
+    if issues:
+        raise typer.Exit(1)
+
+
+def _report(json_mode: bool, valid: bool, doc_count: int, issues: List[str]) -> None:
+    if json_mode:
+        print(json.dumps({"valid": valid, "doc_count": doc_count, "issues": issues}, indent=2))
+        return
+
+    if valid:
+        console.print(f"[green]✓ Valid[/green] — {doc_count} document(s) ready to upload.")
+    else:
+        console.print(f"[red]✗ {len(issues)} issue(s) found[/red] in {doc_count} document(s):")
+        for issue in issues:
+            console.print(f"  [red]•[/red] {issue}")

--- a/packages/moss-cli/src/moss_cli/job_waiter.py
+++ b/packages/moss-cli/src/moss_cli/job_waiter.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import sys
+import time
+from typing import Optional
 
 from rich.console import Console
 from rich.live import Live
@@ -26,17 +30,30 @@ def _progress_float(status_obj: object) -> float:
     return p / 100.0 if p > 1 else p
 
 
+def _timeout_exit(job_id: str, timeout: float, json_mode: bool) -> None:
+    msg = f"Timed out after {timeout:.0f}s waiting for job {job_id}"
+    if json_mode:
+        print(json.dumps({"error": msg}), file=sys.stderr)
+    else:
+        console.print(f"[red]{msg}[/red]")
+    raise SystemExit(1)
+
+
 async def wait_for_job(
     client: MossClient,
     job_id: str,
     poll_interval: float = 2.0,
     json_mode: bool = False,
+    timeout: Optional[float] = None,
 ) -> None:
     """Poll job status until terminal state, showing progress."""
     terminal = {"COMPLETED", "FAILED"}
+    deadline = time.monotonic() + timeout if timeout is not None else None
 
     if json_mode:
         while True:
+            if deadline is not None and time.monotonic() >= deadline:
+                _timeout_exit(job_id, timeout, json_mode)
             status = await client.get_job_status(job_id)
             status_val = _status_str(status)
             if status_val in terminal:
@@ -48,6 +65,8 @@ async def wait_for_job(
 
     with Live(Spinner("dots", text="Waiting for job..."), console=console, transient=True) as live:
         while True:
+            if deadline is not None and time.monotonic() >= deadline:
+                _timeout_exit(job_id, timeout, json_mode)
             status = await client.get_job_status(job_id)
             status_val = _status_str(status)
 
@@ -56,9 +75,14 @@ async def wait_for_job(
             if phase is not None:
                 phase_str = f" ({phase.value if hasattr(phase, 'value') else str(phase)})"
 
+            timeout_str = ""
+            if deadline is not None:
+                remaining = max(0.0, deadline - time.monotonic())
+                timeout_str = f" [dim](timeout in {remaining:.0f}s)[/dim]"
+
             progress_pct = f"{_progress_float(status):.0%}"
             text = Text.from_markup(
-                f"[yellow]{status_val}[/yellow] {progress_pct}{phase_str}"
+                f"[yellow]{status_val}[/yellow] {progress_pct}{phase_str}{timeout_str}"
             )
             live.update(Spinner("dots", text=text))
 

--- a/packages/moss-cli/src/moss_cli/main.py
+++ b/packages/moss-cli/src/moss_cli/main.py
@@ -13,6 +13,8 @@ from .commands.init_cmd import init_command
 from .commands.job import job_app
 from .commands.profile import profile_app
 from .commands.search import query_command
+from .commands.sync import sync_command
+from .commands.validate import validate_command
 from .commands.version import version_command
 from .output import print_error
 
@@ -33,6 +35,8 @@ app.add_typer(profile_app, name="profile", help="Manage auth profiles")
 app.command(name="query")(query_command)
 app.command(name="init")(init_command)
 app.command(name="version")(version_command)
+app.command(name="validate")(validate_command)
+app.command(name="sync")(sync_command)
 
 
 @app.callback()


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [x] I have updated the documentation (if applicable).
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Description

This PR adds three improvements to `moss-cli` focused on developer experience and CI/CD reliability.

**`moss validate`** — new top-level command that validates a document file (JSON, JSONL, CSV) without making any network calls. Catches duplicate IDs, empty text fields, and malformed metadata/embeddings before an upload is attempted. Supports `--json` output for scripting.

**`--timeout SECONDS` on `--wait`** — all commands with `--wait` (`index create`, `doc add`, `doc delete`) now accept `--timeout`. Without it, `--wait` polls forever; if a job hangs in CI the pipeline freezes indefinitely. With `--timeout`, the CLI exits 1 with a clear message after the deadline is exceeded. The interactive spinner also shows a live countdown.

**`moss sync DIR INDEX_NAME`** — new top-level command that loads all JSON/JSONL/CSV files in a directory and upserts their documents into an index. `--watch` keeps the process running and re-upserts any file that is added or modified (polling via `mtime`). No extra dependencies — pure stdlib.

```bash
# one-shot sync
moss sync ./docs my-index --wait

# watch mode — re-upserts on any file change, Ctrl+C to stop
moss sync ./docs my-index --watch --wait --timeout 60
```

Also includes a `samples/` directory with ready-to-use test documents for manual testing.

Fixes # (issue number)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
