### PR TITLE
release: Moss iOS SDK v0.6.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,8 +35,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "MossC",
-            url: "https://github.com/usemoss/moss/releases/download/v0.5.0/Moss.xcframework.zip",
-            checksum: "f1df7a8897c9ff04090536b95471299faa0cffde741e2ff9d6e1974ff62467d2"
+            url: "https://github.com/usemoss/moss/releases/download/v0.6.0/Moss.xcframework.zip",
+            checksum: "ac95812b71a999ab7b6155d94d830ffa20c3e216473c4f048cbd6dbc194d0fc1"
         ),
         .target(
             name: "Moss",

--- a/sdks/swift/Sources/Moss/MossClient.swift
+++ b/sdks/swift/Sources/Moss/MossClient.swift
@@ -291,12 +291,22 @@ public final class MossClient: @unchecked Sendable {
         guard opts.topK >= 0 else {
             throw MossError(code: -2, message: "topK must be non-negative; got \(opts.topK)")
         }
+        // Typed filter takes precedence over the legacy JSON string; surface an
+        // encode failure rather than silently dropping the filter. (Parent
+        // grouping is a session-only feature and is ignored here.)
+        var filterJson = opts.filterJson
+        if let f = opts.filter {
+            guard let encoded = f.encoded() else {
+                throw MossError(code: -2, message: "could not encode metadata filter")
+            }
+            filterJson = encoded
+        }
         return try await Task.detached { [self] () throws -> SearchResult in
             let h = try borrowHandle()
             defer { returnHandle() }
             return try indexName.withCString { iname in
                 try query.withCString { q in
-                    try withOptionalCString(opts.filterJson) { filter in
+                    try withOptionalCString(filterJson) { filter in
                         var nativeOpts = MossQueryOptions(
                             top_k: UInt(opts.topK),
                             alpha: opts.alpha,
@@ -543,9 +553,7 @@ public final class MossClient: @unchecked Sendable {
                 try withOptionalCString(opts.modelId) { cmodel in
                     var nativeOpts = MossSessionOptions(
                         model_id: cmodel,
-                        vector_quantization: opts.vectorQuantization.rawValue,
-                        // C ABI field is uint8_t: 1 = skip auto-load, 0 = keep it.
-                        skip_auto_load_on_init: opts.autoLoadOnInit ? 0 : 1
+                        vector_quantization: opts.vectorQuantization.rawValue
                     )
                     var raw: OpaquePointer?
                     let r = moss_client_session(h, cname, &nativeOpts, &raw)
@@ -657,7 +665,8 @@ public final class MossClient: @unchecked Sendable {
                         id: cstr(d.id),
                         score: d.score,
                         text: cstr(d.text),
-                        metadata: parseMetadata(d.metadata, count: d.metadata_count)
+                        metadata: parseMetadata(d.metadata, count: d.metadata_count),
+                        payload: d.payload.map { String(cString: $0) }
                     )
                 )
             }

--- a/sdks/swift/Sources/Moss/MossSession.swift
+++ b/sdks/swift/Sources/Moss/MossSession.swift
@@ -113,35 +113,83 @@ public final class MossSession: @unchecked Sendable {
         }.value
     }
 
-    /// Return documents by id. Passing nil returns all docs in the
-    /// index — convenient for inspection, but expensive on large indexes.
-    /// An empty array returns nothing (vs nil's "everything") so callers
-    /// can distinguish "no filter" from "asked for no docs".
-    public func getDocs(_ docIds: [String]? = nil) async throws -> [DocumentInfo] {
-        try await Task.detached { [self] () throws -> [DocumentInfo] in
+    /// Deterministic fetch — no embedding, no similarity ranking. Returns docs
+    /// by exact id and/or a metadata predicate, optionally sorted and collapsed
+    /// by parent unit. See [GetDocsOptions].
+    public func getDocs(options: GetDocsOptions) async throws -> [DocumentInfo] {
+        let opts = options
+        return try await Task.detached { [self] () throws -> [DocumentInfo] in
             let h = try borrowHandle()
             defer { returnHandle() }
-            if let docIds {
-                return try withCStringArray(docIds) { ptrs in
-                    try Self.runGetDocs(h, idsPtr: ptrs, idCount: UInt(docIds.count))
-                }
-            }
-            return try Self.runGetDocs(h, idsPtr: nil, idCount: 0)
+            return try Self.runGetDocs(h, options: opts)
         }.value
+    }
+
+    /// Return documents by id, in the order requested. Passing nil returns all
+    /// docs (convenient for inspection, expensive on large indexes). An empty
+    /// array returns nothing (vs nil's "everything").
+    public func getDocs(_ docIds: [String]? = nil) async throws -> [DocumentInfo] {
+        try await getDocs(options: GetDocsOptions(ids: docIds))
+    }
+
+    /// Fetch exact ids, returned in the order requested.
+    public func getDocs(ids: [String]) async throws -> [DocumentInfo] {
+        try await getDocs(options: GetDocsOptions(ids: ids))
+    }
+
+    /// Fetch by a metadata predicate — deterministic, ordered, no query vector.
+    public func getDocs(
+        where filter: Filter, sortBy: String? = nil, ascending: Bool = true
+    ) async throws -> [DocumentInfo] {
+        try await getDocs(options: GetDocsOptions(
+            filter: filter, sortBy: sortBy, ascending: ascending))
     }
 
     private static func runGetDocs(
         _ h: OpaquePointer,
-        idsPtr: UnsafePointer<UnsafePointer<CChar>?>?,
-        idCount: UInt
+        options: GetDocsOptions
     ) throws -> [DocumentInfo] {
-        var outDocs: UnsafeMutablePointer<MossDocumentInfo>?
-        var outCount: UInt = 0
-        let r = moss_session_get_docs(h, idsPtr, idCount, &outDocs, &outCount)
-        try MossClient.throwIfErr(r)
-        guard let outDocs else { return [] }
-        defer { moss_free_documents(outDocs, outCount) }
-        return parseDocuments(outDocs, count: outCount)
+        // An explicit empty id list fetches nothing (vs nil = all docs).
+        if let ids = options.ids, ids.isEmpty { return [] }
+        var filterJson: String? = nil
+        if let f = options.filter {
+            guard let encoded = f.encoded() else {
+                throw MossError(code: -2, message: "could not encode metadata filter")
+            }
+            filterJson = encoded
+        }
+        let group = options.groupByParent
+
+        func call(
+            _ idsPtr: UnsafePointer<UnsafePointer<CChar>?>?, _ idCount: UInt
+        ) throws -> [DocumentInfo] {
+            try withOptionalCString(filterJson) { filterC in
+                try withOptionalCString(options.sortBy) { sortC in
+                    try withOptionalCString(group?.parentField) { parentC in
+                        try withOptionalCString(group?.orderField) { orderC in
+                            var outDocs: UnsafeMutablePointer<MossDocumentInfo>?
+                            var outCount: UInt = 0
+                            let r = moss_session_get_docs(
+                                h, idsPtr, idCount, filterC, sortC,
+                                options.ascending, parentC, orderC,
+                                &outDocs, &outCount
+                            )
+                            try MossClient.throwIfErr(r)
+                            guard let outDocs else { return [] }
+                            defer { moss_free_documents(outDocs, outCount) }
+                            return parseDocuments(outDocs, count: outCount)
+                        }
+                    }
+                }
+            }
+        }
+
+        if let ids = options.ids {
+            return try withCStringArray(ids) { ptrs in
+                try call(ptrs, UInt(ids.count))
+            }
+        }
+        return try call(nil, 0)
     }
 
     // ── Query ────────────────────────────────────────────────────────
@@ -193,40 +241,50 @@ public final class MossSession: @unchecked Sendable {
         return try await Task.detached { [self] () throws -> SearchResult in
             let h = try borrowHandle()
             defer { returnHandle() }
+            // Typed filter takes precedence over the legacy JSON string;
+            // surface an encode failure rather than silently dropping the filter.
+            var filterJson = opts.filterJson
+            if let f = opts.filter {
+                guard let encoded = f.encoded() else {
+                    throw MossError(code: -2, message: "could not encode metadata filter")
+                }
+                filterJson = encoded
+            }
+            let group = opts.groupByParent
             return try q.withCString { cq in
-                try withOptionalCString(opts.filterJson) { filter in
-                    // `embedding` is captured by-ref in the closure
-                    // body; need to give it a stable pointer for the
-                    // lifetime of the C call. `withUnsafeBufferPointer`
-                    // on an Array of Float gives us that without
-                    // copying out of Swift-managed storage.
-                    let result: UnsafeMutablePointer<MossSearchResult>? = try {
-                        var resultLocal: UnsafeMutablePointer<MossSearchResult>?
-                        // `MossResult` is emitted by cbindgen as both an
-                        // enum and a typedef; Swift sees that as
-                        // ambiguous. Treat the wire value as Int32 and
-                        // hand it straight to `throwIfErr`.
-                        let invoke: (UnsafePointer<Float>?, Int) -> Int32 = { embPtr, embLen in
-                            var nativeOpts = MossQueryOptions(
-                                top_k: UInt(opts.topK),
-                                alpha: opts.alpha,
-                                filter_json: filter,
-                                embedding: embPtr,
-                                embedding_dim: UInt(embLen)
-                            )
-                            return moss_session_query(h, cq, &nativeOpts, &resultLocal)
+                try withOptionalCString(filterJson) { filter in
+                    try withOptionalCString(group?.parentField) { parentC in
+                        try withOptionalCString(group?.orderField) { orderC in
+                            // `embedding` is captured by-ref; give it a stable
+                            // pointer for the C call via withUnsafeBufferPointer.
+                            let result: UnsafeMutablePointer<MossSearchResult>? = try {
+                                var resultLocal: UnsafeMutablePointer<MossSearchResult>?
+                                // `MossResult` is emitted as both enum + typedef
+                                // (ambiguous in Swift); treat the wire value as Int32.
+                                let invoke: (UnsafePointer<Float>?, Int) -> Int32 = { embPtr, embLen in
+                                    var nativeOpts = MossQueryOptions(
+                                        top_k: UInt(opts.topK),
+                                        alpha: opts.alpha,
+                                        filter_json: filter,
+                                        embedding: embPtr,
+                                        embedding_dim: UInt(embLen)
+                                    )
+                                    return moss_session_query(
+                                        h, cq, &nativeOpts, parentC, orderC, &resultLocal)
+                                }
+                                let r: Int32 = if let emb = embedding {
+                                    emb.withUnsafeBufferPointer { bp in invoke(bp.baseAddress, bp.count) }
+                                } else {
+                                    invoke(nil, 0)
+                                }
+                                try MossClient.throwIfErr(r)
+                                return resultLocal
+                            }()
+                            guard let result else { throw MossClient.lastError(code: -7) }
+                            defer { moss_free_search_result(result) }
+                            return MossClient.parseSearchResult(result.pointee)
                         }
-                        let r: Int32 = if let emb = embedding {
-                            emb.withUnsafeBufferPointer { bp in invoke(bp.baseAddress, bp.count) }
-                        } else {
-                            invoke(nil, 0)
-                        }
-                        try MossClient.throwIfErr(r)
-                        return resultLocal
-                    }()
-                    guard let result else { throw MossClient.lastError(code: -7) }
-                    defer { moss_free_search_result(result) }
-                    return MossClient.parseSearchResult(result.pointee)
+                    }
                 }
             }
         }.value
@@ -371,6 +429,7 @@ public final class MossSession: @unchecked Sendable {
         var embHolders: [UnsafeMutablePointer<Float>] = []
         var metaHolders: [UnsafeMutablePointer<MossMetadataEntry>] = []
         var metaKVHolders: [UnsafeMutablePointer<CChar>] = []
+        var payloadHolders: [UnsafeMutablePointer<CChar>] = []
 
         defer {
             for p in idHolders { free(p) }
@@ -378,6 +437,7 @@ public final class MossSession: @unchecked Sendable {
             for p in embHolders { p.deallocate() }
             for p in metaHolders { p.deallocate() }
             for p in metaKVHolders { free(p) }
+            for p in payloadHolders { free(p) }
         }
 
         var native: [MossDocumentInfo] = []
@@ -420,13 +480,21 @@ public final class MossSession: @unchecked Sendable {
                 metaCount = UInt(m.count)
             }
 
+            var payloadPtr: UnsafeMutablePointer<CChar>? = nil
+            if let p = d.payload {
+                let pp = strdup(p)!
+                payloadHolders.append(pp)
+                payloadPtr = pp
+            }
+
             native.append(MossDocumentInfo(
                 id: idPtr,
                 text: textPtr,
                 metadata: metaPtr,
                 metadata_count: metaCount,
                 embedding: embPtr,
-                embedding_dim: embLen
+                embedding_dim: embLen,
+                payload: payloadPtr
             ))
         }
 
@@ -456,7 +524,8 @@ public final class MossSession: @unchecked Sendable {
                 id: cstr(d.id),
                 text: cstr(d.text),
                 metadata: metadata,
-                embedding: embedding
+                embedding: embedding,
+                payload: d.payload.map { String(cString: $0) }
             ))
         }
         return out

--- a/sdks/swift/Sources/Moss/MossTypes.swift
+++ b/sdks/swift/Sources/Moss/MossTypes.swift
@@ -8,12 +8,25 @@ public struct QueryResult: Sendable {
     /// inspection and filtering. `nil` when the document has no metadata;
     /// values are always strings (matching the native key/value model).
     public let metadata: [String: String]?
+    /// Verbatim structured payload stored at index time (e.g. JSON), returned
+    /// unchanged. `nil` when the document has none. Not embedded or searched.
+    public let payload: String?
 
-    public init(id: String, score: Float, text: String, metadata: [String: String]? = nil) {
+    public init(
+        id: String, score: Float, text: String,
+        metadata: [String: String]? = nil, payload: String? = nil
+    ) {
         self.id = id
         self.score = score
         self.text = text
         self.metadata = metadata
+        self.payload = payload
+    }
+
+    /// Decode `payload` as a `Decodable` type. Returns `nil` when there is no payload.
+    public func decodedPayload<P: Decodable>(_ type: P.Type) throws -> P? {
+        guard let payload, let data = payload.data(using: .utf8) else { return nil }
+        return try JSONDecoder().decode(P.self, from: data)
     }
 }
 
@@ -27,13 +40,24 @@ public struct QueryOptions: Sendable {
     public var topK: Int
     /// Hybrid weight between dense (1.0) and sparse (0.0) scores.
     public var alpha: Float
-    /// Optional metadata filter as a JSON string.
+    /// Typed metadata filter (preferred). Serialized internally; when set it
+    /// takes precedence over `filterJson`.
+    public var filter: Filter?
+    /// Optional metadata filter as a JSON string (escape hatch / legacy).
     public var filterJson: String?
+    /// Collapse sibling hits sharing a parent identifier into one result per
+    /// unit (assembled in `orderField` order). Session queries only.
+    public var groupByParent: ParentGrouping?
 
-    public init(topK: Int = 5, alpha: Float = 0.8, filterJson: String? = nil) {
+    public init(
+        topK: Int = 5, alpha: Float = 0.8, filter: Filter? = nil,
+        filterJson: String? = nil, groupByParent: ParentGrouping? = nil
+    ) {
         self.topK = topK
         self.alpha = alpha
+        self.filter = filter
         self.filterJson = filterJson
+        self.groupByParent = groupByParent
     }
 }
 
@@ -43,12 +67,38 @@ public struct DocumentInfo: Sendable, Codable {
     public let text: String
     public let metadata: [String: String]?
     public let embedding: [Float]?
+    /// Verbatim structured payload (e.g. JSON), stored and returned unchanged.
+    /// Not embedded or searched. Use `decodedPayload(_:)` to read it typed, or
+    /// the `structured:` initializer to write a `Encodable` value.
+    public let payload: String?
 
-    public init(id: String, text: String, metadata: [String: String]? = nil, embedding: [Float]? = nil) {
+    public init(
+        id: String, text: String, metadata: [String: String]? = nil,
+        embedding: [Float]? = nil, payload: String? = nil
+    ) {
         self.id = id
         self.text = text
         self.metadata = metadata
         self.embedding = embedding
+        self.payload = payload
+    }
+
+    /// Store an `Encodable` value as the payload (JSON-encoded).
+    public init<P: Encodable>(
+        id: String, text: String, metadata: [String: String]? = nil,
+        embedding: [Float]? = nil, structured: P
+    ) throws {
+        let data = try JSONEncoder().encode(structured)
+        self.init(
+            id: id, text: text, metadata: metadata, embedding: embedding,
+            payload: String(data: data, encoding: .utf8)
+        )
+    }
+
+    /// Decode `payload` as a `Decodable` type. Returns `nil` when there is no payload.
+    public func decodedPayload<P: Decodable>(_ type: P.Type) throws -> P? {
+        guard let payload, let data = payload.data(using: .utf8) else { return nil }
+        return try JSONDecoder().decode(P.self, from: data)
     }
 }
 
@@ -122,34 +172,10 @@ public struct SessionOptions: Sendable {
     public var modelId: String?
     /// On-disk vector precision used by `MossSession.save(toCachePath:)`.
     public var vectorQuantization: VectorQuantization
-    /// When `true` (the default), `MossClient.session(_:)` auto-loads the named
-    /// index from the cloud at creation time (resolve + download + hydrate)
-    /// before returning. Set `false` for a local-only session: creation returns
-    /// immediately and you populate it yourself — e.g. restore from the on-disk
-    /// cache first and only hit the cloud on a miss:
-    ///
-    /// ```swift
-    /// let session = try await client.session(name, options: SessionOptions(autoLoadOnInit: false))
-    /// if try await session.loadFromDisk(cachePath: cachePath) > 0 { return session }
-    /// _ = try await session.loadIndex(name, options: LoadIndexOptions())
-    /// try await session.save(toCachePath: cachePath)
-    /// ```
-    ///
-    /// - Warning: with `false`, the session starts empty until you load it.
-    ///   `addDocs` only mutates the in-memory session, but calling `pushIndex()`
-    ///   on a session you never loaded pushes that near-empty session to the
-    ///   cloud and overwrites the existing index instead of appending. Use this
-    ///   for read-only or load-then-mutate flows.
-    public var autoLoadOnInit: Bool
 
-    public init(
-        modelId: String? = nil,
-        vectorQuantization: VectorQuantization = .default,
-        autoLoadOnInit: Bool = true
-    ) {
+    public init(modelId: String? = nil, vectorQuantization: VectorQuantization = .default) {
         self.modelId = modelId
         self.vectorQuantization = vectorQuantization
-        self.autoLoadOnInit = autoLoadOnInit
     }
 }
 
@@ -171,5 +197,127 @@ public struct LoadIndexOptions: Sendable {
         self.autoRefresh = autoRefresh
         self.pollingIntervalSeconds = pollingIntervalSeconds
         self.cachePath = cachePath
+    }
+}
+
+// ── Deterministic (exact / "graph") retrieval ────────────────────────────────
+
+/// A typed metadata value used in a `Filter`. Literal-expressible, so you can
+/// pass `"emotion"`, `27`, `0.7`, or `false` directly.
+public enum FilterValue: Sendable, Hashable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+
+    /// JSON-native representation handed to the engine's filter parser.
+    fileprivate var jsonValue: Any {
+        switch self {
+        case .string(let s): return s
+        case .int(let i): return i
+        case .double(let d): return d
+        case .bool(let b): return b
+        }
+    }
+}
+
+extension FilterValue: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) { self = .string(value) }
+}
+extension FilterValue: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int) { self = .int(value) }
+}
+extension FilterValue: ExpressibleByFloatLiteral {
+    public init(floatLiteral value: Double) { self = .double(value) }
+}
+extension FilterValue: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) { self = .bool(value) }
+}
+
+/// A composable metadata predicate. Used to filter both deterministic fetches
+/// (`getDocs(where:)`) and semantic queries. Serialized internally to the
+/// engine's filter format — no JSON to hand-write.
+public indirect enum Filter: Sendable {
+    case equals(String, FilterValue)
+    case notEquals(String, FilterValue)
+    case greaterThan(String, FilterValue)
+    case greaterThanOrEqual(String, FilterValue)
+    case lessThan(String, FilterValue)
+    case lessThanOrEqual(String, FilterValue)
+    case isIn(String, [FilterValue])
+    case notIn(String, [FilterValue])
+    case near(field: String, lat: Double, lng: Double, withinMeters: Double)
+    case and([Filter])
+    case or([Filter])
+    /// Escape hatch: a raw engine-format filter JSON string.
+    case raw(String)
+
+    private func jsonObject() -> Any {
+        func field(_ f: String, _ op: String, _ v: Any) -> [String: Any] {
+            ["field": f, "condition": [op: v]]
+        }
+        switch self {
+        case .equals(let f, let v): return field(f, "$eq", v.jsonValue)
+        case .notEquals(let f, let v): return field(f, "$ne", v.jsonValue)
+        case .greaterThan(let f, let v): return field(f, "$gt", v.jsonValue)
+        case .greaterThanOrEqual(let f, let v): return field(f, "$gte", v.jsonValue)
+        case .lessThan(let f, let v): return field(f, "$lt", v.jsonValue)
+        case .lessThanOrEqual(let f, let v): return field(f, "$lte", v.jsonValue)
+        case .isIn(let f, let vs): return field(f, "$in", vs.map(\.jsonValue))
+        case .notIn(let f, let vs): return field(f, "$nin", vs.map(\.jsonValue))
+        case .near(let f, let lat, let lng, let m):
+            return field(f, "$near", "\(lat),\(lng),\(m)")
+        case .and(let fs): return ["$and": fs.map { $0.jsonObject() }]
+        case .or(let fs): return ["$or": fs.map { $0.jsonObject() }]
+        case .raw(let s):
+            return (try? JSONSerialization.jsonObject(with: Data(s.utf8))) ?? [String: Any]()
+        }
+    }
+
+    /// Serialize to the engine's filter JSON. `nil` only if serialization fails.
+    public func encoded() -> String? {
+        guard let data = try? JSONSerialization.data(withJSONObject: jsonObject()) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+}
+
+/// Collapse sibling documents that share a parent identifier into one logical
+/// result. Siblings are assembled in `orderField` order (numeric-aware).
+public struct ParentGrouping: Sendable {
+    public var parentField: String   // e.g. "unit_id"
+    public var orderField: String    // e.g. "chunk_index"
+
+    public init(parentField: String, orderField: String) {
+        self.parentField = parentField
+        self.orderField = orderField
+    }
+}
+
+/// Options for `MossSession.getDocs(_:)` — the deterministic, non-semantic
+/// fetch path (no query vector, no similarity ranking).
+public struct GetDocsOptions: Sendable {
+    /// Fetch these exact ids, returned in this order. Missing ids are skipped.
+    public var ids: [String]?
+    /// Metadata predicate; documents matching it are returned.
+    public var filter: Filter?
+    /// Metadata field to order results by (numeric-aware). Ignored when `ids`
+    /// already fixes the order.
+    public var sortBy: String?
+    /// Sort direction for `sortBy`.
+    public var ascending: Bool
+    /// Collapse siblings into one result per parent unit.
+    public var groupByParent: ParentGrouping?
+
+    public init(
+        ids: [String]? = nil, filter: Filter? = nil, sortBy: String? = nil,
+        ascending: Bool = true, groupByParent: ParentGrouping? = nil
+    ) {
+        self.ids = ids
+        self.filter = filter
+        self.sortBy = sortBy
+        self.ascending = ascending
+        self.groupByParent = groupByParent
     }
 }

--- a/sdks/swift/Sources/Moss/MossTypes.swift
+++ b/sdks/swift/Sources/Moss/MossTypes.swift
@@ -89,9 +89,11 @@ public struct DocumentInfo: Sendable, Codable {
         embedding: [Float]? = nil, structured: P
     ) throws {
         let data = try JSONEncoder().encode(structured)
+        // JSONEncoder always emits UTF-8; a non-failable decode avoids ever
+        // storing a nil payload on a (impossible) decode failure.
         self.init(
             id: id, text: text, metadata: metadata, embedding: embedding,
-            payload: String(data: data, encoding: .utf8)
+            payload: String(decoding: data, as: UTF8.self)
         )
     }
 
@@ -252,7 +254,7 @@ public indirect enum Filter: Sendable {
     /// Escape hatch: a raw engine-format filter JSON string.
     case raw(String)
 
-    private func jsonObject() -> Any {
+    private func jsonObject() -> Any? {
         func field(_ f: String, _ op: String, _ v: Any) -> [String: Any] {
             ["field": f, "condition": [op: v]]
         }
@@ -267,16 +269,28 @@ public indirect enum Filter: Sendable {
         case .notIn(let f, let vs): return field(f, "$nin", vs.map(\.jsonValue))
         case .near(let f, let lat, let lng, let m):
             return field(f, "$near", "\(lat),\(lng),\(m)")
-        case .and(let fs): return ["$and": fs.map { $0.jsonObject() }]
-        case .or(let fs): return ["$or": fs.map { $0.jsonObject() }]
+        case .and(let fs):
+            // A child that fails to encode must abort the whole filter rather
+            // than be dropped — dropping it would silently broaden the query.
+            let children = fs.compactMap { $0.jsonObject() }
+            guard children.count == fs.count else { return nil }
+            return ["$and": children]
+        case .or(let fs):
+            let children = fs.compactMap { $0.jsonObject() }
+            guard children.count == fs.count else { return nil }
+            return ["$or": children]
         case .raw(let s):
-            return (try? JSONSerialization.jsonObject(with: Data(s.utf8))) ?? [String: Any]()
+            // Invalid raw JSON returns nil (→ encode failure) instead of
+            // falling back to `{}`, which would drop the filter entirely.
+            return try? JSONSerialization.jsonObject(with: Data(s.utf8))
         }
     }
 
-    /// Serialize to the engine's filter JSON. `nil` only if serialization fails.
+    /// Serialize to the engine's filter JSON. `nil` if serialization fails —
+    /// including invalid `.raw` JSON anywhere in the tree.
     public func encoded() -> String? {
-        guard let data = try? JSONSerialization.data(withJSONObject: jsonObject()) else {
+        guard let obj = jsonObject(),
+              let data = try? JSONSerialization.data(withJSONObject: obj) else {
             return nil
         }
         return String(data: data, encoding: .utf8)


### PR DESCRIPTION
Syncs `sdks/swift/Sources/Moss` from `bindings/ios/Sources/Moss` (internal) and points `Package.swift` at the `v0.6.0` xcframework.

- **Tag:** `v0.6.0` · native runtime `sdkVersion` `0.21.0`
- **xcframework checksum:** `ac95812b71a999ab7b6155d94d830ffa20c3e216473c4f048cbd6dbc194d0fc1`

### What's new (graph / exact retrieval)
- Deterministic `getDocs(ids:)` (returns in requested order) + `getDocs(where:sortBy:ascending:)` filter-fetch with no query vector.
- Typed `Filter` DSL (no hand-written JSON) usable in `getDocs(where:)` and `QueryOptions.filter`.
- Parent-unit grouping via `ParentGrouping(parentField:orderField:)` on `getDocs`/`query`.
- Verbatim structured `payload` on `DocumentInfo`/`QueryResult` with Codable sugar.

Wrapper verified byte-identical to the canonical source; `Package.swift` checksum matches the draft release artifact.

> Auto-generated branch by `ios-sdk-release.yml`; PR opened manually because the release PAT can't create PRs. **Merge before publishing the draft release** so the `v0.6.0` tag (cut at `main` HEAD on publish) carries the matching wrapper + manifest.