### PR TITLE
fix(ios): point Package.swift binaryTarget at v0.3.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@
 // To consume from another package or app:
 //
 //     dependencies: [
-//         .package(url: "https://github.com/usemoss/moss", from: "0.2.0"),
+//         .package(url: "https://github.com/usemoss/moss", from: "0.3.0"),
 //     ],
 //     targets: [
 //         .target(name: "YourTarget", dependencies: [
@@ -35,8 +35,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "MossC",
-            url: "https://github.com/usemoss/moss/releases/download/v0.2.0/Moss.xcframework.zip",
-            checksum: "0e0c6ef37569f0570511d86878c28485b5c3c8865f30541a16242875fdde9cbc"
+            url: "https://github.com/usemoss/moss/releases/download/v0.3.0/Moss.xcframework.zip",
+            checksum: "be385a25f0a8bdcae5b2a1f415b9c01a50d2b8b83187cb32640e23bba1e0cea7"
         ),
         .target(
             name: "Moss",


### PR DESCRIPTION
## What

Update the `MossC` `.binaryTarget` to the **v0.3.0** release asset and its checksum. The `v0.3.0` tag was published while `Package.swift` still referenced the **v0.2.0** binary — which has since been deleted — so `from: "0.3.0"` currently fails to resolve (the binary URL 404s).

- `url` → `.../releases/download/v0.3.0/Moss.xcframework.zip`
- `checksum` → `be385a25f0a8bdcae5b2a1f415b9c01a50d2b8b83187cb32640e23bba1e0cea7` (SHA-256 of the published v0.3.0 asset)
- doc-comment example bumped `0.2.0` → `0.3.0`

## Why v0.3.0

v0.3.0 = the v0.2 on-device session SDK **plus a mandatory auth gate**: opening a session now requires valid credentials + network. Previously the local add/embed/query flow ran with no network and even with invalid credentials. This is a breaking behavior change vs v0.2, hence the minor bump.

## ⚠️ After merge — move the tag

The `v0.3.0` tag must be force-moved to the merge commit so the tag's manifest references the correct asset:

```bash
git fetch origin && git tag -f v0.3.0 origin/main && git push --force origin v0.3.0
```

Safe to do now: the current tag's binary URL 404s, so nobody has successfully resolved v0.3.0 yet — there's no cached checksum/`Package.resolved` to break. Then smoke-test: `swift package resolve` against `from: "0.3.0"`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usemoss/moss/pull/267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->