### PR TITLE
release: Moss iOS SDK v0.6.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,8 +35,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "MossC",
-            url: "https://github.com/usemoss/moss/releases/download/v0.6.0/Moss.xcframework.zip",
-            checksum: "ac95812b71a999ab7b6155d94d830ffa20c3e216473c4f048cbd6dbc194d0fc1"
+            url: "https://github.com/usemoss/moss/releases/download/v0.6.1/Moss.xcframework.zip",
+            checksum: "0e0944e39af5369fb8c45f0621c71e938df74835a4f4529180fe8c0e3cccd86c"
         ),
         .target(
             name: "Moss",

--- a/sdks/swift/Sources/Moss/MossClient.swift
+++ b/sdks/swift/Sources/Moss/MossClient.swift
@@ -553,7 +553,9 @@ public final class MossClient: @unchecked Sendable {
                 try withOptionalCString(opts.modelId) { cmodel in
                     var nativeOpts = MossSessionOptions(
                         model_id: cmodel,
-                        vector_quantization: opts.vectorQuantization.rawValue
+                        vector_quantization: opts.vectorQuantization.rawValue,
+                        // C ABI field is uint8_t: 1 = skip auto-load, 0 = keep it.
+                        skip_auto_load_on_init: opts.autoLoadOnInit ? 0 : 1
                     )
                     var raw: OpaquePointer?
                     let r = moss_client_session(h, cname, &nativeOpts, &raw)

--- a/sdks/swift/Sources/Moss/MossTypes.swift
+++ b/sdks/swift/Sources/Moss/MossTypes.swift
@@ -174,10 +174,34 @@ public struct SessionOptions: Sendable {
     public var modelId: String?
     /// On-disk vector precision used by `MossSession.save(toCachePath:)`.
     public var vectorQuantization: VectorQuantization
+    /// When `true` (the default), `MossClient.session(_:)` auto-loads the named
+    /// index from the cloud at creation time (resolve + download + hydrate)
+    /// before returning. Set `false` for a local-only session: creation returns
+    /// immediately and you populate it yourself — e.g. restore from the on-disk
+    /// cache first and only hit the cloud on a miss:
+    ///
+    /// ```swift
+    /// let session = try await client.session(name, options: SessionOptions(autoLoadOnInit: false))
+    /// if try await session.loadFromDisk(cachePath: cachePath) > 0 { return session }
+    /// _ = try await session.loadIndex(name, options: LoadIndexOptions())
+    /// try await session.save(toCachePath: cachePath)
+    /// ```
+    ///
+    /// - Warning: with `false`, the session starts empty until you load it.
+    ///   `addDocs` only mutates the in-memory session, but calling `pushIndex()`
+    ///   on a session you never loaded pushes that near-empty session to the
+    ///   cloud and overwrites the existing index instead of appending. Use this
+    ///   for read-only or load-then-mutate flows.
+    public var autoLoadOnInit: Bool
 
-    public init(modelId: String? = nil, vectorQuantization: VectorQuantization = .default) {
+    public init(
+        modelId: String? = nil,
+        vectorQuantization: VectorQuantization = .default,
+        autoLoadOnInit: Bool = true
+    ) {
         self.modelId = modelId
         self.vectorQuantization = vectorQuantization
+        self.autoLoadOnInit = autoLoadOnInit
     }
 }
 


### PR DESCRIPTION
Restores `SessionOptions.autoLoadOnInit` (regressed in v0.6.0) on top of the v0.6.0 graph-retrieval release, and points `Package.swift` at the `v0.6.1` xcframework.

- **Tag:** `v0.6.1` · native runtime `sdkVersion` `0.21.1`
- **xcframework checksum:** `0e0944e39af5369fb8c45f0621c71e938df74835a4f4529180fe8c0e3cccd86c`

### Why
`autoLoadOnInit` shipped in v0.5.0 but was merged into `fix/mossvec-save-atomic`, never `main`, so the graph-retrieval branch (and v0.6.0) dropped it — `SessionOptions(autoLoadOnInit:)` failed to compile against v0.6.0. v0.6.1 carries **both** graph/exact retrieval and `autoLoadOnInit`.

### Diff
- `MossTypes.swift`: `SessionOptions.autoLoadOnInit` (default `true`) restored.
- `MossClient.swift`: `session()` wires it to the C ABI `skip_auto_load_on_init` byte.
- `Package.swift`: url + checksum → v0.6.1.

Wrapper verified byte-identical to the canonical source; checksum matches the draft release artifact.

> Auto-generated branch by `ios-sdk-release.yml`; PR opened manually because the release PAT can't create PRs. **Merge before publishing the draft release** so the `v0.6.1` tag carries the matching wrapper + manifest.