### PR TITLE
docs(examples): add session samples — local cache (saveToDisk) + custom authenticator

### DIFF
--- a/examples/javascript/.gitignore
+++ b/examples/javascript/.gitignore
@@ -3,3 +3,6 @@ node_modules
 dist
 .log
 out.log
+
+# Local index / session caches written by the samples
+.moss-*

--- a/examples/javascript/README.md
+++ b/examples/javascript/README.md
@@ -62,6 +62,14 @@ Open a local-first `SessionIndex`, add documents in real time (no cloud round tr
 npx tsx session_sample.ts
 ```
 
+### Session Cache Sample
+
+Build a local-first `SessionIndex`, persist it to the local filesystem with `saveToDisk`, then restore it into a fresh session with `loadFromDisk` — so a session survives a process restart with no cloud round trip (no `pushIndex`). Also shows the client-level `cachePath` option (requires `@moss-dev/moss` >= 1.2.1).
+
+```bash
+npx tsx session_cache_sample.ts
+```
+
 ## Requirements
 
 - Node.js (version 20 or higher)

--- a/examples/javascript/README.md
+++ b/examples/javascript/README.md
@@ -70,6 +70,14 @@ Build a local-first `SessionIndex`, persist it to the local filesystem with `sav
 npx tsx session_cache_sample.ts
 ```
 
+### Session + Custom Authenticator Sample
+
+Open a local-first session when the client is built with a custom `IAuthenticator` (short-lived tokens / delegated auth) instead of a static project key — the session authenticates through the same token source, so the project key never has to live on the device. Requires `@moss-dev/moss` >= 1.3.0.
+
+```bash
+npx tsx session_custom_auth_sample.ts
+```
+
 ## Requirements
 
 - Node.js (version 20 or higher)

--- a/examples/javascript/package-lock.json
+++ b/examples/javascript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@moss-dev/moss": "^1.1.0",
+        "@moss-dev/moss": "^1.2.1",
         "dotenv": "^17.4.2",
         "openai": "^6.42.0"
       },
@@ -591,34 +591,34 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@moss-dev/moss": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss/-/moss-1.1.0.tgz",
-      "integrity": "sha512-Q9KnJth6A7OZolTweRa0D/pUdvADu/79AIJXmyRyAmZRA4ch9kIUD0U1EAte4LDHjL8+XojW4Gr83SbvDeDLxg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss/-/moss-1.2.1.tgz",
+      "integrity": "sha512-R20ok7Y3nHfXwLO1+HtmG+DZHDxF0OdwKd0fFHnhC0LV0CzPdYTcjnDyYFQMJvW1hPSIoEMTbyp3SZwSKRyBfw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@moss-dev/moss-core": "0.17.0"
+        "@moss-dev/moss-core": "0.18.0"
       }
     },
     "node_modules/@moss-dev/moss-core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core/-/moss-core-0.17.0.tgz",
-      "integrity": "sha512-LLDhTFK/IhDbc0iRmM5IIZBBEHLdB8vrtKRuBbS6AAL6vX9Y0AbK3doUiEtGRVIr/krugSKIr1CO1XdtVZ0guQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core/-/moss-core-0.18.0.tgz",
+      "integrity": "sha512-h97RT9onCdWf7QSG0L1c2ITrvEujUoltuKdG28AHeuab5EYtvbWaZyRzqCBsjRdu3wHDa05TxAhUSbMjzykZXQ==",
       "license": "Proprietary",
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@moss-dev/moss-core-darwin-arm64": "0.17.0",
-        "@moss-dev/moss-core-darwin-x64": "0.17.0",
-        "@moss-dev/moss-core-linux-arm64-gnu": "0.17.0",
-        "@moss-dev/moss-core-linux-x64-gnu": "0.17.0",
-        "@moss-dev/moss-core-win32-x64-msvc": "0.17.0"
+        "@moss-dev/moss-core-darwin-arm64": "0.18.0",
+        "@moss-dev/moss-core-darwin-x64": "0.18.0",
+        "@moss-dev/moss-core-linux-arm64-gnu": "0.18.0",
+        "@moss-dev/moss-core-linux-x64-gnu": "0.18.0",
+        "@moss-dev/moss-core-win32-x64-msvc": "0.18.0"
       }
     },
     "node_modules/@moss-dev/moss-core-darwin-arm64": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-darwin-arm64/-/moss-core-darwin-arm64-0.17.0.tgz",
-      "integrity": "sha512-GkkHcz///h/i2qYdg4sMQMdOrbdSs49cZczKFqXOGvM8MToS2yCOzK0StK4X9/QnLyo4DhOHB+XLcNdVmEHhdA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-darwin-arm64/-/moss-core-darwin-arm64-0.18.0.tgz",
+      "integrity": "sha512-ZxQii7nEwtvgvnN/arwSC4oJO6iPODxDlLfSCkgmlhDuHl3lxx/+WpJgXQ2Kv0potbOKs80/BPkmTrT5FU68Ug==",
       "cpu": [
         "arm64"
       ],
@@ -632,9 +632,9 @@
       }
     },
     "node_modules/@moss-dev/moss-core-darwin-x64": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-darwin-x64/-/moss-core-darwin-x64-0.17.0.tgz",
-      "integrity": "sha512-xF3iay9BQt6ZyRTnRBgriho4zem7bp/vTBRiEcsN6uoAvmmHg0YGofwHhpzqSIIqEZPAhze4FlyC2cjaxnQKZg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-darwin-x64/-/moss-core-darwin-x64-0.18.0.tgz",
+      "integrity": "sha512-mEIBz33BaYMGxhF/WPHAzCDKPFiXiy3BH+FNkMQNlfkDJ96mJlf+dJGE50W6YvjOzFBXdNfkcDl2/xxf90R49g==",
       "cpu": [
         "x64"
       ],
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@moss-dev/moss-core-linux-arm64-gnu": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-linux-arm64-gnu/-/moss-core-linux-arm64-gnu-0.17.0.tgz",
-      "integrity": "sha512-FJ18yeCm08rS0G3jmvCVx26S+AEk0UZ2CGNiUW9pIOXhd7oshBDaUCXnsRCzfL+yxB5UoHQTYzUE1bXYFemp2A==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-linux-arm64-gnu/-/moss-core-linux-arm64-gnu-0.18.0.tgz",
+      "integrity": "sha512-gIjWJjaOTQ+f1cxh58vlqYijbTZFaD2F3sh7rc0K8NgQfMLOiXRQYGD0ZBwE4H109f8w2n0ThlZUTkIshBFn9w==",
       "cpu": [
         "arm64"
       ],
@@ -664,9 +664,9 @@
       }
     },
     "node_modules/@moss-dev/moss-core-linux-x64-gnu": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-linux-x64-gnu/-/moss-core-linux-x64-gnu-0.17.0.tgz",
-      "integrity": "sha512-/ueQ/76V/Suteb4oUr6LsKRwtD21aGwkrGjCDdF/atyBlwsJGAoR553bBx9O5QeRn+FNshZCuuwsas0N7WXXJA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-linux-x64-gnu/-/moss-core-linux-x64-gnu-0.18.0.tgz",
+      "integrity": "sha512-vffFCFLqOmRSL4wc2OJIoXPSj4S4NoyjH3wv8jwOl1Jd6nju2Aik8BgdTKJt4O39SEQEWqN1rLfdmuhRGOUCcA==",
       "cpu": [
         "x64"
       ],
@@ -680,9 +680,9 @@
       }
     },
     "node_modules/@moss-dev/moss-core-win32-x64-msvc": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-win32-x64-msvc/-/moss-core-win32-x64-msvc-0.17.0.tgz",
-      "integrity": "sha512-7ILWACI5aUNBZi1n7lK2ORF5TFnkTcDT6unldWmJHEQBZNZF309Y9GszJzulj0P0PMot2SGd01G7hRPCmYhdMA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-win32-x64-msvc/-/moss-core-win32-x64-msvc-0.18.0.tgz",
+      "integrity": "sha512-W538bG5RGJOFuO3NQmMZ3kVNREogTcoPRQiPeHC1506ui7V2o0GmgZsXpQ1c58omlbRhcHwhS8oc8QtWdQBHnQ==",
       "cpu": [
         "x64"
       ],
@@ -799,6 +799,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -1021,6 +1022,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1315,6 +1317,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2340,6 +2343,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2424,6 +2428,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2491,6 +2496,7 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",

--- a/examples/javascript/package-lock.json
+++ b/examples/javascript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@moss-dev/moss": "^1.2.1",
+        "@moss-dev/moss": "^1.3.0",
         "dotenv": "^17.4.2",
         "openai": "^6.42.0"
       },
@@ -591,34 +591,34 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@moss-dev/moss": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss/-/moss-1.2.1.tgz",
-      "integrity": "sha512-R20ok7Y3nHfXwLO1+HtmG+DZHDxF0OdwKd0fFHnhC0LV0CzPdYTcjnDyYFQMJvW1hPSIoEMTbyp3SZwSKRyBfw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss/-/moss-1.3.0.tgz",
+      "integrity": "sha512-3D1yZWetHzUDfKQPkcvR1WznWDjq4PThWdqqtY2E5MSgMMnA94kJF7YwN7L4sADTQdql9mX5HrPLY+utaRY8bw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@moss-dev/moss-core": "0.18.0"
+        "@moss-dev/moss-core": "0.19.0"
       }
     },
     "node_modules/@moss-dev/moss-core": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core/-/moss-core-0.18.0.tgz",
-      "integrity": "sha512-h97RT9onCdWf7QSG0L1c2ITrvEujUoltuKdG28AHeuab5EYtvbWaZyRzqCBsjRdu3wHDa05TxAhUSbMjzykZXQ==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core/-/moss-core-0.19.0.tgz",
+      "integrity": "sha512-yziQuEjA9rZwky6zSy3DgAQzOuDKCL+XtaJmdJ0UJn5CEVXgozym8HdIiwMsNzmqByI2eTFxwkWLTHenwbKBag==",
       "license": "Proprietary",
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@moss-dev/moss-core-darwin-arm64": "0.18.0",
-        "@moss-dev/moss-core-darwin-x64": "0.18.0",
-        "@moss-dev/moss-core-linux-arm64-gnu": "0.18.0",
-        "@moss-dev/moss-core-linux-x64-gnu": "0.18.0",
-        "@moss-dev/moss-core-win32-x64-msvc": "0.18.0"
+        "@moss-dev/moss-core-darwin-arm64": "0.19.0",
+        "@moss-dev/moss-core-darwin-x64": "0.19.0",
+        "@moss-dev/moss-core-linux-arm64-gnu": "0.19.0",
+        "@moss-dev/moss-core-linux-x64-gnu": "0.19.0",
+        "@moss-dev/moss-core-win32-x64-msvc": "0.19.0"
       }
     },
     "node_modules/@moss-dev/moss-core-darwin-arm64": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-darwin-arm64/-/moss-core-darwin-arm64-0.18.0.tgz",
-      "integrity": "sha512-ZxQii7nEwtvgvnN/arwSC4oJO6iPODxDlLfSCkgmlhDuHl3lxx/+WpJgXQ2Kv0potbOKs80/BPkmTrT5FU68Ug==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-darwin-arm64/-/moss-core-darwin-arm64-0.19.0.tgz",
+      "integrity": "sha512-RR4TMm8N8SYNOatIQSXsuHveqxdlBESdD1RybERLyOYIqx3jTJFDgD201SjIo3rG16kPGhqUW7j92J/qQbs5vQ==",
       "cpu": [
         "arm64"
       ],
@@ -632,9 +632,9 @@
       }
     },
     "node_modules/@moss-dev/moss-core-darwin-x64": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-darwin-x64/-/moss-core-darwin-x64-0.18.0.tgz",
-      "integrity": "sha512-mEIBz33BaYMGxhF/WPHAzCDKPFiXiy3BH+FNkMQNlfkDJ96mJlf+dJGE50W6YvjOzFBXdNfkcDl2/xxf90R49g==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-darwin-x64/-/moss-core-darwin-x64-0.19.0.tgz",
+      "integrity": "sha512-kqv091zkAq5FMKG39udk8U6qHslE5Gz1k6Tn/MTpPv3I3jZ9lj/hn6Jm/lZBqrJMa8FKOstrlHIHrjr2g75ZNg==",
       "cpu": [
         "x64"
       ],
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@moss-dev/moss-core-linux-arm64-gnu": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-linux-arm64-gnu/-/moss-core-linux-arm64-gnu-0.18.0.tgz",
-      "integrity": "sha512-gIjWJjaOTQ+f1cxh58vlqYijbTZFaD2F3sh7rc0K8NgQfMLOiXRQYGD0ZBwE4H109f8w2n0ThlZUTkIshBFn9w==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-linux-arm64-gnu/-/moss-core-linux-arm64-gnu-0.19.0.tgz",
+      "integrity": "sha512-9n7o1OpGb9Wga9Rkl1zBt4RFj66eJrw6mncHtcByG6inTzTbmRVcaTI+T1RGC8ikKeWS4DJJ35dMyi8r/qGjAQ==",
       "cpu": [
         "arm64"
       ],
@@ -664,9 +664,9 @@
       }
     },
     "node_modules/@moss-dev/moss-core-linux-x64-gnu": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-linux-x64-gnu/-/moss-core-linux-x64-gnu-0.18.0.tgz",
-      "integrity": "sha512-vffFCFLqOmRSL4wc2OJIoXPSj4S4NoyjH3wv8jwOl1Jd6nju2Aik8BgdTKJt4O39SEQEWqN1rLfdmuhRGOUCcA==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-linux-x64-gnu/-/moss-core-linux-x64-gnu-0.19.0.tgz",
+      "integrity": "sha512-L9Y7GiOSCidc+bYuy4WUUFhMy1QAnI9ifG2rNBgYxYW4U2gPgPYLGG6nNkQYBo0iqK5mKzEp1Qhp1K5Pi157RA==",
       "cpu": [
         "x64"
       ],
@@ -680,9 +680,9 @@
       }
     },
     "node_modules/@moss-dev/moss-core-win32-x64-msvc": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-win32-x64-msvc/-/moss-core-win32-x64-msvc-0.18.0.tgz",
-      "integrity": "sha512-W538bG5RGJOFuO3NQmMZ3kVNREogTcoPRQiPeHC1506ui7V2o0GmgZsXpQ1c58omlbRhcHwhS8oc8QtWdQBHnQ==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-win32-x64-msvc/-/moss-core-win32-x64-msvc-0.19.0.tgz",
+      "integrity": "sha512-2xFB8OQagwAHihg+ktjJxQNdMzMaXwwxIcbyV265ZvBxcjW4odLraumgjsReJr2Z+N5Y4pMVpoLtx+C9K2ThMg==",
       "cpu": [
         "x64"
       ],

--- a/examples/javascript/package.json
+++ b/examples/javascript/package.json
@@ -37,10 +37,11 @@
     "format": "prettier --write .",
     "cached-load": "tsx cached_load_sample.ts",
     "session": "tsx session_sample.ts",
+    "session-cache": "tsx session_cache_sample.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@moss-dev/moss": "^1.1.0",
+    "@moss-dev/moss": "^1.2.1",
     "dotenv": "^17.4.2",
     "openai": "^6.42.0"
   },

--- a/examples/javascript/package.json
+++ b/examples/javascript/package.json
@@ -38,10 +38,11 @@
     "cached-load": "tsx cached_load_sample.ts",
     "session": "tsx session_sample.ts",
     "session-cache": "tsx session_cache_sample.ts",
+    "session-custom-auth": "tsx session_custom_auth_sample.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@moss-dev/moss": "^1.2.1",
+    "@moss-dev/moss": "^1.3.0",
     "dotenv": "^17.4.2",
     "openai": "^6.42.0"
   },

--- a/examples/javascript/session_cache_sample.ts
+++ b/examples/javascript/session_cache_sample.ts
@@ -1,0 +1,99 @@
+/**
+ * Moss SDK Session Cache Sample
+ *
+ * A SessionIndex is local-first: documents are embedded and queried entirely
+ * in-process, with no cloud round trip. `saveToDisk` / `loadFromDisk` let you
+ * persist that in-memory index to the local filesystem and restore it later —
+ * so a session can survive a process restart **without ever leaving the
+ * device** (no `pushIndex`, nothing uploaded).
+ *
+ * This sample:
+ *   1. Builds a session and saves it to local disk.
+ *   2. Restores it into a fresh session (simulating a restart) and queries it.
+ *
+ * The client is constructed with a top-level `cachePath`, which is also where
+ * the anonymous per-device telemetry id is persisted (`<cachePath>/.moss-device-id`).
+ *
+ * Requires `@moss-dev/moss` >= 1.2.1 (client-level `cachePath` option).
+ *
+ * Required Environment Variables:
+ * - MOSS_PROJECT_ID: Your Moss project ID
+ * - MOSS_PROJECT_KEY: Your Moss project key
+ */
+
+import { MossClient, DocumentInfo } from "@moss-dev/moss";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { config } from "dotenv";
+
+// Load environment variables
+config();
+
+// Directory the session is cached to. saveToDisk writes the session under
+// `<CACHE_DIR>/<sessionName>/`; the device-id file lives at `<CACHE_DIR>/.moss-device-id`.
+const CACHE_DIR = "./.moss-session-cache";
+const SESSION_NAME = "session-cache-demo";
+
+async function sessionCacheSample(): Promise<void> {
+  console.log("Moss SDK - Session Cache Sample");
+
+  const projectId = process.env.MOSS_PROJECT_ID;
+  const projectKey = process.env.MOSS_PROJECT_KEY;
+
+  if (!projectId || !projectKey) {
+    console.error("Error: set MOSS_PROJECT_ID and MOSS_PROJECT_KEY in .env");
+    return;
+  }
+
+  // Top-level cachePath: one location, honored by every operation that emits
+  // telemetry (loadIndex, session, …) for the per-device id.
+  const client = new MossClient(projectId, projectKey, { cachePath: CACHE_DIR });
+
+  try {
+    // 1) Build a session and add documents locally (embedded on-device).
+    console.log(`\nBuilding session '${SESSION_NAME}'...`);
+    const session = await client.session(SESSION_NAME);
+    const turns: DocumentInfo[] = [
+      { id: "turn-1", text: "Customer was charged twice for the March renewal." },
+      { id: "turn-2", text: "Agent confirmed a refund for the duplicate charge." },
+      { id: "turn-3", text: "Customer also asked to cancel auto-renew." },
+    ];
+    await session.addDocs(turns);
+    console.log(`Added ${session.docCount} docs (in memory)`);
+
+    // 2) Persist the session to local disk — no cloud round trip.
+    await session.saveToDisk(CACHE_DIR);
+    console.log(`Saved session to ${join(CACHE_DIR, SESSION_NAME)}/ (local only)`);
+
+    // 3) Simulate a restart: open a fresh, empty session and restore from disk.
+    console.log(`\nRestoring into a fresh session (simulating a restart)...`);
+    const restored = await client.session(SESSION_NAME);
+    console.log(`Fresh session docs before restore: ${restored.docCount}`);
+    const loaded = await restored.loadFromDisk(CACHE_DIR);
+    console.log(`Restored ${loaded} docs from disk (${restored.docCount} total)`);
+
+    // 4) Query the restored session — same data, still entirely local.
+    console.log(`\nQuerying the restored session...`);
+    const results = await restored.query("what did the customer want refunded", {
+      topK: 3,
+    });
+    results.docs.forEach((doc) => {
+      console.log(`  [${doc.id}] ${doc.score.toFixed(3)}  ${doc.text}`);
+    });
+
+    // The anonymous per-device id persisted under the client cachePath.
+    const deviceIdFile = join(CACHE_DIR, ".moss-device-id");
+    if (existsSync(deviceIdFile)) {
+      console.log(`\nDevice id (anonymous): ${readFileSync(deviceIdFile, "utf8").trim()}`);
+    }
+
+    console.log(`\nDone — the documents never left the device (no pushIndex).`);
+  } catch (error) {
+    console.error(`Error: ${error}`);
+  }
+}
+
+// Run the example if this file is executed directly
+if (require.main === module) {
+  sessionCacheSample().catch(console.error);
+}

--- a/examples/javascript/session_custom_auth_sample.ts
+++ b/examples/javascript/session_custom_auth_sample.ts
@@ -1,0 +1,103 @@
+/**
+ * Moss SDK — Sessions with a custom IAuthenticator
+ *
+ * Local-first sessions work when the client is constructed with a custom
+ * `IAuthenticator` (short-lived tokens / delegated auth), not just a static
+ * project key. The session authenticates — credential validation on open,
+ * and any `pushIndex` / `loadIndex` — through the same token source, so the
+ * project key never has to live on the device.
+ *
+ * In production your `IAuthenticator` fetches a Moss token from YOUR backend
+ * (which holds the project key): see
+ * https://docs.moss.dev/docs/reference/js/custom-authenticator. To keep this
+ * sample runnable, the demo authenticator calls the Moss identity service
+ * directly — equivalent to what your backend would do server-side.
+ *
+ * Requires `@moss-dev/moss` >= 1.3.0.
+ *
+ * Required Environment Variables:
+ * - MOSS_PROJECT_ID: Your Moss project ID
+ * - MOSS_PROJECT_KEY: Your Moss project key
+ */
+
+import { MossClient, IAuthenticator, AuthToken, DocumentInfo } from "@moss-dev/moss";
+import { config } from "dotenv";
+
+// Load environment variables
+config();
+
+async function sessionCustomAuthSample(): Promise<void> {
+  console.log("Moss SDK - Session + Custom Authenticator Sample");
+
+  const projectId = process.env.MOSS_PROJECT_ID;
+  const projectKey = process.env.MOSS_PROJECT_KEY;
+  if (!projectId || !projectKey) {
+    console.error("Error: set MOSS_PROJECT_ID and MOSS_PROJECT_KEY in .env");
+    return;
+  }
+
+  // A custom IAuthenticator. In production `getAuthToken()` calls YOUR backend
+  // (e.g. POST /api/moss-token), which holds the project key and returns
+  // `{ token, expiresIn }`. Here we call the Moss identity service directly so
+  // the sample is self-contained. The project key never reaches the client in
+  // a real deployment.
+  const identityUrl =
+    process.env.MOSS_AUTH_URL ?? "https://service.usemoss.dev/identity/auth/token";
+  const authenticator: IAuthenticator = {
+    async getAuthToken(): Promise<AuthToken> {
+      const response = await fetch(identityUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectId, projectKey }),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!response.ok) {
+        throw new Error(`Auth failed HTTP ${response.status}: ${await response.text()}`);
+      }
+      return (await response.json()) as AuthToken;
+    },
+    async getAuthHeader(): Promise<string> {
+      const { token } = await this.getAuthToken();
+      return `Bearer ${token}`;
+    },
+  };
+
+  // Build the client with the authenticator instead of a raw project key.
+  const client = new MossClient(projectId, authenticator);
+
+  try {
+    // Opening the session validates credentials with the cloud *through the
+    // authenticator* — proof the custom-auth path is wired end to end.
+    console.log("\nOpening a session via the custom authenticator...");
+    const session = await client.session("custom-auth-session-demo");
+    console.log(`Session open (${session.docCount} existing docs)`);
+
+    // Add and query entirely in-process — no cloud round trip, no key on device.
+    const turns: DocumentInfo[] = [
+      { id: "turn-1", text: "Customer was charged twice for the March renewal." },
+      { id: "turn-2", text: "Agent confirmed a refund for the duplicate charge." },
+      { id: "turn-3", text: "Customer also asked to cancel auto-renew." },
+    ];
+    const { added } = await session.addDocs(turns);
+    console.log(`Added ${added} docs locally (${session.docCount} total)`);
+
+    console.log("\nQuerying the session...");
+    const results = await session.query("what did the customer want refunded", {
+      topK: 3,
+    });
+    results.docs.forEach((doc) => {
+      console.log(`  [${doc.id}] ${doc.score.toFixed(3)}  ${doc.text}`);
+    });
+
+    console.log(
+      "\nDone — session authenticated via a custom IAuthenticator; documents stayed on the device.",
+    );
+  } catch (error) {
+    console.error(`Error: ${error}`);
+  }
+}
+
+// Run the example if this file is executed directly
+if (require.main === module) {
+  sessionCustomAuthSample().catch(console.error);
+}


### PR DESCRIPTION
## What

Adds `examples/javascript/session_cache_sample.ts` — a runnable example of **local session persistence**: build a local-first `SessionIndex`, `saveToDisk`, then restore it into a fresh session with `loadFromDisk` and query it. The session survives a process restart **with no cloud round trip** (no `pushIndex` — nothing is uploaded).

It also shows the client-level `cachePath` option (`new MossClient(id, key, { cachePath })`).
## Why

We had `session_sample.ts` (which ends by pushing to the cloud) but no example of the **fully-local** save/restore flow. This is the common ask for keeping session contents on the device across restarts.

## Changes

- `session_cache_sample.ts` (new)
- `npm run session-cache` script
- bump `@moss-dev/moss` → `^1.2.1` (the client-level `cachePath` option)
- gitignore `.moss-*` sample cache dirs
- README section

## Verified

Runs end-to-end against a real project:

```
Building session 'session-cache-demo'...
Added 3 docs (in memory)
Saved session to .moss-session-cache/session-cache-demo/ (local only)

Restoring into a fresh session (simulating a restart)...
Fresh session docs before restore: 0
Restored 3 docs from disk (3 total)

Querying the restored session...
  [turn-2] 1.000  Agent confirmed a refund for the duplicate charge.
  [turn-3] 0.963  Customer also asked to cancel auto-renew.
  [turn-1] 0.945  Customer was charged twice for the March renewal.

Done — the documents never left the device (no pushIndex).
```