### PR TITLE
fix(swift): sync MossSession to the shipped C ABI (4-arg load_index)

### DIFF
--- a/sdks/swift/Sources/Moss/MossSession.swift
+++ b/sdks/swift/Sources/Moss/MossSession.swift
@@ -234,20 +234,40 @@ public final class MossSession: @unchecked Sendable {
 
     // ── Persistence ──────────────────────────────────────────────────
 
-    /// Pull a server-side index into this session as a one-time
-    /// hydration. Returns the doc count loaded (0 if the cloud has no
-    /// index by that name). The session subsequently behaves as a
-    /// local one — add/delete/query don't hit the network.
+    /// Pull a server-side index into this session. Returns the doc count
+    /// loaded (0 if the cloud has no index by that name).
+    ///
+    /// By default this is a one-time hydration: the session then behaves as a
+    /// local one — add/delete/query don't hit the network. Pass
+    /// `options.autoRefresh = true` to keep it in sync: a background task
+    /// polls the cloud index every `options.pollingIntervalSeconds` and pulls
+    /// newer versions in on the next `query`/`getDocs`/`docCount`. Auto-refresh
+    /// pauses while the session has un-pushed local edits (`addDocs`/`deleteDocs`
+    /// before a `pushIndex`), so it never clobbers local work.
+    ///
+    /// `options.cachePath` is ignored for sessions — use `save(toCachePath:)`
+    /// for on-disk persistence.
     @discardableResult
-    public func loadIndex(_ indexName: String) async throws -> Int {
-        try await Task.detached { [self] () throws -> Int in
+    public func loadIndex(
+        _ indexName: String,
+        options: LoadIndexOptions = LoadIndexOptions()
+    ) async throws -> Int {
+        let opts = options
+        return try await Task.detached { [self] () throws -> Int in
             let h = try borrowHandle()
             defer { returnHandle() }
             return try indexName.withCString { cname in
-                var docCount: UInt = 0
-                let r = moss_session_load_index(h, cname, &docCount)
-                try MossClient.throwIfErr(r)
-                return Int(docCount)
+                try withOptionalCString(opts.cachePath) { cachePath in
+                    var nativeOpts = MossLoadIndexOptions(
+                        auto_refresh: opts.autoRefresh,
+                        polling_interval_secs: opts.pollingIntervalSeconds,
+                        cache_path: cachePath
+                    )
+                    var docCount: UInt = 0
+                    let r = moss_session_load_index(h, cname, &nativeOpts, &docCount)
+                    try MossClient.throwIfErr(r)
+                    return Int(docCount)
+                }
             }
         }.value
     }

--- a/sdks/swift/Sources/Moss/MossSession.swift
+++ b/sdks/swift/Sources/Moss/MossSession.swift
@@ -257,17 +257,18 @@ public final class MossSession: @unchecked Sendable {
             let h = try borrowHandle()
             defer { returnHandle() }
             return try indexName.withCString { cname in
-                try withOptionalCString(opts.cachePath) { cachePath in
-                    var nativeOpts = MossLoadIndexOptions(
-                        auto_refresh: opts.autoRefresh,
-                        polling_interval_secs: opts.pollingIntervalSeconds,
-                        cache_path: cachePath
-                    )
-                    var docCount: UInt = 0
-                    let r = moss_session_load_index(h, cname, &nativeOpts, &docCount)
-                    try MossClient.throwIfErr(r)
-                    return Int(docCount)
-                }
+                // `cachePath` is intentionally not forwarded: the native session
+                // load ignores it (sessions persist via `save(toCachePath:)`),
+                // so passing it would only mislead callers.
+                var nativeOpts = MossLoadIndexOptions(
+                    auto_refresh: opts.autoRefresh,
+                    polling_interval_secs: opts.pollingIntervalSeconds,
+                    cache_path: nil
+                )
+                var docCount: UInt = 0
+                let r = moss_session_load_index(h, cname, &nativeOpts, &docCount)
+                try MossClient.throwIfErr(r)
+                return Int(docCount)
             }
         }.value
     }

--- a/sdks/swift/Sources/Moss/MossSession.swift
+++ b/sdks/swift/Sources/Moss/MossSession.swift
@@ -245,8 +245,9 @@ public final class MossSession: @unchecked Sendable {
     /// pauses while the session has un-pushed local edits (`addDocs`/`deleteDocs`
     /// before a `pushIndex`), so it never clobbers local work.
     ///
-    /// `options.cachePath` is ignored for sessions — use `save(toCachePath:)`
-    /// for on-disk persistence.
+    /// For on-disk persistence of a session, use `save(toCachePath:)` /
+    /// `loadFromDisk(cachePath:)`. `options.cachePath` applies to
+    /// `MossClient.loadIndex`, not to sessions, so it is not forwarded here.
     @discardableResult
     public func loadIndex(
         _ indexName: String,

--- a/sdks/swift/Sources/Moss/MossTypes.swift
+++ b/sdks/swift/Sources/Moss/MossTypes.swift
@@ -130,14 +130,20 @@ public struct SessionOptions: Sendable {
 }
 
 public struct LoadIndexOptions: Sendable {
+    /// Keep the loaded index in sync by polling the cloud in the background.
     public var autoRefresh: Bool
+    /// How often the auto-refresh poll runs, in seconds (only used when
+    /// `autoRefresh` is true). Defaults to 600 (10 minutes); the engine clamps
+    /// values below 1 to 1, so leave it at the default rather than passing 0.
     public var pollingIntervalSeconds: UInt64
     /// Optional sandbox path used to cache the index on disk so subsequent
-    /// launches don't re-download. Pass `FileManager.default.urls(for:
-    /// .documentDirectory, in: .userDomainMask).first!.path` or similar.
+    /// launches don't re-download. Applies to `MossClient.loadIndex`; sessions
+    /// persist via `MossSession.save(toCachePath:)` instead. Pass
+    /// `FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.path`
+    /// or similar.
     public var cachePath: String?
 
-    public init(autoRefresh: Bool = false, pollingIntervalSeconds: UInt64 = 0, cachePath: String? = nil) {
+    public init(autoRefresh: Bool = false, pollingIntervalSeconds: UInt64 = 600, cachePath: String? = nil) {
         self.autoRefresh = autoRefresh
         self.pollingIntervalSeconds = pollingIntervalSeconds
         self.cachePath = cachePath


### PR DESCRIPTION
main's `MossSession.swift` still calls the old 3-arg `moss_session_load_index(h, name, &docCount)`, but the released xcframework exports `moss_session_load_index(session, name, const MossLoadIndexOptions *opts, out)`. Consuming the package fails to compile (`Cannot convert UnsafePointer<UInt> to UnsafePointer<MossLoadIndexOptions>` / missing arg `#4`).

This syncs `MossSession.swift` from the canonical `moss-sdks-internal/bindings/ios` source (4-arg `load_index` + `LoadIndexOptions`, `save(toCachePath:)`, `loadFromDisk`). The other four wrapper files already matched. The `v0.4.0` tag was already re-pointed to this wrapper so the published release compiles; this brings `main` in line.

Process note: the iOS binary is built from `moss-sdks-internal` but the Swift wrapper lives here - releases must sync `sdks/swift/Sources/Moss` from `bindings/ios/Sources/Moss`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usemoss/moss/pull/274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->