### PR TITLE
Fix: Update node version for Docker JS example

### DIFF
--- a/apps/docker/javascript/Dockerfile
+++ b/apps/docker/javascript/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:20-trixie-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Pull Request Checklist

Please ensure that your PR meets the following requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [ ] I have updated the documentation (if applicable).
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Description

The JavaScript Docker example in `apps/docker/javascript` was failing at runtime when loading `@moss-dev/moss-core` because `node:20-slim` did not provide a compatible `glibc` version for the native binding.

This updates the base image to `node:20-trixie-slim`, which includes a newer `glibc` and allows the container to load the Moss native addon successfully.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
