### PR TITLE
examples(ios): cached backend-token auth + local token server

### DIFF
--- a/examples/ios/MossExample/BackendTokenAuthenticator.swift
+++ b/examples/ios/MossExample/BackendTokenAuthenticator.swift
@@ -54,19 +54,16 @@ final class BackendTokenAuthenticator: Authenticator {
     }
 
     func getAuthHeader() async throws -> String {
-        // 1. On-device check — return the cached token with no network call
-        //    as long as it's still valid.
-        if let cached = await store.valid() {
-            return cached
+        // Returns the cached token while it's still valid (a local clock check,
+        // no network). On a miss, fetches once — concurrent callers are
+        // coalesced onto a single refresh inside TokenStore, so a cold start or
+        // an expiry boundary triggers one backend round-trip, not one per call.
+        //
+        // Returns the RAW token only — the SDK prepends "Bearer " itself.
+        try await store.token {
+            let fetched = try await self.fetchToken()
+            return (fetched.token, fetched.expiresIn)
         }
-
-        // 2. Missing or expired — fetch a fresh token from your backend and
-        //    cache it (with the 60s safety buffer applied in TokenStore.set).
-        let fetched = try await fetchToken()
-        await store.set(fetched.token, expiresIn: fetched.expiresIn)
-
-        // Return the RAW token only — the SDK prepends "Bearer " itself.
-        return fetched.token
     }
 
     // ── Backend call ─────────────────────────────────────────────────────────
@@ -79,6 +76,9 @@ final class BackendTokenAuthenticator: Authenticator {
     private func fetchToken() async throws -> TokenResponse {
         var request = URLRequest(url: tokenURL)
         request.httpMethod = "GET"
+        // Always hit the backend — never serve the token from URLSession's
+        // cache, so an expired token can't be replayed from a stale response.
+        request.cachePolicy = .reloadIgnoringLocalCacheData
 
         // Authenticate *this* request with your own user credential so your
         // backend knows who's asking before it hands out a Moss token, e.g.:
@@ -100,21 +100,37 @@ final class BackendTokenAuthenticator: Authenticator {
 
 /// Thread-safe token cache. An `actor` because the SDK may invoke
 /// `getAuthHeader()` from a background worker thread.
+///
+/// Callers that arrive while a refresh is already running are coalesced onto
+/// that single in-flight fetch, so a cold start (or the instant after expiry)
+/// triggers exactly one backend round-trip rather than one per request.
 actor TokenStore {
     private var token: String?
     private var expiresAt: Date = .distantPast
+    private var refresh: Task<(token: String, expiresIn: TimeInterval), Error>?
 
-    /// Returns the cached token if it's still valid, otherwise `nil`.
-    func valid() -> String? {
-        guard let token, expiresAt > Date() else { return nil }
-        return token
-    }
-
-    /// Caches a token, expiring it 60s early to match the SDK's internal
+    /// Returns a valid cached token, or runs `fetch` exactly once and caches
+    /// the result. Expires the token 60s early to match the SDK's internal
     /// safety margin (avoids a token lapsing mid-request under clock skew).
-    func set(_ token: String, expiresIn: TimeInterval) {
-        self.token = token
-        self.expiresAt = Date().addingTimeInterval(max(0, expiresIn - 60))
+    func token(
+        orFetch fetch: @Sendable @escaping () async throws -> (token: String, expiresIn: TimeInterval)
+    ) async throws -> String {
+        if let token, expiresAt > Date() {
+            return token
+        }
+        // A refresh is already in flight — await it instead of starting another.
+        if let refresh {
+            return try await refresh.value.token
+        }
+
+        let task = Task { try await fetch() }
+        refresh = task
+        defer { refresh = nil }
+
+        let fetched = try await task.value
+        token = fetched.token
+        expiresAt = Date().addingTimeInterval(max(0, fetched.expiresIn - 60))
+        return fetched.token
     }
 }
 

--- a/examples/ios/MossExample/BackendTokenAuthenticator.swift
+++ b/examples/ios/MossExample/BackendTokenAuthenticator.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Moss
+
+/// Production-ready `Authenticator` that keeps your long-lived `projectKey` on
+/// your own backend and lets the app authenticate with short-lived tokens.
+///
+/// ## Why cache on-device?
+///
+/// The SDK calls `getAuthHeader()` on **every** outbound request and does not
+/// cache delegated tokens for you (unlike the static-key path, where the SDK
+/// caches internally). If `getAuthHeader()` called your backend every time,
+/// you'd pay a network round-trip per `query` / `loadIndex`.
+///
+/// So this implementation caches the token on-device and only calls your
+/// backend when the cached token is missing or about to expire. The expiry
+/// check is a local clock comparison — no network — so steady-state queries
+/// never touch your server.
+///
+/// ## Backend contract
+///
+/// Your token endpoint should return JSON in the same shape Moss's own token
+/// endpoint uses:
+///
+/// ```json
+/// { "token": "eyJhbGciOi...", "expiresIn": 3600 }
+/// ```
+///
+/// `expiresIn` is the token's lifetime in seconds. We refresh 60 seconds early
+/// (the same safety margin the SDK uses internally) so a token can't expire
+/// while a request is in flight.
+///
+/// ## Usage
+///
+/// ```swift
+/// let auth = BackendTokenAuthenticator(
+///     tokenURL: URL(string: "https://api.yourapp.com/moss-token")!
+/// )
+/// let client = try MossClient(projectId: "your_project_id", authenticator: auth)
+/// ```
+///
+/// Only `let` stored properties (all `Sendable`) live on the class; the mutable
+/// cache is isolated in the `TokenStore` actor, so the type is safely
+/// `Sendable` as the `Authenticator` protocol requires.
+final class BackendTokenAuthenticator: Authenticator {
+
+    /// Your backend endpoint that vends a short-lived Moss token.
+    private let tokenURL: URL
+    private let session: URLSession
+    private let store = TokenStore()
+
+    init(tokenURL: URL, session: URLSession = .shared) {
+        self.tokenURL = tokenURL
+        self.session = session
+    }
+
+    func getAuthHeader() async throws -> String {
+        // 1. On-device check — return the cached token with no network call
+        //    as long as it's still valid.
+        if let cached = await store.valid() {
+            return cached
+        }
+
+        // 2. Missing or expired — fetch a fresh token from your backend and
+        //    cache it (with the 60s safety buffer applied in TokenStore.set).
+        let fetched = try await fetchToken()
+        await store.set(fetched.token, expiresIn: fetched.expiresIn)
+
+        // Return the RAW token only — the SDK prepends "Bearer " itself.
+        return fetched.token
+    }
+
+    // ── Backend call ─────────────────────────────────────────────────────────
+
+    private struct TokenResponse: Decodable {
+        let token: String
+        let expiresIn: TimeInterval // seconds
+    }
+
+    private func fetchToken() async throws -> TokenResponse {
+        var request = URLRequest(url: tokenURL)
+        request.httpMethod = "GET"
+
+        // Authenticate *this* request with your own user credential so your
+        // backend knows who's asking before it hands out a Moss token, e.g.:
+        //
+        //   request.setValue("Bearer \(myUserSessionToken)",
+        //                    forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw AuthError(message: "Token endpoint returned a non-HTTP response")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw AuthError(message: "Token endpoint failed (HTTP \(http.statusCode)): \(body)")
+        }
+        return try JSONDecoder().decode(TokenResponse.self, from: data)
+    }
+}
+
+/// Thread-safe token cache. An `actor` because the SDK may invoke
+/// `getAuthHeader()` from a background worker thread.
+actor TokenStore {
+    private var token: String?
+    private var expiresAt: Date = .distantPast
+
+    /// Returns the cached token if it's still valid, otherwise `nil`.
+    func valid() -> String? {
+        guard let token, expiresAt > Date() else { return nil }
+        return token
+    }
+
+    /// Caches a token, expiring it 60s early to match the SDK's internal
+    /// safety margin (avoids a token lapsing mid-request under clock skew).
+    func set(_ token: String, expiresIn: TimeInterval) {
+        self.token = token
+        self.expiresAt = Date().addingTimeInterval(max(0, expiresIn - 60))
+    }
+}
+
+/// Error raised when the token endpoint can't be reached or returns a failure.
+private struct AuthError: LocalizedError {
+    let message: String
+    var errorDescription: String? { message }
+}

--- a/examples/ios/MossExample/ContentView.swift
+++ b/examples/ios/MossExample/ContentView.swift
@@ -9,18 +9,30 @@ import SwiftUI
 struct ContentView: View {
     @AppStorage("project_id") private var projectId: String = ""
     @AppStorage("project_key") private var projectKey: String = ""
+    // Optional: a backend token endpoint. When set, the app authenticates via
+    // `BackendTokenAuthenticator` (short-lived, cached tokens) instead of the
+    // static project key — the production pattern. See the README.
+    @AppStorage("token_url") private var tokenURL: String = ""
+
+    /// Ready once we have a project ID plus *some* credential — either the
+    /// static project key or a backend token endpoint URL.
+    private var hasCredentials: Bool {
+        !projectId.isEmpty && (!projectKey.isEmpty || !tokenURL.isEmpty)
+    }
 
     var body: some View {
         Group {
-            if projectId.isEmpty || projectKey.isEmpty {
-                CredentialsView(projectId: $projectId, projectKey: $projectKey)
+            if !hasCredentials {
+                CredentialsView(projectId: $projectId, projectKey: $projectKey, tokenURL: $tokenURL)
             } else {
                 MainView(
                     projectId: projectId,
                     projectKey: projectKey,
+                    tokenURL: tokenURL,
                     onReset: {
                         projectId = ""
                         projectKey = ""
+                        tokenURL = ""
                     }
                 )
             }
@@ -33,9 +45,11 @@ struct ContentView: View {
 struct CredentialsView: View {
     @Binding var projectId: String
     @Binding var projectKey: String
+    @Binding var tokenURL: String
 
     @State private var draftId: String = ""
     @State private var draftKey: String = ""
+    @State private var draftTokenURL: String = ""
     @State private var error: String?
 
     var body: some View {
@@ -63,6 +77,16 @@ struct CredentialsView: View {
                 Text("Project Key").font(.caption).padding(.top, 8)
                 SecureField("moss_…", text: $draftKey)
                     .textFieldStyle(.roundedBorder)
+
+                Text("Token endpoint URL (optional)").font(.caption).padding(.top, 8)
+                TextField("http://localhost:3456/moss-token", text: $draftTokenURL)
+                    .textFieldStyle(.roundedBorder)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                    .keyboardType(.URL)
+                Text("Set this to authenticate via your backend (BackendTokenAuthenticator). Leave it blank to use the static project key.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
             }
             .padding(.horizontal)
 
@@ -73,12 +97,18 @@ struct CredentialsView: View {
             Button("Continue") {
                 let id = draftId.trimmingCharacters(in: .whitespaces)
                 let key = draftKey.trimmingCharacters(in: .whitespaces)
-                if id.isEmpty || key.isEmpty {
-                    error = "Both fields are required."
+                let url = draftTokenURL.trimmingCharacters(in: .whitespaces)
+                if id.isEmpty {
+                    error = "Project ID is required."
+                    return
+                }
+                if key.isEmpty && url.isEmpty {
+                    error = "Enter a project key or a token endpoint URL."
                     return
                 }
                 projectId = id
                 projectKey = key
+                tokenURL = url
             }
             .buttonStyle(.borderedProminent)
             .padding(.top)
@@ -94,6 +124,7 @@ struct CredentialsView: View {
 struct MainView: View {
     let projectId: String
     let projectKey: String
+    let tokenURL: String
     let onReset: () -> Void
 
     @StateObject private var demo = MossDemoModel()
@@ -145,7 +176,7 @@ struct MainView: View {
         }
         .padding()
         .task {
-            await demo.connect(projectId: projectId, projectKey: projectKey)
+            await demo.connect(projectId: projectId, projectKey: projectKey, tokenURL: tokenURL)
         }
     }
 }

--- a/examples/ios/MossExample/Info.plist
+++ b/examples/ios/MossExample/Info.plist
@@ -22,6 +22,11 @@
 	<string>1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UIRequiresFullScreen</key>

--- a/examples/ios/MossExample/MossDemoModel.swift
+++ b/examples/ios/MossExample/MossDemoModel.swift
@@ -16,14 +16,28 @@ final class MossDemoModel: ObservableObject {
 
     // ── Lifecycle ──────────────────────────────────────────────────────────
 
-    /// Construct the `MossClient` with the project credentials, which
-    /// authenticate the client before any session is opened.
-    func connect(projectId: String, projectKey: String) async {
+    /// Construct the `MossClient`, which authenticates before any session is
+    /// opened. If `tokenURL` is set, the client authenticates through
+    /// `BackendTokenAuthenticator` (short-lived tokens fetched from your
+    /// backend and cached on-device); otherwise it uses the static project key.
+    func connect(projectId: String, projectKey: String, tokenURL: String = "") async {
         appendLog("Constructing MossClient (sdk \(MossClient.sdkVersion))…")
         busy = true
         defer { busy = false }
         do {
-            client = try MossClient(projectId: projectId, projectKey: projectKey)
+            if !tokenURL.isEmpty {
+                guard let url = URL(string: tokenURL) else {
+                    appendLog("✗ Invalid token endpoint URL: \(tokenURL)")
+                    status = "error"
+                    return
+                }
+                appendLog("Auth: backend token endpoint \(url.absoluteString)")
+                let auth = BackendTokenAuthenticator(tokenURL: url)
+                client = try MossClient(projectId: projectId, authenticator: auth)
+            } else {
+                appendLog("Auth: static project key")
+                client = try MossClient(projectId: projectId, projectKey: projectKey)
+            }
             appendLog("✓ Client ready.")
             status = "ready"
         } catch {

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -127,11 +127,11 @@ needed. The dependency is declared in [`project.yml`](project.yml):
 packages:
   Moss:
     url: https://github.com/usemoss/moss
-    from: 0.3.0
+    from: 0.4.1
 ```
 
 On first build, Xcode downloads the precompiled `Moss.xcframework` from the
-[v0.3.0 release](https://github.com/usemoss/moss/releases/tag/v0.3.0),
+[v0.4.1 release](https://github.com/usemoss/moss/releases/tag/v0.4.1),
 verifies its checksum, and links it in.
 
 ## Generate the project
@@ -185,6 +185,7 @@ To target a specific simulator instead, pass e.g.
 | [`MossDemoModel.swift`](MossExample/MossDemoModel.swift) | Every SDK call, narrated step-by-step. Start here. |
 | [`ContentView.swift`](MossExample/ContentView.swift) | SwiftUI wiring - credentials screen and the demo button. |
 | [`MossExampleApp.swift`](MossExample/MossExampleApp.swift) | App entry point. |
+| [`BackendTokenAuthenticator.swift`](MossExample/BackendTokenAuthenticator.swift) | Production auth: short-lived backend tokens cached on-device. See [Credentials in production](#credentials-in-production). |
 
 ## Credentials in production
 
@@ -196,9 +197,64 @@ on your server rather than shipping in the binary.
 ```swift
 final class MyAuth: Authenticator {
     func getAuthHeader() async throws -> String {
-        try await myServer.fetchMossToken()
+        try await myServer.fetchMossToken()  // return the raw token, no "Bearer " prefix
     }
 }
 
 let client = try MossClient(projectId: id, authenticator: MyAuth())
 ```
+
+### Cache the token on-device
+
+The SDK calls `getAuthHeader()` on **every** outbound request and does **not**
+cache delegated tokens for you. (The static-key path *does* cache internally,
+but a custom `Authenticator` only returns a token string, so the runtime has no
+expiry to cache against.) The naive `MyAuth` above therefore hits your backend
+once per `query` / `loadIndex`.
+
+To avoid that, cache the token in your own `Authenticator` and only refetch
+once it's expired. The cleanest way is to have your token endpoint return
+`expiresIn` alongside the token — store both, and skip the network call while
+the token is still valid:
+
+```swift
+let auth = BackendTokenAuthenticator(
+    tokenURL: URL(string: "https://api.yourapp.com/moss-token")!
+)
+let client = try MossClient(projectId: id, authenticator: auth)
+```
+
+With caching in place your backend is only hit on a cold start and once per
+token lifetime (e.g. once an hour for `expiresIn: 3600`) — every query in
+between is served from the in-memory cache. Refresh the token ~60s early (the
+same safety margin the SDK applies internally) so it can't lapse mid-request.
+
+See [`BackendTokenAuthenticator.swift`](MossExample/BackendTokenAuthenticator.swift)
+for the full implementation, including the thread-safe token store and the
+backend response shape (`{ "token": "...", "expiresIn": 3600 }`).
+
+### Try it end-to-end
+
+A runnable token server lives in [`token-server/`](token-server/) so you can
+exercise the whole loop locally — app → your backend → cached token → query.
+It ships in both Node and Python (pick either — same endpoint, same response):
+
+```bash
+# Node
+cd token-server/node
+npm install
+MOSS_PROJECT_ID=your_project_id MOSS_PROJECT_KEY=your_project_key npm start
+
+# …or Python
+cd token-server/python
+pip install -r requirements.txt
+MOSS_PROJECT_ID=your_project_id MOSS_PROJECT_KEY=your_project_key \
+  uvicorn server:app --port 3456
+```
+
+Then on the app's credentials screen, enter your **Project ID** and set the
+**Token endpoint URL** to `http://localhost:3456/moss-token` (leave the project
+key blank). Run the demo and watch the server log: you'll see a single
+`vended token` line for the whole run, confirming the on-device cache is
+serving every query after the first fetch. Full steps in
+[`token-server/README.md`](token-server/README.md).

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -10,7 +10,7 @@ packages:
   # from the GitHub release on first resolve and verifies its checksum.
   Moss:
     url: https://github.com/usemoss/moss
-    from: 0.3.0
+    from: 0.4.1
 
 targets:
   MossExample:
@@ -38,6 +38,11 @@ targets:
           - UIInterfaceOrientationPortrait
         UIRequiresFullScreen: true
         ITSAppUsesNonExemptEncryption: false
+        # Lets the Simulator reach the plain-HTTP localhost token server during
+        # development (see token-server/). A production token endpoint is HTTPS,
+        # so you can drop this whole key for a real build.
+        NSAppTransportSecurity:
+          NSAllowsLocalNetworking: true
     dependencies:
       - package: Moss
         product: Moss

--- a/examples/ios/token-server/README.md
+++ b/examples/ios/token-server/README.md
@@ -1,0 +1,71 @@
+# Token server (for the iOS auth sample)
+
+A tiny stand-in for *your* backend. It holds the long-lived `projectKey` and
+vends short-lived Moss tokens to the iOS app, so the key never ships in the app
+binary. Pairs with
+[`BackendTokenAuthenticator.swift`](../MossExample/BackendTokenAuthenticator.swift).
+
+The app only needs an HTTP endpoint that returns
+`{ "token": "...", "expiresIn": 3600 }`, so the backend language is your choice.
+Two equivalent implementations are provided — pick one:
+
+| Language | Folder | How it gets the token |
+| --- | --- | --- |
+| Node | [`node/`](node/) | Uses the JS SDK's `MossClient.getAuthToken()` helper. |
+| Python | [`python/`](python/) | Calls Moss's auth endpoint directly. |
+
+Both expose the same `GET /moss-token` route on port `3456` and return the same
+JSON, so nothing changes on the iOS side either way.
+
+## Run it
+
+### Node
+
+```bash
+cd node
+npm install
+MOSS_PROJECT_ID=your_project_id MOSS_PROJECT_KEY=your_project_key npm start
+```
+
+### Python
+
+```bash
+cd python
+pip install -r requirements.txt
+MOSS_PROJECT_ID=your_project_id MOSS_PROJECT_KEY=your_project_key \
+  uvicorn server:app --port 3456
+```
+
+Either way you should be able to hit it from another terminal:
+
+```bash
+curl http://localhost:3456/moss-token
+# {"token":"eyJhbGciOi...","expiresIn":3600}
+```
+
+## Point the app at it
+
+1. Launch the app and, on the credentials screen, fill in the **Project ID**
+   and the **Token endpoint URL** (`http://localhost:3456/moss-token`). Leave
+   the project key blank — when a token URL is present the app authenticates
+   through `BackendTokenAuthenticator` instead of the static key.
+2. Tap **Run Session Demo**. Watch the server log: you'll see **one**
+   `vended token` line for the whole run, not one per request — that's the
+   on-device cache working.
+
+- **Simulator:** `http://localhost:3456` reaches your Mac directly.
+- **Real device:** use your Mac's LAN IP (e.g. `http://192.168.1.20:3456`) and
+  make sure the phone is on the same Wi-Fi.
+
+## Note on HTTP
+
+The app's `Info.plist` enables `NSAllowsLocalNetworking` so the Simulator can
+reach this plain-HTTP localhost server during development. A production token
+endpoint is served over **HTTPS**, which needs no App Transport Security
+exception — you can drop that key for a real build.
+
+## Production note
+
+Both servers skip authenticating the *caller* to stay short. In production,
+verify the request comes from a signed-in user (session cookie, your own JWT,
+OAuth introspection, …) before vending a Moss token.

--- a/examples/ios/token-server/node/package.json
+++ b/examples/ios/token-server/node/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "moss-ios-token-server",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Minimal token-vending backend for the Moss iOS BackendTokenAuthenticator sample",
+  "scripts": {
+    "start": "node server.mjs"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "dependencies": {
+    "@moss-dev/moss": "^1.0.1"
+  }
+}

--- a/examples/ios/token-server/node/server.mjs
+++ b/examples/ios/token-server/node/server.mjs
@@ -44,7 +44,9 @@ const server = http.createServer(async (req, res) => {
 
   try {
     const authToken = await moss.getAuthToken(); // { token, expiresIn }
-    res.writeHead(200, { 'Content-Type': 'application/json' });
+    // no-store: this response carries a bearer token; never let a browser,
+    // proxy, or CDN cache it.
+    res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
     res.end(JSON.stringify(authToken));
     console.log(`vended token (expiresIn=${authToken.expiresIn}s)`);
   } catch (err) {

--- a/examples/ios/token-server/node/server.mjs
+++ b/examples/ios/token-server/node/server.mjs
@@ -48,9 +48,11 @@ const server = http.createServer(async (req, res) => {
     res.end(JSON.stringify(authToken));
     console.log(`vended token (expiresIn=${authToken.expiresIn}s)`);
   } catch (err) {
-    res.writeHead(500, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: String(err) }));
+    // Log the details server-side only; return a generic message so internal
+    // error/stack details aren't exposed to the caller.
     console.error('token vend failed:', err);
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Failed to vend token' }));
   }
 });
 

--- a/examples/ios/token-server/node/server.mjs
+++ b/examples/ios/token-server/node/server.mjs
@@ -1,0 +1,59 @@
+/**
+ * Minimal token-vending backend for the iOS `BackendTokenAuthenticator` sample.
+ *
+ * This stands in for *your* API server. It is the only place that holds the
+ * long-lived `projectKey`; the iOS app never sees it. The app calls
+ * `GET /moss-token` and gets back a short-lived `{ token, expiresIn }` which it
+ * caches on-device (see BackendTokenAuthenticator.swift).
+ *
+ * Run it:
+ *   cd examples/ios/token-server/node
+ *   npm install
+ *   MOSS_PROJECT_ID=... MOSS_PROJECT_KEY=... npm start
+ *
+ * The iOS Simulator reaches this over http://localhost:3456 (the simulator
+ * shares the host Mac's network). For a real device, use your Mac's LAN IP.
+ */
+
+import http from 'http';
+import { MossClient } from '@moss-dev/moss';
+
+const PROJECT_ID = process.env.MOSS_PROJECT_ID;
+const PROJECT_KEY = process.env.MOSS_PROJECT_KEY;
+const PORT = Number(process.env.PORT ?? 3456);
+
+if (!PROJECT_ID || !PROJECT_KEY) {
+  console.error('Set MOSS_PROJECT_ID and MOSS_PROJECT_KEY in the environment.');
+  process.exit(1);
+}
+
+// The MossClient holds the projectKey and knows how to exchange it for a
+// short-lived token via getAuthToken() — no need to re-implement that flow.
+const moss = new MossClient(PROJECT_ID, PROJECT_KEY);
+
+const server = http.createServer(async (req, res) => {
+  if (req.method !== 'GET' || req.url !== '/moss-token') {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+    return;
+  }
+
+  // PRODUCTION: authenticate the caller here first (session cookie, your own
+  // JWT, etc.) so only your signed-in users can mint Moss tokens. This sample
+  // skips that to stay short.
+
+  try {
+    const authToken = await moss.getAuthToken(); // { token, expiresIn }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(authToken));
+    console.log(`vended token (expiresIn=${authToken.expiresIn}s)`);
+  } catch (err) {
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: String(err) }));
+    console.error('token vend failed:', err);
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Moss token server listening on http://localhost:${PORT}/moss-token`);
+});

--- a/examples/ios/token-server/python/requirements.txt
+++ b/examples/ios/token-server/python/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.110
+uvicorn>=0.29
+httpx>=0.27

--- a/examples/ios/token-server/python/server.py
+++ b/examples/ios/token-server/python/server.py
@@ -22,6 +22,7 @@ import os
 
 import httpx
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
 
 MOSS_AUTH_URL = "https://service.usemoss.dev/identity/auth/token"
 
@@ -52,4 +53,6 @@ async def moss_token():
     # which caches it on-device until ~60s before expiry.
     data = resp.json()
     print(f"vended token (expiresIn={data.get('expiresIn')}s)")
-    return data
+    # no-store: this response carries a bearer token; never let a browser,
+    # proxy, or CDN cache it.
+    return JSONResponse(content=data, headers={"Cache-Control": "no-store"})

--- a/examples/ios/token-server/python/server.py
+++ b/examples/ios/token-server/python/server.py
@@ -1,0 +1,55 @@
+"""
+Minimal token-vending backend for the iOS `BackendTokenAuthenticator` sample.
+
+This stands in for *your* API server. It is the only place that holds the
+long-lived projectKey; the iOS app never sees it. The app calls
+`GET /moss-token` and gets back a short-lived { token, expiresIn } which it
+caches on-device (see BackendTokenAuthenticator.swift).
+
+It exchanges your projectId + projectKey for a short-lived token via Moss's
+auth endpoint.
+
+Run it:
+    cd examples/ios/token-server/python
+    pip install -r requirements.txt
+    MOSS_PROJECT_ID=... MOSS_PROJECT_KEY=... uvicorn server:app --port 3456
+
+The iOS Simulator reaches this over http://localhost:3456 (the simulator shares
+the host Mac's network). For a real device, use your Mac's LAN IP.
+"""
+
+import os
+
+import httpx
+from fastapi import FastAPI, HTTPException
+
+MOSS_AUTH_URL = "https://service.usemoss.dev/identity/auth/token"
+
+PROJECT_ID = os.environ.get("MOSS_PROJECT_ID")
+PROJECT_KEY = os.environ.get("MOSS_PROJECT_KEY")
+if not PROJECT_ID or not PROJECT_KEY:
+    raise SystemExit("Set MOSS_PROJECT_ID and MOSS_PROJECT_KEY in the environment.")
+
+app = FastAPI()
+
+
+@app.get("/moss-token")
+async def moss_token():
+    # PRODUCTION: authenticate the caller here first (session cookie, your own
+    # JWT, etc.) so only your signed-in users can mint Moss tokens. This sample
+    # skips that to stay short.
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.post(
+            MOSS_AUTH_URL,
+            json={"projectId": PROJECT_ID, "projectKey": PROJECT_KEY},
+        )
+
+    if resp.status_code == 401:
+        raise HTTPException(status_code=401, detail="Invalid Moss credentials")
+    resp.raise_for_status()
+
+    # { "token": "...", "expiresIn": 3600 } — passed straight through to the app,
+    # which caches it on-device until ~60s before expiry.
+    data = resp.json()
+    print(f"vended token (expiresIn={data.get('expiresIn')}s)")
+    return data


### PR DESCRIPTION
## What

Shows the **production auth pattern** for the iOS SDK and gives customers a runnable end-to-end reference. Prompted by a customer (iOS) asking how to avoid a backend round-trip on every query.

## Why

On iOS the SDK calls `getAuthHeader()` on **every** request and does **not** cache delegated tokens (the static-key path caches internally, but a custom `Authenticator` only returns a token string, so the runtime has no expiry to cache against). The existing `MyAuth` snippet in the README fetched a fresh token every call — one backend round-trip per `query`/`loadIndex`. This PR demonstrates caching the token client-side so the backend is only hit when it actually expires.

## Changes

- **`BackendTokenAuthenticator.swift`** — delegated `Authenticator` that caches the token on-device and refetches only when expired (refreshes 60s early; thread-safe `TokenStore` actor).
- **Sample app wiring** — optional **Token endpoint URL** field on the credentials screen; when set, the client authenticates via the authenticator instead of the static project key (`MossDemoModel.connect` branches).
- **`token-server/`** — runnable backends in **Node** and **Python**, identical `GET /moss-token` route and `{ token, expiresIn }` response, so the iOS side is unchanged either way.
- **SDK bump** — pinned `0.3.0` → `0.4.1`.
- **`NSAllowsLocalNetworking`** — lets the Simulator reach the local HTTP token server during dev (production endpoints are HTTPS; the key can be dropped).
- **Docs** — README "Credentials in production" rewritten to cover on-device caching + an end-to-end test walkthrough.

## Test plan

- `xcodegen generate` + `xcodebuild` (iOS Simulator, arm64) — **build succeeds** against SDK 0.4.1 with the authenticator wired in.
- ATS key confirmed present in the built `Info.plist`.
- Both servers syntax-checked (`node --check`, `python -m py_compile`).
- End-to-end: run either server, set the app's token URL to `http://localhost:3456/moss-token`, run the demo — the server logs a **single** `vended token` line for the whole run, confirming the on-device cache.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usemoss/moss/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->