### PR TITLE
release: Moss iOS SDK v0.4.1 (sync Swift wrapper + Package.swift)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "MossC",
-            url: "https://github.com/usemoss/moss/releases/download/v0.4.0/Moss.xcframework.zip",
+            url: "https://github.com/usemoss/moss/releases/download/v0.4.1/Moss.xcframework.zip",
             checksum: "49a9c47198ffd75f50b3a91aaa7f416091ebe893a79e1517631a90ecff4b340c"
         ),
         .target(

--- a/sdks/swift/Sources/Moss/MossSession.swift
+++ b/sdks/swift/Sources/Moss/MossSession.swift
@@ -234,20 +234,40 @@ public final class MossSession: @unchecked Sendable {
 
     // ── Persistence ──────────────────────────────────────────────────
 
-    /// Pull a server-side index into this session as a one-time
-    /// hydration. Returns the doc count loaded (0 if the cloud has no
-    /// index by that name). The session subsequently behaves as a
-    /// local one — add/delete/query don't hit the network.
+    /// Pull a server-side index into this session. Returns the doc count
+    /// loaded (0 if the cloud has no index by that name).
+    ///
+    /// By default this is a one-time hydration: the session then behaves as a
+    /// local one — add/delete/query don't hit the network. Pass
+    /// `options.autoRefresh = true` to keep it in sync: a background task
+    /// polls the cloud index every `options.pollingIntervalSeconds` and pulls
+    /// newer versions in on the next `query`/`getDocs`/`docCount`. Auto-refresh
+    /// pauses while the session has un-pushed local edits (`addDocs`/`deleteDocs`
+    /// before a `pushIndex`), so it never clobbers local work.
+    ///
+    /// `options.cachePath` is ignored for sessions — use `save(toCachePath:)`
+    /// for on-disk persistence.
     @discardableResult
-    public func loadIndex(_ indexName: String) async throws -> Int {
-        try await Task.detached { [self] () throws -> Int in
+    public func loadIndex(
+        _ indexName: String,
+        options: LoadIndexOptions = LoadIndexOptions()
+    ) async throws -> Int {
+        let opts = options
+        return try await Task.detached { [self] () throws -> Int in
             let h = try borrowHandle()
             defer { returnHandle() }
             return try indexName.withCString { cname in
-                var docCount: UInt = 0
-                let r = moss_session_load_index(h, cname, &docCount)
-                try MossClient.throwIfErr(r)
-                return Int(docCount)
+                try withOptionalCString(opts.cachePath) { cachePath in
+                    var nativeOpts = MossLoadIndexOptions(
+                        auto_refresh: opts.autoRefresh,
+                        polling_interval_secs: opts.pollingIntervalSeconds,
+                        cache_path: cachePath
+                    )
+                    var docCount: UInt = 0
+                    let r = moss_session_load_index(h, cname, &nativeOpts, &docCount)
+                    try MossClient.throwIfErr(r)
+                    return Int(docCount)
+                }
             }
         }.value
     }

--- a/sdks/swift/Sources/Moss/MossSession.swift
+++ b/sdks/swift/Sources/Moss/MossSession.swift
@@ -257,17 +257,18 @@ public final class MossSession: @unchecked Sendable {
             let h = try borrowHandle()
             defer { returnHandle() }
             return try indexName.withCString { cname in
-                try withOptionalCString(opts.cachePath) { cachePath in
-                    var nativeOpts = MossLoadIndexOptions(
-                        auto_refresh: opts.autoRefresh,
-                        polling_interval_secs: opts.pollingIntervalSeconds,
-                        cache_path: cachePath
-                    )
-                    var docCount: UInt = 0
-                    let r = moss_session_load_index(h, cname, &nativeOpts, &docCount)
-                    try MossClient.throwIfErr(r)
-                    return Int(docCount)
-                }
+                // `cachePath` is intentionally not forwarded: the native session
+                // load ignores it (sessions persist via `save(toCachePath:)`),
+                // so passing it would only mislead callers.
+                var nativeOpts = MossLoadIndexOptions(
+                    auto_refresh: opts.autoRefresh,
+                    polling_interval_secs: opts.pollingIntervalSeconds,
+                    cache_path: nil
+                )
+                var docCount: UInt = 0
+                let r = moss_session_load_index(h, cname, &nativeOpts, &docCount)
+                try MossClient.throwIfErr(r)
+                return Int(docCount)
             }
         }.value
     }

--- a/sdks/swift/Sources/Moss/MossSession.swift
+++ b/sdks/swift/Sources/Moss/MossSession.swift
@@ -245,8 +245,9 @@ public final class MossSession: @unchecked Sendable {
     /// pauses while the session has un-pushed local edits (`addDocs`/`deleteDocs`
     /// before a `pushIndex`), so it never clobbers local work.
     ///
-    /// `options.cachePath` is ignored for sessions — use `save(toCachePath:)`
-    /// for on-disk persistence.
+    /// For on-disk persistence of a session, use `save(toCachePath:)` /
+    /// `loadFromDisk(cachePath:)`. `options.cachePath` applies to
+    /// `MossClient.loadIndex`, not to sessions, so it is not forwarded here.
     @discardableResult
     public func loadIndex(
         _ indexName: String,

--- a/sdks/swift/Sources/Moss/MossTypes.swift
+++ b/sdks/swift/Sources/Moss/MossTypes.swift
@@ -130,14 +130,20 @@ public struct SessionOptions: Sendable {
 }
 
 public struct LoadIndexOptions: Sendable {
+    /// Keep the loaded index in sync by polling the cloud in the background.
     public var autoRefresh: Bool
+    /// How often the auto-refresh poll runs, in seconds (only used when
+    /// `autoRefresh` is true). Defaults to 600 (10 minutes); the engine clamps
+    /// values below 1 to 1, so leave it at the default rather than passing 0.
     public var pollingIntervalSeconds: UInt64
     /// Optional sandbox path used to cache the index on disk so subsequent
-    /// launches don't re-download. Pass `FileManager.default.urls(for:
-    /// .documentDirectory, in: .userDomainMask).first!.path` or similar.
+    /// launches don't re-download. Applies to `MossClient.loadIndex`; sessions
+    /// persist via `MossSession.save(toCachePath:)` instead. Pass
+    /// `FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.path`
+    /// or similar.
     public var cachePath: String?
 
-    public init(autoRefresh: Bool = false, pollingIntervalSeconds: UInt64 = 0, cachePath: String? = nil) {
+    public init(autoRefresh: Bool = false, pollingIntervalSeconds: UInt64 = 600, cachePath: String? = nil) {
         self.autoRefresh = autoRefresh
         self.pollingIntervalSeconds = pollingIntervalSeconds
         self.cachePath = cachePath


### PR DESCRIPTION
Brings `main` in line with the published **v0.4.1** tag.

- **Swift wrapper** synced from the canonical `moss-sdks-internal/bindings/ios/Sources/Moss`: 4-arg `moss_session_load_index` (matches the shipped binary's C ABI), `cache_path: nil` on session `loadIndex` (native ignores it), and `pollingIntervalSeconds` default 600.
- **Package.swift** points at the `v0.4.1` xcframework asset (checksum `49a9c47…`, same binary as v0.4.0).

Background: `v0.4.0` was force-moved twice, which SwiftPM caches as a pin mismatch (`version 0.4.0 does not match previously recorded value …`). v0.4.1 is a clean, never-moved re-release.

Supersedes #274 (wrapper-only). Recommend closing #274 in favor of this.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usemoss/moss/pull/275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->