### PR TITLE
release: Moss iOS SDK v0.6.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,8 +35,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "MossC",
-            url: "https://github.com/usemoss/moss/releases/download/v0.6.1/Moss.xcframework.zip",
-            checksum: "0e0944e39af5369fb8c45f0621c71e938df74835a4f4529180fe8c0e3cccd86c"
+            url: "https://github.com/usemoss/moss/releases/download/v0.6.2/Moss.xcframework.zip",
+            checksum: "db6bffcd27fec51ad275e27777f2037746a173c5c3e05f1b8d67981229b9e7d1"
         ),
         .target(
             name: "Moss",


### PR DESCRIPTION
Points `Package.swift` at the **v0.6.2** xcframework. Patch release shipping the #308 review fixes, which live in the Rust core + C binding (compiled into the binary), so the Swift wrapper is unchanged from v0.6.1 — this diff is `Package.swift` only.

- **Tag:** `v0.6.2` · native runtime `sdkVersion` `0.21.2`
- **xcframework checksum:** `db6bffcd27fec51ad275e27777f2037746a173c5c3e05f1b8d67981229b9e7d1`

### What changed in the binary
- Parent grouping on `query(…, groupByParent:)` over-fetches candidates and truncates to `topK` units (was collapsing the already-`topK`-truncated result → under-assembled units). `getDocs(where:…, groupByParent:)` remains the complete-units path.
- Deterministic within-unit sibling order (id tie-break on `orderField`).

Checksum verified against the draft release artifact; wrapper verified byte-identical to the canonical source.

> Auto-generated branch by `ios-sdk-release.yml`; PR opened manually (release PAT can't create PRs). **Merge before publishing the draft release.**