### PR TITLE
Complete OpenAI Agents cookbook retrieval options

### DIFF
--- a/examples/cookbook/openai-agents/README.md
+++ b/examples/cookbook/openai-agents/README.md
@@ -1,38 +1,160 @@
 # OpenAI Agents + Moss Cookbook
 
-This cookbook demonstrates how to build an AI agent using the [OpenAI Agents Python SDK](https://github.com/openai/openai-agents-python) and retrieve real-time context from a local knowledge base using [Moss](https://docs.moss.dev).
+This cookbook shows how to use [Moss](https://docs.moss.dev) semantic search as
+a local function tool inside the
+[OpenAI Agents Python SDK](https://github.com/openai/openai-agents-python).
 
-Instead of calling external API search services, this example registers a local function tool decorated with `@function_tool` that queries Moss with sub-10ms latency.
+The example loads a Moss index before the agent runs, exposes a `moss_search`
+tool with `query`, `top_k`, and `filter` arguments, and returns structured
+retrieval results that the agent can use to answer a support question.
 
-## Setup
+## Requirements
 
-1. Copy the `.env.example` to `.env`:
-   ```bash
-   cp .env.example .env
-   ```
+- Python 3.10+
+- A Moss project with `MOSS_PROJECT_ID` and `MOSS_PROJECT_KEY`
+- An index name in `MOSS_INDEX_NAME`
+- An OpenAI API key in `OPENAI_API_KEY`
 
-2. Fill in your environment variables:
-   - `MOSS_PROJECT_ID`
-   - `MOSS_PROJECT_KEY`
-   - `MOSS_INDEX_NAME`
-   - `OPENAI_API_KEY`
+## Installation
 
-3. Create a virtual environment and install the dependencies:
-   ```bash
-   python -m venv .venv
-   source .venv/bin/activate
-   pip install -e .
-   ```
+From this directory:
 
-## Running the Example
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
 
-Run the script to start the agent:
+## Environment Setup
+
+Copy the example environment file and fill in your values:
+
+```bash
+cp .env.example .env
+```
+
+```env
+MOSS_PROJECT_ID=your-project-id
+MOSS_PROJECT_KEY=your-project-key
+MOSS_INDEX_NAME=your-index-name
+OPENAI_API_KEY=your-openai-api-key
+```
+
+`example.py` validates all four variables before creating the Moss client or
+running the OpenAI agent.
+
+## Demo Index
+
+On startup, the script checks whether `MOSS_INDEX_NAME` already exists. If it
+does, the existing index is reused. If not, the script creates a small support
+index with password reset, refund policy, and support-hours documents.
+
+The demo documents include metadata such as `category` and `region` so metadata
+filters can be tried immediately after the index is created.
+
+## Local Index Loading
+
+The example explicitly calls:
+
+```python
+await client.load_index(index_name)
+```
+
+before `Runner.run(...)`.
+
+Loading the index places it in the Moss local runtime. Once loaded, queries avoid
+a network hop on the query hot path and can use local metadata filtering. Without
+a locally loaded index, `MossClient.query()` may use its documented cloud
+fallback behavior. Actual latency depends on index size, machine resources,
+network conditions, and whether the local model/index cache is already warm.
+
+## Run the Example
+
 ```bash
 python example.py
 ```
 
-The script will:
-1. Initialize the `MossClient` and load the specified index into memory.
-2. Define a retrieval tool `moss_search` using `@function_tool`.
-3. Create an OpenAI `Agent` configured with `tools=[moss_search]`.
-4. Ask a question about "refund policy" and output the agent's final response after retrieving the correct context.
+The script asks:
+
+```text
+How long do refunds take to process?
+```
+
+Expected behavior:
+
+1. Moss creates or reuses the demo index.
+2. Moss loads the index into the local runtime.
+3. The OpenAI agent calls `moss_search`.
+4. The tool returns JSON with matching document IDs, text, scores, and metadata.
+5. The agent returns an answer grounded in those retrieved documents.
+
+## Tool Arguments
+
+The OpenAI Agents SDK derives the public tool schema from the decorated function:
+
+```python
+async def moss_search(
+    query: str,
+    top_k: int = 3,
+    filter: dict[str, Any] | None = None,
+) -> str:
+    ...
+```
+
+- `query`: Natural-language lookup text.
+- `top_k`: Number of Moss results to return. The cookbook accepts `1` through
+  `20` and defaults to `3`.
+- `filter`: Optional Moss metadata filter passed directly to
+  `QueryOptions(filter=...)`.
+
+## Metadata Filters
+
+Use metadata filters when the question should be constrained to a known slice of
+the index, such as product category, region, customer segment, document source,
+or publication date bucket. Filters are especially useful when the same index
+contains similar documents for different audiences or workflows.
+
+Equality filter:
+
+```python
+filter = {"field": "category", "condition": {"$eq": "policy"}}
+```
+
+Compound filter:
+
+```python
+filter = {
+    "$and": [
+        {"field": "category", "condition": {"$eq": "policy"}},
+        {"field": "region", "condition": {"$eq": "global"}},
+    ]
+}
+```
+
+Other supported operators in the Moss Python examples and tests include `$ne`,
+`$gt`, `$lt`, `$gte`, `$lte`, `$in`, `$nin`, `$or`, nested `$and`/`$or`, and
+`$near` for location-style metadata.
+
+## Testing
+
+The unit tests mock Moss and OpenAI Agents SDK objects. They do not require real
+credentials or network calls.
+
+```bash
+python -m unittest test_example.py
+python -m py_compile example.py test_example.py
+ruff check example.py test_example.py
+black --check example.py test_example.py
+```
+
+## Troubleshooting
+
+- Missing credentials: ensure `.env` exists and contains `MOSS_PROJECT_ID`,
+  `MOSS_PROJECT_KEY`, `MOSS_INDEX_NAME`, and `OPENAI_API_KEY`.
+- Missing index: the demo creates a small index if `MOSS_INDEX_NAME` is not
+  found. If creation fails, check that the Moss project credentials can create
+  indexes.
+- Slow first run: the first `load_index()` call may need to download index data
+  or local model assets. Later runs can be faster once caches are warm.
+- Filter returns no results: confirm the documents in the index have metadata
+  keys and values matching the filter exactly.

--- a/examples/cookbook/openai-agents/example.py
+++ b/examples/cookbook/openai-agents/example.py
@@ -1,11 +1,41 @@
 import asyncio
+import json
 import os
+from typing import Any, Dict, Optional
+
 from agents import Agent, Runner, function_tool
 from dotenv import load_dotenv
 from moss import DocumentInfo, MossClient, QueryOptions
 
-# Load environment variables
-load_dotenv()
+DEFAULT_TOP_K = 3
+MAX_TOP_K = 20
+REQUIRED_ENV_VARS = (
+    "MOSS_PROJECT_ID",
+    "MOSS_PROJECT_KEY",
+    "MOSS_INDEX_NAME",
+    "OPENAI_API_KEY",
+)
+
+
+def _require_env_vars(names: tuple[str, ...] = REQUIRED_ENV_VARS) -> Dict[str, str]:
+    """Return required environment variables or raise a clear setup error."""
+    values = {name: os.getenv(name) for name in names}
+    missing = [name for name, value in values.items() if not value]
+    if missing:
+        raise RuntimeError(
+            "Missing required environment variables: " + ", ".join(missing)
+        )
+    return {name: value for name, value in values.items() if value is not None}
+
+
+def _validate_top_k(top_k: int) -> int:
+    """Keep cookbook retrieval bounds simple and explicit."""
+    if not isinstance(top_k, int) or isinstance(top_k, bool):
+        raise ValueError("top_k must be an integer.")
+    if top_k < 1 or top_k > MAX_TOP_K:
+        raise ValueError(f"top_k must be between 1 and {MAX_TOP_K}.")
+    return top_k
+
 
 async def _ensure_demo_index(client: MossClient, index_name: str) -> None:
     """Create a small demo index if it does not already exist."""
@@ -21,65 +51,125 @@ async def _ensure_demo_index(client: MossClient, index_name: str) -> None:
                 "To reset your password, go to Settings > Security, choose Reset "
                 "Password, and follow the email verification link."
             ),
+            metadata={"category": "account", "region": "global"},
         ),
         DocumentInfo(
             id="refund-policy",
             text="Refunds are processed within 3-5 business days after approval.",
+            metadata={"category": "policy", "region": "global"},
         ),
         DocumentInfo(
             id="support-hours",
             text="Customer support is available Monday to Friday, 9 AM to 6 PM IST.",
+            metadata={"category": "support", "region": "in"},
         ),
     ]
     await client.create_index(index_name, docs)
 
 
-async def main() -> None:
-    # 1. Initialize Moss Client and Load Index
-    client = MossClient(
-        project_id=os.getenv("MOSS_PROJECT_ID"),
-        project_key=os.getenv("MOSS_PROJECT_KEY"),
+def _format_search_results(query: str, docs: list[Any]) -> str:
+    """Return structured tool output that an agent can cite and reason over."""
+    if not docs:
+        return json.dumps(
+            {
+                "query": query,
+                "message": "No relevant results found.",
+                "results": [],
+            },
+            indent=2,
+        )
+
+    results = []
+    for doc in docs:
+        results.append(
+            {
+                "id": getattr(doc, "id", ""),
+                "text": getattr(doc, "text", ""),
+                "score": getattr(doc, "score", None),
+                "metadata": getattr(doc, "metadata", None) or {},
+            }
+        )
+    return json.dumps({"query": query, "results": results}, indent=2)
+
+
+async def search_moss(
+    client: MossClient,
+    index_name: str,
+    query: str,
+    top_k: int = DEFAULT_TOP_K,
+    filter: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Query Moss and format results for the OpenAI agent."""
+    top_k = _validate_top_k(top_k)
+    result = await client.query(
+        index_name,
+        query,
+        options=QueryOptions(top_k=top_k, filter=filter),
     )
-    index_name = os.getenv("MOSS_INDEX_NAME")  # e.g. "my-index"
+    return _format_search_results(query, result.docs)
 
-    # Ensure the demo index exists in the cloud before pre-loading it
-    await _ensure_demo_index(client, index_name)
 
-    print(f"Pre-loading index '{index_name}' into Moss local runtime...")
-    await client.load_index(index_name)
+def create_moss_search_tool(client: MossClient, index_name: str) -> Any:
+    """Create the OpenAI Agents SDK function tool backed by Moss."""
 
-    # 2. Define the search tool using @function_tool
     @function_tool
-    async def moss_search(query: str) -> str:
+    async def moss_search(
+        query: str,
+        top_k: int = DEFAULT_TOP_K,
+        filter: Optional[Dict[str, Any]] = None,
+    ) -> str:
         """Search the knowledge base for answers to the user's question.
 
         Args:
-            query: The search query.
+            query: Natural-language search query.
+            top_k: Number of Moss results to return. Use 1-20.
+            filter: Optional Moss metadata filter, such as
+                {"field": "category", "condition": {"$eq": "policy"}}.
         """
         print(f"[Tool Triggered] Searching Moss for: '{query}'")
-        result = await client.query(
-            index_name,
-            query,
-            options=QueryOptions(top_k=3),
-        )
-        if not result.docs:
-            return "No relevant results found."
-        return "\n\n".join(doc.text for doc in result.docs)
+        return await search_moss(client, index_name, query, top_k, filter)
 
-    # 3. Create the OpenAI Agent with the search tool
+    return moss_search
+
+
+async def run_agent(client: MossClient, index_name: str, question: str) -> Any:
+    """Load the local index, create the agent, and run the user question."""
+    print(f"Pre-loading index '{index_name}' into Moss local runtime...")
+    await client.load_index(index_name)
+
+    moss_search = create_moss_search_tool(client, index_name)
+
     agent = Agent(
         name="Support Assistant",
         instructions=(
             "You are a helpful customer support assistant. "
-            "Use the moss_search tool to look up information and answer "
-            "the user's questions about policies, hours, or password resets."
+            "Use the moss_search tool to look up information before answering. "
+            "Ground your response in the retrieved documents and mention when "
+            "the knowledge base has no relevant result."
         ),
         tools=[moss_search],
     )
 
-    # 4. Run the Agent
     print("\nRunning agent query...")
-    result = await Runner.run(agent, "How long do refunds take to process?")
+    return await Runner.run(agent, question)
+
+
+async def main() -> None:
+    load_dotenv()
+    env = _require_env_vars()
+
+    # 1. Initialize Moss Client and Load Index
+    client = MossClient(
+        project_id=env["MOSS_PROJECT_ID"],
+        project_key=env["MOSS_PROJECT_KEY"],
+    )
+    index_name = env["MOSS_INDEX_NAME"]  # e.g. "my-index"
+
+    # Ensure the demo index exists in the cloud before pre-loading it
+    await _ensure_demo_index(client, index_name)
+
+    # 2. Load the index locally, create the agent, and run the question.
+    result = await run_agent(client, index_name, "How long do refunds take to process?")
     print(f"\nFinal Agent Response:\n{result.final_output}")
 
 

--- a/examples/cookbook/openai-agents/test_example.py
+++ b/examples/cookbook/openai-agents/test_example.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class QueryOptions:
+    def __init__(self, top_k=None, filter=None):
+        self.top_k = top_k
+        self.filter = filter
+
+
+class DocumentInfo:
+    def __init__(self, id, text, metadata=None):
+        self.id = id
+        self.text = text
+        self.metadata = metadata
+
+
+class MossClient:
+    pass
+
+
+class Agent:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class Runner:
+    @staticmethod
+    async def run(agent, question):
+        return types.SimpleNamespace(
+            agent=agent, question=question, final_output="done"
+        )
+
+
+def function_tool(func):
+    func.is_function_tool = True
+    return func
+
+
+def load_dotenv():
+    return None
+
+
+sys.modules["moss"] = types.SimpleNamespace(
+    DocumentInfo=DocumentInfo,
+    MossClient=MossClient,
+    QueryOptions=QueryOptions,
+)
+sys.modules["agents"] = types.SimpleNamespace(
+    Agent=Agent,
+    Runner=Runner,
+    function_tool=function_tool,
+)
+sys.modules["dotenv"] = types.SimpleNamespace(load_dotenv=load_dotenv)
+
+example = importlib.import_module("example")
+
+
+def _doc(doc_id="d1", text="sample text", score=0.9, metadata=None):
+    return types.SimpleNamespace(
+        id=doc_id,
+        text=text,
+        score=score,
+        metadata=metadata or {},
+    )
+
+
+def _search_result(docs):
+    return types.SimpleNamespace(docs=docs)
+
+
+class TestSearchMoss(unittest.IsolatedAsyncioTestCase):
+    async def test_query_is_passed_to_client_query(self):
+        client = MagicMock()
+        client.query = AsyncMock(return_value=_search_result([_doc()]))
+
+        await example.search_moss(client, "support-index", "refund status")
+
+        client.query.assert_awaited_once()
+        self.assertEqual(
+            client.query.await_args.args[:2], ("support-index", "refund status")
+        )
+
+    async def test_top_k_is_forwarded_to_query_options(self):
+        client = MagicMock()
+        client.query = AsyncMock(return_value=_search_result([_doc()]))
+
+        await example.search_moss(client, "idx", "refund", top_k=7)
+
+        options = client.query.await_args.kwargs["options"]
+        self.assertEqual(options.top_k, 7)
+
+    async def test_metadata_filter_is_forwarded(self):
+        client = MagicMock()
+        client.query = AsyncMock(return_value=_search_result([_doc()]))
+        metadata_filter = {"field": "category", "condition": {"$eq": "policy"}}
+
+        await example.search_moss(
+            client,
+            "idx",
+            "refund",
+            top_k=5,
+            filter=metadata_filter,
+        )
+
+        options = client.query.await_args.kwargs["options"]
+        self.assertEqual(options.filter, metadata_filter)
+
+    async def test_filter_none_is_allowed(self):
+        client = MagicMock()
+        client.query = AsyncMock(return_value=_search_result([_doc()]))
+
+        await example.search_moss(client, "idx", "refund", filter=None)
+
+        options = client.query.await_args.kwargs["options"]
+        self.assertIsNone(options.filter)
+
+    async def test_empty_results_produce_clear_response(self):
+        client = MagicMock()
+        client.query = AsyncMock(return_value=_search_result([]))
+
+        output = await example.search_moss(client, "idx", "unknown")
+
+        self.assertIn("No relevant results found.", output)
+        self.assertIn('"results": []', output)
+
+    async def test_invalid_top_k_is_handled_clearly(self):
+        client = MagicMock()
+        client.query = AsyncMock(return_value=_search_result([]))
+
+        with self.assertRaisesRegex(ValueError, "top_k must be between 1 and 20"):
+            await example.search_moss(client, "idx", "refund", top_k=0)
+
+        client.query.assert_not_called()
+
+    async def test_structured_results_include_grounding_fields(self):
+        client = MagicMock()
+        client.query = AsyncMock(
+            return_value=_search_result(
+                [
+                    _doc(
+                        doc_id="refund-policy",
+                        text="Refunds take 3-5 business days.",
+                        score=0.94,
+                        metadata={"category": "policy"},
+                    )
+                ]
+            )
+        )
+
+        output = await example.search_moss(client, "idx", "refund")
+
+        self.assertIn('"id": "refund-policy"', output)
+        self.assertIn('"text": "Refunds take 3-5 business days."', output)
+        self.assertIn('"score": 0.94', output)
+        self.assertIn('"metadata"', output)
+
+
+class TestEnvironmentValidation(unittest.TestCase):
+    def test_missing_env_vars_are_reported_together(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(RuntimeError, "MOSS_PROJECT_ID"):
+                example._require_env_vars()
+
+        try:
+            with patch.dict(os.environ, {}, clear=True):
+                example._require_env_vars()
+        except RuntimeError as exc:
+            message = str(exc)
+        else:
+            self.fail("_require_env_vars should have raised RuntimeError")
+
+        self.assertIn("MOSS_PROJECT_KEY", message)
+        self.assertIn("MOSS_INDEX_NAME", message)
+        self.assertIn("OPENAI_API_KEY", message)
+
+
+class TestAgentSetup(unittest.IsolatedAsyncioTestCase):
+    async def test_load_index_happens_before_runner_run(self):
+        events = []
+        client = MagicMock()
+
+        async def load_index(index_name):
+            events.append(("load_index", index_name))
+
+        class RecordingRunner:
+            @staticmethod
+            async def run(agent, question):
+                events.append(
+                    ("run", question, agent.kwargs["tools"][0].is_function_tool)
+                )
+                return types.SimpleNamespace(final_output="answer")
+
+        client.load_index = AsyncMock(side_effect=load_index)
+
+        with patch.object(example, "Runner", RecordingRunner):
+            result = await example.run_agent(client, "idx", "How long do refunds take?")
+
+        self.assertEqual(result.final_output, "answer")
+        self.assertEqual(events[0], ("load_index", "idx"))
+        self.assertEqual(events[1], ("run", "How long do refunds take?", True))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/cookbook/openai-agents/test_example.py
+++ b/examples/cookbook/openai-agents/test_example.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import os
+from pathlib import Path
 import sys
 import types
 import unittest
@@ -47,19 +48,41 @@ def load_dotenv():
     return None
 
 
-sys.modules["moss"] = types.SimpleNamespace(
-    DocumentInfo=DocumentInfo,
-    MossClient=MossClient,
-    QueryOptions=QueryOptions,
-)
-sys.modules["agents"] = types.SimpleNamespace(
-    Agent=Agent,
-    Runner=Runner,
-    function_tool=function_tool,
-)
-sys.modules["dotenv"] = types.SimpleNamespace(load_dotenv=load_dotenv)
+def _import_example_with_stubs():
+    cookbook_dir = Path(__file__).resolve().parent
+    original_sys_path = sys.path[:]
+    missing = object()
+    original_modules = {
+        name: sys.modules.get(name, missing)
+        for name in ("moss", "agents", "dotenv", "example")
+    }
 
-example = importlib.import_module("example")
+    try:
+        sys.path.insert(0, str(cookbook_dir))
+        sys.modules["moss"] = types.SimpleNamespace(
+            DocumentInfo=DocumentInfo,
+            MossClient=MossClient,
+            QueryOptions=QueryOptions,
+        )
+        sys.modules["agents"] = types.SimpleNamespace(
+            Agent=Agent,
+            Runner=Runner,
+            function_tool=function_tool,
+        )
+        sys.modules["dotenv"] = types.SimpleNamespace(load_dotenv=load_dotenv)
+        sys.modules.pop("example", None)
+
+        return importlib.import_module("example")
+    finally:
+        for name, module in original_modules.items():
+            if module is missing:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+        sys.path[:] = original_sys_path
+
+
+example = _import_example_with_stubs()
 
 
 def _doc(doc_id="d1", text="sample text", score=0.9, metadata=None):


### PR DESCRIPTION
## Description

Completes the remaining acceptance criteria for the existing OpenAI Agents + Moss cookbook introduced in PR #304.

The cookbook previously supported a basic Moss retrieval tool, but `top_k` was hard-coded, metadata filters were not exposed, retrieval results lacked structured grounding information, and there were no credential-free tests.

This PR:

* Exposes `query`, `top_k`, and optional `filter` arguments through the `@function_tool`.
* Passes metadata filters through `QueryOptions(filter=...)`.
* Validates `top_k` using a range of 1–20.
* Returns structured JSON containing document IDs, text, scores, and metadata.
* Validates required Moss and OpenAI environment variables.
* Preserves `load_index()` before `Runner.run(...)`.
* Adds metadata filter and local-vs-cloud retrieval documentation.
* Adds mocked unit tests that require no credentials or network calls.

Completes the remaining acceptance criteria for #92.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [x] Documentation update

## Testing

The following checks passed locally:

```bash
python -m unittest test_example.py
python -m py_compile example.py test_example.py
black --check example.py test_example.py
git diff --check
```

Test result:

```text
Ran 9 tests in 0.012s

OK
```

Ruff was not run because it was not installed in the local environment.

## Checklist

* [x] Existing cookbook structure preserved
* [x] Local Moss index loaded before the agent runs
* [x] `@function_tool` integration retained
* [x] `query`, `top_k`, and optional `filter` exposed
* [x] Metadata filters passed through `QueryOptions`
* [x] Structured retrieval results returned for grounding
* [x] Credential-free tests added
* [x] Documentation updated