### PR TITLE
release: Moss iOS SDK v0.5.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,8 +35,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "MossC",
-            url: "https://github.com/usemoss/moss/releases/download/v0.4.1/Moss.xcframework.zip",
-            checksum: "49a9c47198ffd75f50b3a91aaa7f416091ebe893a79e1517631a90ecff4b340c"
+            url: "https://github.com/usemoss/moss/releases/download/v0.5.0/Moss.xcframework.zip",
+            checksum: "f1df7a8897c9ff04090536b95471299faa0cffde741e2ff9d6e1974ff62467d2"
         ),
         .target(
             name: "Moss",

--- a/sdks/swift/Sources/Moss/MossClient.swift
+++ b/sdks/swift/Sources/Moss/MossClient.swift
@@ -543,7 +543,9 @@ public final class MossClient: @unchecked Sendable {
                 try withOptionalCString(opts.modelId) { cmodel in
                     var nativeOpts = MossSessionOptions(
                         model_id: cmodel,
-                        vector_quantization: opts.vectorQuantization.rawValue
+                        vector_quantization: opts.vectorQuantization.rawValue,
+                        // C ABI field is uint8_t: 1 = skip auto-load, 0 = keep it.
+                        skip_auto_load_on_init: opts.autoLoadOnInit ? 0 : 1
                     )
                     var raw: OpaquePointer?
                     let r = moss_client_session(h, cname, &nativeOpts, &raw)

--- a/sdks/swift/Sources/Moss/MossTypes.swift
+++ b/sdks/swift/Sources/Moss/MossTypes.swift
@@ -122,10 +122,33 @@ public struct SessionOptions: Sendable {
     public var modelId: String?
     /// On-disk vector precision used by `MossSession.save(toCachePath:)`.
     public var vectorQuantization: VectorQuantization
+    /// When `true` (the default), `MossClient.session(_:)` auto-loads the named
+    /// index from the cloud at creation time (resolve + download + hydrate)
+    /// before returning. Set `false` for a local-only session: creation returns
+    /// immediately and you populate it yourself — e.g. restore from the on-disk
+    /// cache first and only hit the cloud on a miss:
+    ///
+    /// ```swift
+    /// let session = try await client.session(name, options: SessionOptions(autoLoadOnInit: false))
+    /// if try await session.loadFromDisk(cachePath: cachePath) > 0 { return session }
+    /// _ = try await session.loadIndex(name, options: LoadIndexOptions())
+    /// try await session.save(toCachePath: cachePath)
+    /// ```
+    ///
+    /// - Warning: with `false`, the session starts empty until you load it, so
+    ///   calling `addDocs`/`pushIndex` before a load overwrites the cloud index
+    ///   instead of appending to it. Use this only for read / load-then-mutate
+    ///   flows.
+    public var autoLoadOnInit: Bool
 
-    public init(modelId: String? = nil, vectorQuantization: VectorQuantization = .default) {
+    public init(
+        modelId: String? = nil,
+        vectorQuantization: VectorQuantization = .default,
+        autoLoadOnInit: Bool = true
+    ) {
         self.modelId = modelId
         self.vectorQuantization = vectorQuantization
+        self.autoLoadOnInit = autoLoadOnInit
     }
 }
 

--- a/sdks/swift/Sources/Moss/MossTypes.swift
+++ b/sdks/swift/Sources/Moss/MossTypes.swift
@@ -135,10 +135,11 @@ public struct SessionOptions: Sendable {
     /// try await session.save(toCachePath: cachePath)
     /// ```
     ///
-    /// - Warning: with `false`, the session starts empty until you load it, so
-    ///   calling `addDocs`/`pushIndex` before a load overwrites the cloud index
-    ///   instead of appending to it. Use this only for read / load-then-mutate
-    ///   flows.
+    /// - Warning: with `false`, the session starts empty until you load it.
+    ///   `addDocs` only mutates the in-memory session, but calling `pushIndex()`
+    ///   on a session you never loaded pushes that near-empty session to the
+    ///   cloud and overwrites the existing index instead of appending. Use this
+    ///   for read-only or load-then-mutate flows.
     public var autoLoadOnInit: Bool
 
     public init(


### PR DESCRIPTION
Syncs `sdks/swift/Sources/Moss` from `bindings/ios/Sources/Moss` and points `Package.swift` at the `v0.5.0` xcframework (checksum `f1df7a8897c9ff04090536b95471299faa0cffde741e2ff9d6e1974ff62467d2`).

Includes the new `SessionOptions.autoLoadOnInit` option (default `true`); set `false` for disk-first session restore.

**Merge before publishing the draft release `v0.5.0`** so the tag is created at `main`'s HEAD carrying the matching wrapper + manifest.