### PR TITLE
Refactor iOS demo to highlight cloud push pathway and update docs

### DIFF
--- a/examples/ios/MossExample/MossDemoModel.swift
+++ b/examples/ios/MossExample/MossDemoModel.swift
@@ -37,9 +37,8 @@ final class MossDemoModel: ObservableObject {
     /// Highlights the push pathway end-to-end: open an on-device session, embed
     /// docs locally and query them, then `pushIndex` the session up to the
     /// cloud as a server-side index, poll until it's processed, and pull it
-    /// back into a fresh session with `loadIndex`. The session keeps its
-    /// on-device model throughout, so the loaded-back index queries locally
-    /// with no model mismatch. Requires network + valid credentials.
+    /// back into a fresh session with `loadIndex`, where it queries locally.
+    /// Requires network + valid credentials.
     func runSessionExample() async {
         guard let c = client else { return }
         busy = true

--- a/examples/ios/MossExample/MossDemoModel.swift
+++ b/examples/ios/MossExample/MossDemoModel.swift
@@ -4,8 +4,8 @@ import Moss
 /// Drives the demo screen - owns a `MossClient`, a status string, and a
 /// running log of operations. UI binds to the `@Published` fields.
 ///
-/// This sample focuses on Moss's on-device sessions: documents are embedded
-/// and searched entirely on the device, with no network calls.
+/// This sample highlights the push pathway: build an index on-device, push it
+/// to the cloud with `pushIndex`, then load it back into a fresh session.
 @MainActor
 final class MossDemoModel: ObservableObject {
     @Published var status: String = "starting…"
@@ -32,25 +32,30 @@ final class MossDemoModel: ObservableObject {
         }
     }
 
-    // ── On-device session example ────────────────────────────────────────────
+    // ── Push pathway example ─────────────────────────────────────────────────
 
-    /// Walks the on-device flow end-to-end: open a session, embed a handful
-    /// of docs locally with the bundled model, query against them, persist to
-    /// disk, reopen, then close. No network calls - everything runs on device.
+    /// Highlights the push pathway end-to-end: open an on-device session, embed
+    /// docs locally and query them, then `pushIndex` the session up to the
+    /// cloud as a server-side index, poll until it's processed, and pull it
+    /// back into a fresh session with `loadIndex`. The session keeps its
+    /// on-device model throughout, so the loaded-back index queries locally
+    /// with no model mismatch. Requires network + valid credentials.
     func runSessionExample() async {
         guard let c = client else { return }
         busy = true
-        appendLog("\n========== On-device session ==========")
+        appendLog("\n========== Session → push → load ==========")
         defer {
             appendLog("========== Done ==========\n")
             busy = false
         }
 
-        let sessionName = "ios-local-\(Int(Date().timeIntervalSince1970 * 1000))"
+        let sessionName = "ios-push-\(Int(Date().timeIntervalSince1970 * 1000))"
         var session: MossSession?
         defer { session?.close() }
+        var pushedName = sessionName
 
         do {
+            // ── Build an index on-device ──────────────────────────────────
             try await step("session('\(sessionName)')") {
                 session = try await c.session(sessionName)
                 self.appendLog("    name=\(session?.name ?? "?")  docCount=\(session?.docCount ?? -1)")
@@ -78,103 +83,57 @@ final class MossDemoModel: ObservableObject {
                 }
             }
 
-            try await step("getDocs (all)") {
-                let docs = try await s.getDocs()
-                self.appendLog("    fetched \(docs.count) docs")
-            }
-
             try await step("deleteDocs(['ml5'])") {
                 let deleted = try await s.deleteDocs(["ml5"])
                 self.appendLog("    deleted=\(deleted) docCount=\(s.docCount)")
             }
 
-            // Persistence round-trip: write the session to disk, close the
-            // handle, open a fresh session for the same name, and verify the
-            // docs survived.
-            let cache = NSTemporaryDirectory()
-            try await step("save(toCachePath:)") {
-                try await s.save(toCachePath: cache)
-                self.appendLog("    saved to disk")
+            // ── Push it to the cloud ──────────────────────────────────────
+            var jobId = ""
+            try await step("pushIndex (local → cloud)") {
+                let r = try await s.pushIndex()
+                jobId = r.jobId
+                pushedName = r.indexName
+                self.appendLog("    job=\(r.jobId)  index=\(r.indexName)  status=\(r.status)")
             }
+
+            try await step("poll getJobStatus until ready") {
+                let done: Set<String> = ["ready", "completed", "done", "succeeded"]
+                let failed: Set<String> = ["failed", "error"]
+                for attempt in 1...30 {
+                    let st = try await c.getJobStatus(jobId)
+                    self.appendLog("    [\(attempt)] status=\(st.status)")
+                    if done.contains(st.status.lowercased()) { return }
+                    if failed.contains(st.status.lowercased()) {
+                        throw DemoError(message: "push job failed: \(st.error ?? "unknown")")
+                    }
+                    try await Task.sleep(nanoseconds: 1_000_000_000)
+                }
+                throw DemoError(message: "push job did not finish in time")
+            }
+
+            // ── Tear down the local session, reload it from the cloud ─────
             session?.close()
             session = nil
 
-            try await step("reopen + loadFromDisk → expect 4 docs") {
-                let restored = try await c.session(sessionName)
-                defer { restored.close() }
-                let count = try await restored.loadFromDisk(cachePath: cache)
-                self.appendLog("    restored \(count) docs")
-                let r = try await restored.query("transformers", options: .init(topK: 2))
-                self.appendLog("    re-query returned \(r.docs.count) hits")
+            try await step("loadIndex (cloud → new session) + query") {
+                let loaded = try await c.session(pushedName)
+                defer { loaded.close() }
+                let count = try await loaded.loadIndex(pushedName)
+                self.appendLog("    loaded \(count) docs from cloud")
+                let r = try await loaded.query("how do transformers work", options: .init(topK: 3))
+                self.appendLog("    \(r.docs.count) hits in \(r.timeMs)ms")
+                for (i, d) in r.docs.enumerated() {
+                    self.appendLog(String(format: "      %d. [%.3f] %@", i + 1, d.score, d.id))
+                }
             }
 
-            // Cloud round-trip: push the on-device index to the cloud, wait
-            // for it to process, then pull it back into a fresh session and
-            // query it. The session keeps its on-device model end-to-end, so
-            // the loaded-back index queries locally with no model mismatch.
-            try await runCloudRoundTrip(c)
+            try await step("deleteIndex (cleanup)") {
+                _ = try await c.deleteIndex(pushedName)
+                self.appendLog("    deleted cloud index \(pushedName)")
+            }
         } catch {
             appendLog("✗ failure: \(error.localizedDescription)")
-        }
-    }
-
-    /// Push the local session to the cloud, poll until the push job finishes,
-    /// then load it back into a new session and query it. Deletes the
-    /// throwaway cloud index at the end. Requires network + valid credentials.
-    private func runCloudRoundTrip(_ c: MossClient) async throws {
-        let cloudName = "ios-pushed-\(Int(Date().timeIntervalSince1970 * 1000))"
-
-        // Build a small index and push it up.
-        let pushSession = try await c.session(cloudName)
-        try await step("addDocs (for push)") {
-            let (added, _) = try await pushSession.addDocs([
-                .init(id: "a", text: "Vector databases store embeddings for fast similarity search."),
-                .init(id: "b", text: "Quantization shrinks vectors so more fit in memory."),
-            ])
-            self.appendLog("    added=\(added)")
-        }
-
-        var jobId = ""
-        var pushedName = cloudName
-        try await step("pushIndex (local → cloud)") {
-            let r = try await pushSession.pushIndex()
-            jobId = r.jobId
-            pushedName = r.indexName
-            self.appendLog("    job=\(r.jobId)  index=\(r.indexName)  status=\(r.status)")
-        }
-        pushSession.close()
-
-        try await step("poll getJobStatus until ready") {
-            let done: Set<String> = ["ready", "completed", "done", "succeeded"]
-            let failed: Set<String> = ["failed", "error"]
-            for attempt in 1...30 {
-                let s = try await c.getJobStatus(jobId)
-                self.appendLog("    [\(attempt)] status=\(s.status)")
-                if done.contains(s.status.lowercased()) { return }
-                if failed.contains(s.status.lowercased()) {
-                    throw DemoError(message: "push job failed: \(s.error ?? "unknown")")
-                }
-                try await Task.sleep(nanoseconds: 1_000_000_000)
-            }
-            throw DemoError(message: "push job did not finish in time")
-        }
-
-        // Pull the pushed index back into a new session and query on-device.
-        try await step("loadIndex (cloud → new session) + query") {
-            let loaded = try await c.session(pushedName)
-            defer { loaded.close() }
-            let count = try await loaded.loadIndex(pushedName)
-            self.appendLog("    loaded \(count) docs from cloud")
-            let r = try await loaded.query("how are vectors stored", options: .init(topK: 2))
-            self.appendLog("    \(r.docs.count) hits in \(r.timeMs)ms")
-            for (i, d) in r.docs.enumerated() {
-                self.appendLog(String(format: "      %d. [%.3f] %@", i + 1, d.score, d.id))
-            }
-        }
-
-        try await step("deleteIndex (cleanup)") {
-            _ = try await c.deleteIndex(pushedName)
-            self.appendLog("    deleted cloud index \(pushedName)")
         }
     }
 

--- a/examples/ios/MossExample/MossDemoModel.swift
+++ b/examples/ios/MossExample/MossDemoModel.swift
@@ -4,7 +4,7 @@ import Moss
 /// Drives the demo screen - owns a `MossClient`, a status string, and a
 /// running log of operations. UI binds to the `@Published` fields.
 ///
-/// This sample highlights the push pathway: build an index on-device, push it
+/// This sample uses an on-device session: build an index on-device, push it
 /// to the cloud with `pushIndex`, then load it back into a fresh session.
 @MainActor
 final class MossDemoModel: ObservableObject {
@@ -32,10 +32,10 @@ final class MossDemoModel: ObservableObject {
         }
     }
 
-    // ── Push pathway example ─────────────────────────────────────────────────
+    // ── On-device session example ────────────────────────────────────────────
 
-    /// Highlights the push pathway end-to-end: open an on-device session, embed
-    /// docs locally and query them, then `pushIndex` the session up to the
+    /// Walks an on-device session end-to-end: open a session, embed docs
+    /// locally and query them, then `pushIndex` the session up to the
     /// cloud as a server-side index, poll until it's processed, and pull it
     /// back into a fresh session with `loadIndex`, where it queries locally.
     /// Requires network + valid credentials.

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -91,6 +91,13 @@ exercised end-to-end with timing.
 - [XcodeGen](https://github.com/yonaskolb/XcodeGen) to generate the project:
   `brew install xcodegen`
 
+## Get your credentials
+
+Sign up at [moss.dev](https://moss.dev) for a `project_id` and `project_key`
+(free tier available) - the same credentials used throughout the
+[main Quickstart](https://github.com/usemoss/moss#quickstart). Enter them on
+the app's first launch.
+
 ## The SDK dependency
 
 The app depends on the published Moss Swift package - no local SDK checkout
@@ -145,9 +152,9 @@ To target a specific simulator instead, pass e.g.
 
 ## Using it
 
-1. **First launch** shows a credentials screen. Enter your Moss project ID
-   and key from the [Moss dashboard](https://portal.usemoss.dev) - they're
-   required to authenticate the client.
+1. **First launch** shows a credentials screen. Enter the `project_id` and
+   `project_key` from [moss.dev](https://moss.dev) (see
+   [Get your credentials](#get-your-credentials)) - they authenticate the client.
 2. Tap **Run Session Demo** to walk the full push pathway - build on-device,
    push to the cloud, then load back. The log shows each step and its timing.
 
@@ -159,7 +166,7 @@ To target a specific simulator instead, pass e.g.
 | [`ContentView.swift`](MossExample/ContentView.swift) | SwiftUI wiring - credentials screen and the demo button. |
 | [`MossExampleApp.swift`](MossExample/MossExampleApp.swift) | App entry point. |
 
-## Credentials
+## Credentials in production
 
 To keep the sample short, it stores the project key in `@AppStorage`. For a
 production app, use the `Authenticator` protocol instead: your app fetches a

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -1,19 +1,18 @@
 # Moss iOS Example
 
 A SwiftUI app that demonstrates the [Moss Swift SDK](https://github.com/usemoss/moss)
-- fast, on-device semantic search for iOS.
+for iOS, highlighting the **push pathway**: build an index on-device, push it
+to the cloud, and load it back into a fresh session.
 
-Documents are embedded and searched **on the device** - no network calls for
-the core flow. The app walks a session end-to-end, with per-step timing:
+The app walks the flow end-to-end, with per-step timing:
 
-`session` → `addDocs` (embedded locally) → `query` → `getDocs` →
-`deleteDocs` → `save` → reopen → `loadFromDisk`
+`session` → `addDocs` (embedded on-device) → `query` → `deleteDocs` →
+`pushIndex` (local → cloud) → poll `getJobStatus` until ready →
+`loadIndex` (cloud → a new session) → query
 
-It then demonstrates the **cloud round-trip**: `pushIndex` (local → cloud) →
-poll `getJobStatus` until ready → `loadIndex` (cloud → a new session) → query.
-Because the session keeps its on-device model throughout, the loaded-back
-index queries locally with no model mismatch. This part needs network access
-and valid credentials.
+Documents are embedded on-device, so the index keeps its on-device model
+across the round-trip and the loaded-back index queries locally with no model
+mismatch. The push/load steps need network access and valid credentials.
 
 ## Architecture
 
@@ -33,28 +32,23 @@ flowchart TB
 
     model -->|connect| client
 
-    subgraph device["On device"]
-        embed["Embed text locally<br/>(moss model)"]
-        disk[("Disk")]
-    end
-
+    embed["Embed text on-device<br/>(moss model)"]
     cloud[("Moss Cloud<br/>server-side index")]
 
     session -->|"addDocs / query"| embed
-    session <-->|"save / loadFromDisk"| disk
     session -->|"pushIndex"| cloud
     cloud -->|"loadIndex"| session
     client -.->|"getJobStatus (poll)"| cloud
 ```
 
-The core session flow (left/bottom) runs entirely on-device. The cloud
-round-trip (`pushIndex` / `loadIndex`) is the only part that touches the
-network.
+Documents are embedded on-device; `pushIndex` uploads the index to the cloud
+and `loadIndex` pulls it back into a session - the push pathway this sample
+highlights.
 
 ## Quick start
 
-The whole API is `async`/`throws`. Construct a client, open a session, then
-add and query documents - all on-device:
+The whole API is `async`/`throws`. Build an index on-device, push it to the
+cloud, then load it back into a fresh session:
 
 ```swift
 import Moss
@@ -62,19 +56,27 @@ import Moss
 let client = try MossClient(projectId: "your_project_id", projectKey: "your_project_key")
 defer { client.close() }
 
+// 1. Build an index on-device.
 let session = try await client.session("notes")
-defer { session.close() }
-
 try await session.addDocs([
     .init(id: "1", text: "Transformers replaced RNNs for sequence modeling."),
     .init(id: "2", text: "Embeddings map text into vectors for similarity search."),
 ])
 
-let hits = try await session.query("how do transformers work", options: .init(topK: 3))
-hits.docs.forEach { print($0.score, $0.id) }
+// 2. Push it to the cloud and wait for the job to finish.
+let push = try await session.pushIndex()
+session.close()
+while try await client.getJobStatus(push.jobId).status != "ready" {
+    try await Task.sleep(nanoseconds: 1_000_000_000)
+}
 
-// Persist so the next launch skips re-embedding.
-try await session.save(toCachePath: NSTemporaryDirectory())
+// 3. Load it back into a new session and query - still on-device.
+let restored = try await client.session(push.indexName)
+defer { restored.close() }
+_ = try await restored.loadIndex(push.indexName)
+
+let hits = try await restored.query("how do transformers work", options: .init(topK: 3))
+hits.docs.forEach { print($0.score, $0.id) }
 ```
 
 See [`MossDemoModel.swift`](MossExample/MossDemoModel.swift) for every call
@@ -146,8 +148,8 @@ To target a specific simulator instead, pass e.g.
 1. **First launch** shows a credentials screen. Enter your Moss project ID
    and key from the [Moss dashboard](https://portal.usemoss.dev) - they're
    required to authenticate the client.
-2. Tap **Run Session Demo** to walk the full flow - the on-device session
-   followed by the cloud round-trip. The log shows each step and its timing.
+2. Tap **Run Session Demo** to walk the full push pathway - build on-device,
+   push to the cloud, then load back. The log shows each step and its timing.
 
 ## Code tour
 

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -10,9 +10,8 @@ The app walks the flow end-to-end, with per-step timing:
 `pushIndex` (local → cloud) → poll `getJobStatus` until ready →
 `loadIndex` (cloud → a new session) → query
 
-Documents are embedded on-device, so the index keeps its on-device model
-across the round-trip and the loaded-back index queries locally with no model
-mismatch. The push/load steps need network access and valid credentials.
+Documents are embedded on-device, and the loaded-back index queries locally.
+The push/load steps need network access and valid credentials.
 
 ## Architecture
 

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -31,17 +31,23 @@ flowchart TB
 
     model -->|connect| client
 
-    embed["Embed text on-device<br/>(moss model)"]
+    subgraph device["On device"]
+        embed["Embed text locally<br/>(moss model)"]
+        disk[("Disk")]
+    end
+
     cloud[("Moss Cloud<br/>server-side index")]
 
     session -->|"addDocs / query"| embed
+    session <-->|"save / loadFromDisk"| disk
     session -->|"pushIndex"| cloud
     cloud -->|"loadIndex"| session
     client -.->|"getJobStatus (poll)"| cloud
 ```
 
-Documents are embedded on-device; `pushIndex` uploads the index to the cloud
-and `loadIndex` pulls it back into a session.
+The core session flow (left/bottom) runs entirely on-device. The cloud
+round-trip (`pushIndex` / `loadIndex`) is the only part that touches the
+network.
 
 ## Quick start
 

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -1,8 +1,8 @@
 # Moss iOS Example
 
 A SwiftUI app that demonstrates the [Moss Swift SDK](https://github.com/usemoss/moss)
-for iOS, highlighting the **push pathway**: build an index on-device, push it
-to the cloud, and load it back into a fresh session.
+for iOS with an **on-device session**: build an index on-device, push it to
+the cloud, and load it back into a fresh session.
 
 The app walks the flow end-to-end, with per-step timing:
 
@@ -41,8 +41,7 @@ flowchart TB
 ```
 
 Documents are embedded on-device; `pushIndex` uploads the index to the cloud
-and `loadIndex` pulls it back into a session - the push pathway this sample
-highlights.
+and `loadIndex` pulls it back into a session.
 
 ## Quick start
 
@@ -170,8 +169,8 @@ To target a specific simulator instead, pass e.g.
 1. **First launch** shows a credentials screen. Enter the `project_id` and
    `project_key` from [moss.dev](https://moss.dev) (see
    [Get your credentials](#get-your-credentials)) - they authenticate the client.
-2. Tap **Run Session Demo** to walk the full push pathway - build on-device,
-   push to the cloud, then load back. The log shows each step and its timing.
+2. Tap **Run Session Demo** to walk the full flow - build on-device, push to
+   the cloud, then load back. The log shows each step and its timing.
 
 ## Code tour
 

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -82,6 +82,23 @@ hits.docs.forEach { print($0.score, $0.id) }
 See [`MossDemoModel.swift`](MossExample/MossDemoModel.swift) for every call
 exercised end-to-end with timing.
 
+### Local persistence (no cloud)
+
+If you don't need the cloud, a session can persist to disk and reopen on the
+next launch - fully offline, no network:
+
+```swift
+let session = try await client.session("notes")
+try await session.addDocs([ /* ... */ ])
+try await session.save(toCachePath: NSTemporaryDirectory())
+session.close()
+
+// Later, or on the next launch:
+let restored = try await client.session("notes")
+try await restored.loadFromDisk(cachePath: NSTemporaryDirectory())
+let hits = try await restored.query("how do transformers work", options: .init(topK: 3))
+```
+
 ## Requirements
 
 - iOS 15.1+

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -94,9 +94,8 @@ exercised end-to-end with timing.
 ## Get your credentials
 
 Sign up at [moss.dev](https://moss.dev) for a `project_id` and `project_key`
-(free tier available) - the same credentials used throughout the
-[main Quickstart](https://github.com/usemoss/moss#quickstart). Enter them on
-the app's first launch.
+(free tier available), then enter them on the app's first launch. See the
+[main Quickstart](https://github.com/usemoss/moss#quickstart) for more.
 
 ## The SDK dependency
 


### PR DESCRIPTION
This pull request updates the iOS example app and its documentation to focus on the "push pathway"—building an index on-device, pushing it to the cloud, and loading it back into a new session. The sample code and README have been revised to remove the previous on-device persistence flow and to clearly highlight the push/load workflow, including updated code comments, flow diagrams, and usage instructions.

**Sample code changes (MossDemoModel.swift):**

- Refactored the demo flow to highlight the push pathway: build an index on-device, push it to the cloud with `pushIndex`, poll for completion, and load it back into a fresh session with `loadIndex`. The previous on-device disk persistence example was removed.
- Updated code comments and log messages to describe the push pathway and clarify each step in the flow.
- Removed the separate cloud round-trip helper function and integrated the push/load steps directly into the main session example.
- Improved error handling for the session example.

**Documentation changes (README.md):**

- Updated the introduction and flow description to focus on the push pathway (on-device → cloud → on-device), removing references to the old on-device-only flow.
- Revised the architecture diagram and explanation to match the new workflow, removing the disk persistence step and emphasizing cloud push/load.
- Updated the code sample in the Quick Start section to demonstrate the push pathway, including pushing to the cloud and loading back into a new session.
- Added a new "Get your credentials" section with instructions for obtaining credentials from moss.dev.
- Updated usage instructions and clarified the credentials flow for first-time users.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usemoss/moss/pull/269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->