### PR TITLE
fix(spm): point Package.swift at v0.4.0 xcframework + checksum

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@
 // To consume from another package or app:
 //
 //     dependencies: [
-//         .package(url: "https://github.com/usemoss/moss", from: "0.3.0"),
+//         .package(url: "https://github.com/usemoss/moss", from: "0.4.0"),
 //     ],
 //     targets: [
 //         .target(name: "YourTarget", dependencies: [
@@ -35,8 +35,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "MossC",
-            url: "https://github.com/usemoss/moss/releases/download/v0.3.0/Moss.xcframework.zip",
-            checksum: "be385a25f0a8bdcae5b2a1f415b9c01a50d2b8b83187cb32640e23bba1e0cea7"
+            url: "https://github.com/usemoss/moss/releases/download/v0.4.0/Moss.xcframework.zip",
+            checksum: "49a9c47198ffd75f50b3a91aaa7f416091ebe893a79e1517631a90ecff4b340c"
         ),
         .target(
             name: "Moss",


### PR DESCRIPTION
This points the `binaryTarget` at the v0.4.0 asset + its SHA-256 (`49a9c471…340c`) and bumps the usage example to `from: "0.4.0"`.

The `v0.4.0` **tag has already been re-pointed** to this commit so the published release resolves correctly; this PR brings `main` in line so future releases start from the correct manifest.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usemoss/moss/pull/273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->