### PR TITLE
SDK Updates for Python

### DIFF
--- a/sdks/python/sdk/pyproject.toml
+++ b/sdks/python/sdk/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "moss"
-version = "1.0.0b19"
-description = "Python SDK for semantic search with on-device AI capabilities"
+version = "1.4.1"
+description = "Python SDK for semantic search with on-device AI capabilities, including local-first session indexing"
 readme = "README.md"
 license-files = ["LICENSE"]
 authors = [
@@ -28,7 +28,7 @@ requires-python = ">=3.10"
 dependencies = [
     "typing-extensions>=4.0.0",
     "httpx>=0.25.0",
-    "inferedge-moss-core==0.8.7",
+    "inferedge-moss-core==0.17.0",
 ]
 
 [project.optional-dependencies]
@@ -77,6 +77,13 @@ target-version = ['py310']
 [tool.isort]
 profile = "black"
 line_length = 88
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+markers = [
+    "e2e: integration tests that require real cloud credentials (MOSS_TEST_PROJECT_ID / MOSS_TEST_PROJECT_KEY)",
+    "slow: tests that take a long time to run (large indexes, etc.)",
+]
 
 [tool.mypy]
 python_version = "3.10"

--- a/sdks/python/sdk/src/moss/__init__.py
+++ b/sdks/python/sdk/src/moss/__init__.py
@@ -16,6 +16,16 @@ Example:
     await client.load_index('my-index')
     results = await client.query('my-index', 'search query')
     ```
+
+Local-first session indexing:
+    ```python
+    session = await client.session("call-abc123")
+
+    await session.add_docs([DocumentInfo(id="1", text="Customer asked about billing")])
+    results = await session.query("billing issue")
+
+    result = await session.push_index()
+    ```
 """
 
 from moss_core import (
@@ -24,6 +34,7 @@ from moss_core import (
     IndexInfo,
     IndexStatus,
     IndexStatusValues,
+    LoadIndexesResult,
     ModelRef,
     MutationOptions,
     MutationResult,
@@ -31,17 +42,23 @@ from moss_core import (
     JobPhase,
     JobProgress,
     JobStatusResponse,
+    PushIndexResult,
     QueryOptions,
     QueryResultDocumentInfo,
     SearchResult,
 )
 
-from .client.moss_client import MossClient
+from .client.moss_client import MossClient, ParseFileInput
+from .client.session_index import SessionIndex
 
-__version__ = "1.0.0b19"
+__version__ = "1.4.1"
 
 __all__ = [
     "MossClient",
+    "ParseFileInput",
+    "SessionIndex",
+    "PushIndexResult",
+    "LoadIndexesResult",
     # Core data types
     "DocumentInfo",
     "GetDocumentsOptions",

--- a/sdks/python/sdk/src/moss/__init__.pyi
+++ b/sdks/python/sdk/src/moss/__init__.pyi
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import ClassVar, Dict, List, Optional, Sequence
+from typing import ClassVar, Dict, List, Optional, Sequence, Tuple
 
 
 class MossClient:
@@ -10,11 +10,24 @@ class MossClient:
 
     def __init__(self, project_id: str, project_key: str) -> None: ...
 
+    async def session(
+        self,
+        index_name: str,
+        model_id: Optional[str] = None,
+    ) -> SessionIndex: ...
+
     async def create_index(
         self,
         name: str,
         docs: List[DocumentInfo],
         model_id: Optional[str] = ...,
+    ) -> MutationResult: ...
+
+    async def create_index_from_files(
+        self,
+        name: str,
+        files: List[ParseFileInput],
+        model_id: Optional[str] = None,
     ) -> MutationResult: ...
 
     async def add_docs(
@@ -53,6 +66,15 @@ class MossClient:
 
     async def unload_index(self, name: str) -> None: ...
 
+    async def load_indexes(
+        self,
+        names: List[str],
+        auto_refresh: bool = False,
+        polling_interval_in_seconds: int = 600,
+    ) -> LoadIndexesResult: ...
+
+    async def unload_indexes(self, names: List[str]) -> None: ...
+
     async def query(
         self,
         name: str,
@@ -60,9 +82,83 @@ class MossClient:
         options: Optional[QueryOptions] = None,
     ) -> SearchResult: ...
 
+    async def query_multi_index(
+        self,
+        names: List[str],
+        query: str,
+        options: Optional[QueryOptions] = None,
+    ) -> SearchResult: ...
+
+
+class SessionIndex:
+    """Local in-session index for real-time indexing and querying."""
+
+    name: str
+    doc_count: int
+
+    async def add_docs(
+        self,
+        docs: List[DocumentInfo],
+        options: Optional[MutationOptions] = None,
+    ) -> Tuple[int, int]: ...
+
+    async def delete_docs(self, doc_ids: List[str]) -> int: ...
+
+    async def get_docs(
+        self,
+        options: Optional[GetDocumentsOptions] = None,
+    ) -> List[DocumentInfo]: ...
+
+    async def query(
+        self,
+        query: str,
+        options: Optional[QueryOptions] = None,
+    ) -> SearchResult: ...
+
+    async def push_index(self) -> PushIndexResult: ...
+
+
+class ParseFileInput:
+    """Input descriptor for a single file in the parse pipeline."""
+
+    name: str
+    content_type: str
+    path: Optional[str]
+    data: Optional[bytes]
+
+    def __init__(
+        self,
+        name: str,
+        content_type: str,
+        path: Optional[str] = None,
+        data: Optional[bytes] = None,
+    ) -> None: ...
+
+
+class PushIndexResult:
+    """Result from SessionIndex.push_index()."""
+
+    job_id: str
+    index_name: str
+    doc_count: int
+    status: str
+
+
+class LoadIndexesResult:
+    """Outcome of a load_indexes call. Best-effort across the batch."""
+
+    loaded: List[str]
+    failed: Dict[str, str]
+
+    def __init__(
+        self,
+        loaded: Optional[List[str]] = None,
+        failed: Optional[Dict[str, str]] = None,
+    ) -> None: ...
+
 
 class MutationResult:
-    """Return value from create_index/add_docs/delete_docs."""
+    """Return value from create_index / add_docs / delete_docs."""
 
     job_id: str
     index_name: str
@@ -86,8 +182,6 @@ class GetDocumentsOptions:
 
 
 class JobStatus:
-    """Enum-like class for job status values."""
-
     PENDING_UPLOAD: ClassVar[str]
     UPLOADING: ClassVar[str]
     BUILDING: ClassVar[str]
@@ -98,8 +192,6 @@ class JobStatus:
 
 
 class JobPhase:
-    """Enum-like class for job phase values."""
-
     DOWNLOADING: ClassVar[str]
     DESERIALIZING: ClassVar[str]
     GENERATING_EMBEDDINGS: ClassVar[str]
@@ -111,8 +203,6 @@ class JobPhase:
 
 
 class JobProgress:
-    """Progress update for a job."""
-
     job_id: str
     status: JobStatus
     progress: float
@@ -120,8 +210,6 @@ class JobProgress:
 
 
 class JobStatusResponse:
-    """Full status response from get_job_status."""
-
     job_id: str
     status: JobStatus
     progress: float
@@ -143,12 +231,14 @@ class QueryResultDocumentInfo:
     text: str
     metadata: Optional[Dict[str, str]]
     score: float
+    index_name: Optional[str]
     def __init__(
         self,
         id: str,
         text: str,
         metadata: Optional[Dict[str, str]] = ...,
         score: float = ...,
+        index_name: Optional[str] = ...,
     ) -> None: ...
 
 
@@ -230,6 +320,10 @@ __version__: str
 
 __all__ = [
     "MossClient",
+    "SessionIndex",
+    "ParseFileInput",
+    "PushIndexResult",
+    "LoadIndexesResult",
     "DocumentInfo",
     "GetDocumentsOptions",
     "IndexInfo",

--- a/sdks/python/sdk/src/moss/__init__.pyi
+++ b/sdks/python/sdk/src/moss/__init__.pyi
@@ -2,93 +2,75 @@ from __future__ import annotations
 
 from typing import ClassVar, Dict, List, Optional, Sequence, Tuple
 
-
 class MossClient:
     """Semantic search client for vector similarity operations."""
 
     DEFAULT_MODEL_ID: ClassVar[str]
 
     def __init__(self, project_id: str, project_key: str) -> None: ...
-
     async def session(
         self,
         index_name: str,
         model_id: Optional[str] = None,
     ) -> SessionIndex: ...
-
     async def create_index(
         self,
         name: str,
         docs: List[DocumentInfo],
         model_id: Optional[str] = ...,
     ) -> MutationResult: ...
-
     async def create_index_from_files(
         self,
         name: str,
         files: List[ParseFileInput],
         model_id: Optional[str] = None,
     ) -> MutationResult: ...
-
     async def add_docs(
         self,
         name: str,
         docs: List[DocumentInfo],
         options: Optional[MutationOptions] = None,
     ) -> MutationResult: ...
-
     async def delete_docs(
         self,
         name: str,
         doc_ids: List[str],
     ) -> MutationResult: ...
-
     async def get_job_status(self, job_id: str) -> JobStatusResponse: ...
-
     async def get_index(self, name: str) -> IndexInfo: ...
-
     async def list_indexes(self) -> List[IndexInfo]: ...
-
     async def delete_index(self, name: str) -> bool: ...
-
     async def get_docs(
         self,
         name: str,
         options: Optional[GetDocumentsOptions] = None,
     ) -> List[DocumentInfo]: ...
-
     async def load_index(
         self,
         name: str,
         auto_refresh: bool = False,
         polling_interval_in_seconds: int = 600,
     ) -> str: ...
-
     async def unload_index(self, name: str) -> None: ...
-
     async def load_indexes(
         self,
         names: List[str],
         auto_refresh: bool = False,
         polling_interval_in_seconds: int = 600,
     ) -> LoadIndexesResult: ...
-
     async def unload_indexes(self, names: List[str]) -> None: ...
-
     async def query(
         self,
         name: str,
         query: str,
         options: Optional[QueryOptions] = None,
     ) -> SearchResult: ...
-
     async def query_multi_index(
         self,
         names: List[str],
         query: str,
         options: Optional[QueryOptions] = None,
     ) -> SearchResult: ...
-
 
 class SessionIndex:
     """Local in-session index for real-time indexing and querying."""
@@ -101,22 +83,17 @@ class SessionIndex:
         docs: List[DocumentInfo],
         options: Optional[MutationOptions] = None,
     ) -> Tuple[int, int]: ...
-
     async def delete_docs(self, doc_ids: List[str]) -> int: ...
-
     async def get_docs(
         self,
         options: Optional[GetDocumentsOptions] = None,
     ) -> List[DocumentInfo]: ...
-
     async def query(
         self,
         query: str,
         options: Optional[QueryOptions] = None,
     ) -> SearchResult: ...
-
     async def push_index(self) -> PushIndexResult: ...
-
 
 class ParseFileInput:
     """Input descriptor for a single file in the parse pipeline."""
@@ -134,7 +111,6 @@ class ParseFileInput:
         data: Optional[bytes] = None,
     ) -> None: ...
 
-
 class PushIndexResult:
     """Result from SessionIndex.push_index()."""
 
@@ -142,7 +118,6 @@ class PushIndexResult:
     index_name: str
     doc_count: int
     status: str
-
 
 class LoadIndexesResult:
     """Outcome of a load_indexes call. Best-effort across the batch."""
@@ -156,14 +131,12 @@ class LoadIndexesResult:
         failed: Optional[Dict[str, str]] = None,
     ) -> None: ...
 
-
 class MutationResult:
     """Return value from create_index / add_docs / delete_docs."""
 
     job_id: str
     index_name: str
     doc_count: int
-
 
 class MutationOptions:
     """Options for add_docs (e.g. upsert behavior)."""
@@ -172,14 +145,12 @@ class MutationOptions:
 
     def __init__(self, upsert: Optional[bool] = None) -> None: ...
 
-
 class GetDocumentsOptions:
     """Options for get_docs (e.g. filter by document IDs)."""
 
     doc_ids: Optional[List[str]]
 
     def __init__(self, doc_ids: Optional[List[str]] = None) -> None: ...
-
 
 class JobStatus:
     PENDING_UPLOAD: ClassVar[str]
@@ -189,7 +160,6 @@ class JobStatus:
     FAILED: ClassVar[str]
 
     value: str
-
 
 class JobPhase:
     DOWNLOADING: ClassVar[str]
@@ -201,13 +171,11 @@ class JobPhase:
 
     value: str
 
-
 class JobProgress:
     job_id: str
     status: JobStatus
     progress: float
     current_phase: Optional[JobPhase]
-
 
 class JobStatusResponse:
     job_id: str
@@ -219,12 +187,10 @@ class JobStatusResponse:
     updated_at: str
     completed_at: Optional[str]
 
-
 class ModelRef:
     id: str
     version: str
     def __init__(self, id: str, version: str) -> None: ...
-
 
 class QueryResultDocumentInfo:
     id: str
@@ -241,7 +207,6 @@ class QueryResultDocumentInfo:
         index_name: Optional[str] = ...,
     ) -> None: ...
 
-
 class DocumentInfo:
     id: str
     text: str
@@ -255,7 +220,6 @@ class DocumentInfo:
         embedding: Optional[Sequence[float]] = ...,
     ) -> None: ...
 
-
 class QueryOptions:
     embedding: Optional[Sequence[float]]
     top_k: Optional[int]
@@ -268,7 +232,6 @@ class QueryOptions:
         alpha: Optional[float] = ...,
         filter: Optional[dict] = ...,
     ) -> None: ...
-
 
 class IndexInfo:
     id: str
@@ -291,7 +254,6 @@ class IndexInfo:
         model: ModelRef,
     ) -> None: ...
 
-
 class SearchResult:
     docs: List[QueryResultDocumentInfo]
     query: str
@@ -305,14 +267,12 @@ class SearchResult:
         time_taken_ms: Optional[int] = None,
     ) -> None: ...
 
-
 class IndexStatus:
     NotStarted: ClassVar[str]
     Building: ClassVar[str]
     Ready: ClassVar[str]
     Failed: ClassVar[str]
     def __init__(self, value: str) -> None: ...
-
 
 IndexStatusValues: Dict[str, str]
 

--- a/sdks/python/sdk/src/moss/client/moss_client.py
+++ b/sdks/python/sdk/src/moss/client/moss_client.py
@@ -271,12 +271,24 @@ class MossClient:
             ],
             return_exceptions=True,
         )
+        # Any index whose query-model warm-up failed cannot serve text queries.
+        # Move it from loaded → failed so callers see an accurate picture and
+        # query_multi_index() doesn't silently fail on an "loaded" index.
+        warm_failed: Dict[str, str] = {}
         for name, exc in zip(result.loaded, warm_results):
             if isinstance(exc, Exception):
                 logger.warning(
                     "Failed to warm query model for '%s' after bulk load: %s", name, exc
                 )
-        return result
+                warm_failed[name] = str(exc)
+
+        if not warm_failed:
+            return result
+
+        return LoadIndexesResult(
+            loaded=[n for n in result.loaded if n not in warm_failed],
+            failed={**result.failed, **warm_failed},
+        )
 
     async def unload_indexes(self, names: List[str]) -> None:
         """Bulk-unload many indexes. Idempotent for names that aren't loaded."""
@@ -409,15 +421,22 @@ class MossClient:
         )
 
         # Attempt to load an existing cloud index into the session.
-        # not-found/404 → fresh session (loaded=False); auth/network errors propagate.
+        # On failure, confirm the index truly doesn't exist via get_index() before
+        # treating this as a fresh session — avoids masking artifact-missing, bad-endpoint,
+        # or other non-index-not-found failures that would otherwise silently overwrite
+        # the cloud index on push_index().
         loaded = False
         try:
             await asyncio.to_thread(sess._inner.load_index, index_name)
             loaded = True
-        except RuntimeError as e:
-            msg = str(e).lower()
-            if "not found" not in msg and "404" not in msg:
-                raise
+        except RuntimeError as load_error:
+            try:
+                await asyncio.to_thread(self._manage.get_index, index_name)
+                # get_index succeeded → index exists, so the load failure is real.
+                raise load_error
+            except RuntimeError:
+                # get_index also failed → index genuinely doesn't exist → fresh session.
+                pass
 
         if loaded:
             # Always inspect the model regardless of doc count — an existing empty

--- a/sdks/python/sdk/src/moss/client/moss_client.py
+++ b/sdks/python/sdk/src/moss/client/moss_client.py
@@ -9,8 +9,6 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 
-_DEFAULT_MANAGE_URL = "https://service.usemoss.dev/v1/manage"
-
 from moss_core import (
     ManageClient,
     DocumentInfo,
@@ -29,6 +27,8 @@ from moss_core import (
 from .session_index import SessionIndex
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_MANAGE_URL = "https://service.usemoss.dev/v1/manage"
 
 
 def _get_manage_url() -> str:
@@ -59,6 +59,7 @@ class ParseFileInput:
     Both ``name`` and ``content_type`` are required. Only ``"application/pdf"``
     is currently supported as ``content_type``.
     """
+
     name: str
     content_type: str
     path: Optional[str] = None
@@ -94,8 +95,12 @@ class MossClient:
         self._project_key = project_key
         self._client_id = str(uuid.uuid4())
         manage_url = _get_manage_url()
-        self._manage = ManageClient(project_id, project_key, manage_url, self._client_id)
-        self._manager = IndexManager(project_id, project_key, manage_url, self._client_id)
+        self._manage = ManageClient(
+            project_id, project_key, manage_url, self._client_id
+        )
+        self._manager = IndexManager(
+            project_id, project_key, manage_url, self._client_id
+        )
 
     # -- Mutations --------------------------------------------------
 
@@ -108,7 +113,10 @@ class MossClient:
         """Create a new index and populate it with documents."""
         resolved_model_id = self._resolve_model_id(docs, model_id)
         return await asyncio.to_thread(
-            self._manage.create_index, name, docs, resolved_model_id,
+            self._manage.create_index,
+            name,
+            docs,
+            resolved_model_id,
         )
 
     async def create_index_from_files(
@@ -139,6 +147,7 @@ class MossClient:
                 "Use create_index() with pre-computed embeddings instead."
             )
         from moss_core import ParseFileInput as CoreParseFileInput
+
         core_files = [
             CoreParseFileInput(f.name, f.content_type, path=f.path, data=f.data)
             for f in files
@@ -155,7 +164,10 @@ class MossClient:
     ) -> MutationResult:
         """Add or update documents in an index."""
         return await asyncio.to_thread(
-            self._manage.add_docs, name, docs, options,
+            self._manage.add_docs,
+            name,
+            docs,
+            options,
         )
 
     async def delete_docs(
@@ -165,7 +177,9 @@ class MossClient:
     ) -> MutationResult:
         """Delete documents from an index by their IDs."""
         return await asyncio.to_thread(
-            self._manage.delete_docs, name, doc_ids,
+            self._manage.delete_docs,
+            name,
+            doc_ids,
         )
 
     async def get_job_status(self, job_id: str) -> JobStatusResponse:
@@ -210,7 +224,10 @@ class MossClient:
         """
         try:
             await asyncio.to_thread(
-                self._manager.load_index, name, auto_refresh, polling_interval_in_seconds,
+                self._manager.load_index,
+                name,
+                auto_refresh,
+                polling_interval_in_seconds,
             )
             await asyncio.to_thread(self._manager.load_query_model, name)
             return name
@@ -429,7 +446,12 @@ class MossClient:
         if query_embedding is None:
             try:
                 return await asyncio.to_thread(
-                    self._manager.query_text, name, query, top_k, alpha, filter_,
+                    self._manager.query_text,
+                    name,
+                    query,
+                    top_k,
+                    alpha,
+                    filter_,
                 )
             except RuntimeError as e:
                 if "requires explicit query embeddings" in str(e):
@@ -440,7 +462,13 @@ class MossClient:
                 raise
 
         return await asyncio.to_thread(
-            self._manager.query, name, query, list(query_embedding), top_k, alpha, filter_,
+            self._manager.query,
+            name,
+            query,
+            list(query_embedding),
+            top_k,
+            alpha,
+            filter_,
         )
 
     async def _query_cloud(

--- a/sdks/python/sdk/src/moss/client/moss_client.py
+++ b/sdks/python/sdk/src/moss/client/moss_client.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 
+_DEFAULT_MANAGE_URL = "https://service.usemoss.dev/v1/manage"
+
 from moss_core import (
     ManageClient,
     DocumentInfo,
@@ -29,9 +31,23 @@ from .session_index import SessionIndex
 logger = logging.getLogger(__name__)
 
 
+def _get_manage_url() -> str:
+    """Manage URL, overridable via env for staging/local/self-hosted setups."""
+    return os.getenv("MOSS_CLOUD_API_MANAGE_URL", _DEFAULT_MANAGE_URL)
+
+
 def _get_query_url() -> str:
-    """Query URL, overridable via env for local development."""
-    return os.getenv("MOSS_QUERY_URL", "https://service.usemoss.dev/query")
+    """
+    Query URL resolution order:
+      1. MOSS_CLOUD_QUERY_URL  (legacy name)
+      2. MOSS_QUERY_URL        (shorter alias)
+      3. Derived from manage URL by replacing /v1/manage → /query
+         so staging and self-hosted setups get the right endpoint automatically.
+    """
+    explicit = os.getenv("MOSS_CLOUD_QUERY_URL") or os.getenv("MOSS_QUERY_URL")
+    if explicit:
+        return explicit
+    return _get_manage_url().replace("/v1/manage", "/query")
 
 
 @dataclass
@@ -77,8 +93,9 @@ class MossClient:
         self._project_id = project_id
         self._project_key = project_key
         self._client_id = str(uuid.uuid4())
-        self._manage = ManageClient(project_id, project_key, client_id=self._client_id)
-        self._manager = IndexManager(project_id, project_key, client_id=self._client_id)
+        manage_url = _get_manage_url()
+        self._manage = ManageClient(project_id, project_key, manage_url, self._client_id)
+        self._manager = IndexManager(project_id, project_key, manage_url, self._client_id)
 
     # -- Mutations --------------------------------------------------
 
@@ -217,14 +234,32 @@ class MossClient:
         Bulk-load many indexes into memory. Best-effort: failures on individual
         names do not roll back successes. Returns a LoadIndexesResult with
         ``loaded`` (list of names) and ``failed`` (dict mapping name -> error).
+
+        Mirrors load_index(): warms the query model for each successfully loaded
+        index so text queries work without caller-supplied embeddings.
         """
-        return await asyncio.to_thread(
+        result = await asyncio.to_thread(
             self._manager.load_indexes,
             names,
             auto_refresh,
             polling_interval_in_seconds,
             None,
         )
+        # Warm query models in parallel — load_query_model is idempotent so
+        # indexes sharing a model only pay the cost once.
+        warm_results = await asyncio.gather(
+            *[
+                asyncio.to_thread(self._manager.load_query_model, name)
+                for name in result.loaded
+            ],
+            return_exceptions=True,
+        )
+        for name, exc in zip(result.loaded, warm_results):
+            if isinstance(exc, Exception):
+                logger.warning(
+                    "Failed to warm query model for '%s' after bulk load: %s", name, exc
+                )
+        return result
 
     async def unload_indexes(self, names: List[str]) -> None:
         """Bulk-unload many indexes. Idempotent for names that aren't loaded."""
@@ -356,10 +391,14 @@ class MossClient:
             client_id=self._client_id,
         )
 
-        loaded_doc_count = await asyncio.to_thread(sess._inner.load_index, index_name)
-        if loaded_doc_count > 0:
-            loaded_model_id = sess._inner.model_id
-            if model_id is not None and loaded_model_id != resolved_model_id:
+        await asyncio.to_thread(sess._inner.load_index, index_name)
+        # Always inspect the model after load — an existing empty cloud index still
+        # carries its original model. Gating on doc_count > 0 silently bypasses the
+        # mismatch check for empty indexes and can silently convert a custom or
+        # moss-mediumlm index into a moss-minilm session.
+        loaded_model_id = sess._inner.model_id
+        if loaded_model_id != resolved_model_id:
+            if model_id is not None:
                 raise ValueError(
                     f"Existing session index '{index_name}' uses model_id='{loaded_model_id}', "
                     f"but session() was called with model_id='{resolved_model_id}'. "

--- a/sdks/python/sdk/src/moss/client/moss_client.py
+++ b/sdks/python/sdk/src/moss/client/moss_client.py
@@ -408,20 +408,31 @@ class MossClient:
             client_id=self._client_id,
         )
 
-        await asyncio.to_thread(sess._inner.load_index, index_name)
-        # Always inspect the model after load — an existing empty cloud index still
-        # carries its original model. Gating on doc_count > 0 silently bypasses the
-        # mismatch check for empty indexes and can silently convert a custom or
-        # moss-mediumlm index into a moss-minilm session.
-        loaded_model_id = sess._inner.model_id
-        if loaded_model_id != resolved_model_id:
-            if model_id is not None:
-                raise ValueError(
-                    f"Existing session index '{index_name}' uses model_id='{loaded_model_id}', "
-                    f"but session() was called with model_id='{resolved_model_id}'. "
-                    "Omit model_id to adopt the stored model or pass the matching model_id."
-                )
-            sess._model_id = loaded_model_id
+        # Attempt to load an existing cloud index into the session.
+        # not-found/404 → fresh session (loaded=False); auth/network errors propagate.
+        loaded = False
+        try:
+            await asyncio.to_thread(sess._inner.load_index, index_name)
+            loaded = True
+        except RuntimeError as e:
+            msg = str(e).lower()
+            if "not found" not in msg and "404" not in msg:
+                raise
+
+        if loaded:
+            # Always inspect the model regardless of doc count — an existing empty
+            # cloud index still carries its original model, so gating on doc_count > 0
+            # would silently convert a custom/moss-mediumlm index into a moss-minilm
+            # session.
+            loaded_model_id = sess._inner.model_id
+            if loaded_model_id != resolved_model_id:
+                if model_id is not None:
+                    raise ValueError(
+                        f"Existing session index '{index_name}' uses model_id='{loaded_model_id}', "
+                        f"but session() was called with model_id='{resolved_model_id}'. "
+                        "Omit model_id to adopt the stored model or pass the matching model_id."
+                    )
+                sess._model_id = loaded_model_id
 
         if sess._model_id != "custom":
             await sess._get_embedding_service()

--- a/sdks/python/sdk/src/moss/client/moss_client.py
+++ b/sdks/python/sdk/src/moss/client/moss_client.py
@@ -4,16 +4,18 @@ import asyncio
 import logging
 import os
 import uuid
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 import httpx
+
 from moss_core import (
-    CLOUD_API_MANAGE_URL,
     ManageClient,
     DocumentInfo,
     GetDocumentsOptions,
     IndexInfo,
     IndexManager,
+    LoadIndexesResult,
     MutationOptions,
     MutationResult,
     JobStatusResponse,
@@ -22,20 +24,29 @@ from moss_core import (
     SearchResult,
 )
 
+from .session_index import SessionIndex
+
 logger = logging.getLogger(__name__)
 
 
-def _get_manage_url() -> str:
-    """Manage URL, overridable via env for local development."""
-    return os.getenv("MOSS_CLOUD_API_MANAGE_URL", CLOUD_API_MANAGE_URL)
-
-
 def _get_query_url() -> str:
-    """Query URL, derived from manage URL or overridable via env."""
-    explicit = os.getenv("MOSS_CLOUD_QUERY_URL")
-    if explicit:
-        return explicit
-    return _get_manage_url().replace("/v1/manage", "/query")
+    """Query URL, overridable via env for local development."""
+    return os.getenv("MOSS_QUERY_URL", "https://service.usemoss.dev/query")
+
+
+@dataclass
+class ParseFileInput:
+    """
+    Input descriptor for a single file in the parse pipeline.
+
+    Either ``path`` (filesystem path) or ``data`` (raw bytes) must be provided.
+    Both ``name`` and ``content_type`` are required. Only ``"application/pdf"``
+    is currently supported as ``content_type``.
+    """
+    name: str
+    content_type: str
+    path: Optional[str] = None
+    data: Optional[bytes] = None
 
 
 class MossClient:
@@ -66,15 +77,10 @@ class MossClient:
         self._project_id = project_id
         self._project_key = project_key
         self._client_id = str(uuid.uuid4())
-        manage_url = _get_manage_url()
-        self._manage = ManageClient(
-            project_id, project_key, manage_url, self._client_id
-        )
-        self._manager = IndexManager(
-            project_id, project_key, manage_url, self._client_id
-        )
+        self._manage = ManageClient(project_id, project_key, client_id=self._client_id)
+        self._manager = IndexManager(project_id, project_key, client_id=self._client_id)
 
-    # -- Mutations (via Rust ManageClient) --------------------------
+    # -- Mutations --------------------------------------------------
 
     async def create_index(
         self,
@@ -85,10 +91,43 @@ class MossClient:
         """Create a new index and populate it with documents."""
         resolved_model_id = self._resolve_model_id(docs, model_id)
         return await asyncio.to_thread(
-            self._manage.create_index,
-            name,
-            docs,
-            resolved_model_id,
+            self._manage.create_index, name, docs, resolved_model_id,
+        )
+
+    async def create_index_from_files(
+        self,
+        name: str,
+        files: List[ParseFileInput],
+        model_id: Optional[str] = None,
+    ) -> MutationResult:
+        """
+        Create a new index by uploading raw files (PDFs) for server-side
+        parsing and embedding. At most 20 files per call.
+
+        Args:
+            name: Name for the new index.
+            files: List of ParseFileInput. Each requires ``name`` and
+                   ``content_type``, plus at least one of ``path`` or ``data``.
+            model_id: Embedding model. Defaults to 'moss-minilm'. 'custom' is
+                      not supported (embeddings are generated server-side).
+
+        Raises:
+            ValueError: If model_id is 'custom'.
+        """
+        resolved = model_id or self.DEFAULT_MODEL_ID
+        if resolved == "custom":
+            raise ValueError(
+                "create_index_from_files does not support model_id='custom' — "
+                "the parse pipeline generates embeddings server-side. "
+                "Use create_index() with pre-computed embeddings instead."
+            )
+        from moss_core import ParseFileInput as CoreParseFileInput
+        core_files = [
+            CoreParseFileInput(f.name, f.content_type, path=f.path, data=f.data)
+            for f in files
+        ]
+        return await asyncio.to_thread(
+            self._manage.create_index_from_files, name, core_files, resolved
         )
 
     async def add_docs(
@@ -99,10 +138,7 @@ class MossClient:
     ) -> MutationResult:
         """Add or update documents in an index."""
         return await asyncio.to_thread(
-            self._manage.add_docs,
-            name,
-            docs,
-            options,
+            self._manage.add_docs, name, docs, options,
         )
 
     async def delete_docs(
@@ -112,16 +148,14 @@ class MossClient:
     ) -> MutationResult:
         """Delete documents from an index by their IDs."""
         return await asyncio.to_thread(
-            self._manage.delete_docs,
-            name,
-            doc_ids,
+            self._manage.delete_docs, name, doc_ids,
         )
 
     async def get_job_status(self, job_id: str) -> JobStatusResponse:
         """Get the status of a bulk operation job."""
         return await asyncio.to_thread(self._manage.get_job_status, job_id)
 
-    # -- Read operations (via Rust ManageClient) --------------------
+    # -- Read operations --------------------------------------------
 
     async def get_index(self, name: str) -> IndexInfo:
         """Get information about a specific index."""
@@ -143,7 +177,7 @@ class MossClient:
         """Retrieve documents from an index."""
         return await asyncio.to_thread(self._manage.get_docs, name, options)
 
-    # -- Index loading & querying -----------------------------------
+    # -- Index loading ----------------------------------------------
 
     async def load_index(
         self,
@@ -152,17 +186,14 @@ class MossClient:
         polling_interval_in_seconds: int = 600,
     ) -> str:
         """
-        Downloads an index from the cloud into memory for fast local querying.
+        Download an index from the cloud into memory for fast local querying.
 
         Without load_index(), query() falls back to the cloud API (~100-500ms).
         With load_index(), queries run entirely in-memory (~1-10ms).
         """
         try:
             await asyncio.to_thread(
-                self._manager.load_index,
-                name,
-                auto_refresh,
-                polling_interval_in_seconds,
+                self._manager.load_index, name, auto_refresh, polling_interval_in_seconds,
             )
             await asyncio.to_thread(self._manager.load_query_model, name)
             return name
@@ -176,6 +207,31 @@ class MossClient:
         except RuntimeError as e:
             raise RuntimeError(f"Failed to unload index '{name}': {e}") from e
 
+    async def load_indexes(
+        self,
+        names: List[str],
+        auto_refresh: bool = False,
+        polling_interval_in_seconds: int = 600,
+    ) -> LoadIndexesResult:
+        """
+        Bulk-load many indexes into memory. Best-effort: failures on individual
+        names do not roll back successes. Returns a LoadIndexesResult with
+        ``loaded`` (list of names) and ``failed`` (dict mapping name -> error).
+        """
+        return await asyncio.to_thread(
+            self._manager.load_indexes,
+            names,
+            auto_refresh,
+            polling_interval_in_seconds,
+            None,
+        )
+
+    async def unload_indexes(self, names: List[str]) -> None:
+        """Bulk-unload many indexes. Idempotent for names that aren't loaded."""
+        await asyncio.to_thread(self._manager.unload_indexes, names)
+
+    # -- Querying ---------------------------------------------------
+
     async def query(
         self,
         name: str,
@@ -185,8 +241,8 @@ class MossClient:
         """
         Perform a semantic similarity search.
 
-        If the index is loaded locally (via load_index), queries run in-memory.
-        Otherwise, falls back to the cloud query API.
+        Queries run in-memory if the index is loaded via load_index(),
+        otherwise falls back to the cloud query API.
 
         Args:
             options: Query options (top_k, alpha, embedding, filter). Example filter:
@@ -208,6 +264,114 @@ class MossClient:
             )
         return await self._query_cloud(name, query, options)
 
+    async def query_multi_index(
+        self,
+        names: List[str],
+        query: str,
+        options: Optional[QueryOptions] = None,
+    ) -> SearchResult:
+        """
+        Search across multiple loaded indexes and return the global top-K.
+
+        All requested indexes must be loaded locally and share the same
+        embedding model. Each result document is tagged with its source
+        ``index_name``.
+
+        Multi-index search is embedding-only — ``options.alpha`` is ignored
+        (forced to 1.0) because BM25 IDF is per-corpus and not comparable
+        across indexes.
+
+        Args:
+            names: Names of indexes to search; must be non-empty and all loaded.
+            query: The query text.
+            options: Query options (top_k, embedding, filter). ``alpha`` is ignored.
+        """
+        if not names:
+            raise ValueError("query_multi_index requires at least one index name")
+
+        top_k = getattr(options, "top_k", None) or 10
+        query_embedding = getattr(options, "embedding", None)
+        filter_ = getattr(options, "filter", None)
+
+        if query_embedding is not None:
+            return await asyncio.to_thread(
+                self._manager.query_multi_index,
+                names,
+                query,
+                list(query_embedding),
+                top_k,
+                filter_,
+            )
+
+        try:
+            return await asyncio.to_thread(
+                self._manager.query_multi_index_text,
+                names,
+                query,
+                top_k,
+                filter_,
+            )
+        except RuntimeError as e:
+            if "requires explicit query embeddings" in str(e):
+                raise ValueError(
+                    "One or more indexes use custom embeddings. "
+                    "Query embeddings must be provided via QueryOptions.embedding."
+                ) from e
+            raise
+
+    # -- Sessions ---------------------------------------------------
+
+    async def session(
+        self,
+        index_name: str,
+        model_id: Optional[str] = None,
+    ) -> SessionIndex:
+        """
+        Create or resume a local session index.
+
+        If a cloud index with the given name already exists it is automatically
+        loaded into the session; otherwise the session starts empty. The
+        workflow is the same either way — add docs, query, push at the end.
+
+        Args:
+            index_name: Cloud index name used as the push target.
+            model_id: Embedding model. Defaults to "moss-minilm".
+                      Other options: "moss-mediumlm", "custom".
+
+        Returns:
+            SessionIndex: A local index ready to use.
+
+        Raises:
+            RuntimeError: If project credentials are invalid.
+            ValueError: If an existing cloud index uses a different model than
+                        the explicit model_id passed here.
+        """
+        resolved_model_id = model_id or self.DEFAULT_MODEL_ID
+
+        sess = SessionIndex._create(
+            name=index_name,
+            model_id=resolved_model_id,
+            project_id=self._project_id,
+            project_key=self._project_key,
+            client_id=self._client_id,
+        )
+
+        loaded_doc_count = await asyncio.to_thread(sess._inner.load_index, index_name)
+        if loaded_doc_count > 0:
+            loaded_model_id = sess._inner.model_id
+            if model_id is not None and loaded_model_id != resolved_model_id:
+                raise ValueError(
+                    f"Existing session index '{index_name}' uses model_id='{loaded_model_id}', "
+                    f"but session() was called with model_id='{resolved_model_id}'. "
+                    "Omit model_id to adopt the stored model or pass the matching model_id."
+                )
+            sess._model_id = loaded_model_id
+
+        if sess._model_id != "custom":
+            await sess._get_embedding_service()
+
+        return sess
+
     # -- Internal ---------------------------------------------------
 
     async def _query_local(
@@ -216,24 +380,17 @@ class MossClient:
         query: str,
         options: Optional[QueryOptions],
     ) -> SearchResult:
-        top_k = getattr(options, "top_k", None)
-        if top_k is None:
-            top_k = 5
-        alpha = getattr(options, "alpha", None)
-        if alpha is None:
-            alpha = 0.8
+        top_k_raw = getattr(options, "top_k", None)
+        top_k = 5 if top_k_raw is None else top_k_raw
+        alpha_raw = getattr(options, "alpha", None)
+        alpha = 0.8 if alpha_raw is None else alpha_raw
         query_embedding = getattr(options, "embedding", None)
-        filter = getattr(options, "filter", None)
+        filter_ = getattr(options, "filter", None)
 
         if query_embedding is None:
             try:
                 return await asyncio.to_thread(
-                    self._manager.query_text,
-                    name,
-                    query,
-                    top_k,
-                    alpha,
-                    filter,
+                    self._manager.query_text, name, query, top_k, alpha, filter_,
                 )
             except RuntimeError as e:
                 if "requires explicit query embeddings" in str(e):
@@ -244,13 +401,7 @@ class MossClient:
                 raise
 
         return await asyncio.to_thread(
-            self._manager.query,
-            name,
-            query,
-            list(query_embedding),
-            top_k,
-            alpha,
-            filter,
+            self._manager.query, name, query, list(query_embedding), top_k, alpha, filter_,
         )
 
     async def _query_cloud(

--- a/sdks/python/sdk/src/moss/client/session_index.py
+++ b/sdks/python/sdk/src/moss/client/session_index.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import asyncio
+from typing import List, Optional, Tuple
+
+from moss_core import (
+    AddDocumentsOptions as _RustAddDocumentsOptions,
+    DocumentInfo,
+    GetDocumentsOptions,
+    MutationOptions,
+    QueryOptions,
+    SearchResult,
+    SessionIndex as _RustSessionIndex,
+    PushIndexResult,
+)
+
+
+class SessionIndex:
+    """
+    A local in-session index for real-time indexing and querying.
+
+    All operations (add_docs, delete_docs, query) run entirely in-memory
+    with no cloud round trips. Call push_index() at session end to persist
+    the index to the cloud for bookkeeping and future retrieval.
+
+    Usage telemetry is tracked and reported automatically in the background.
+
+    Example:
+        ```python
+        # Auto-loads from cloud if the index exists, starts fresh if not
+        session = await client.session(index_name="session-abc")
+
+        await session.add_docs([DocumentInfo(id="1", text="Customer asked about billing")])
+        results = await session.query("billing question")
+
+        result = await session.push_index()
+        # optionally: await client.get_job_status(result.job_id)
+        ```
+    """
+
+    def __init__(self, name: str, model_id: str, _inner: "_RustSessionIndex") -> None:
+        self._model_id = model_id
+        self._inner = _inner
+
+    @classmethod
+    def _create(
+        cls,
+        name: str,
+        model_id: str,
+        project_id: str,
+        project_key: str,
+        client_id: Optional[str] = None,
+    ) -> "SessionIndex":
+        inner = _RustSessionIndex(name, model_id, project_id, project_key, client_id)
+        return cls(name, model_id, inner)
+
+    @property
+    def name(self) -> str:
+        """The index name."""
+        return self._inner.name
+
+    @property
+    def doc_count(self) -> int:
+        """Number of documents in the local session index."""
+        return self._inner.doc_count
+
+    async def add_docs(
+        self,
+        docs: List[DocumentInfo],
+        options: Optional[MutationOptions] = None,
+    ) -> Tuple[int, int]:
+        """
+        Add or update documents in the local session index.
+
+        Embeddings are generated locally via Rust core — no cloud round trip.
+
+        Args:
+            docs: Documents to add. When using model_id='custom', each doc
+                  must have .embedding set.
+            options: Mutation options (e.g. upsert behavior).
+
+        Returns:
+            Tuple of (added_count, updated_count).
+        """
+        rust_opts = None
+        if options is not None:
+            upsert = bool(options.upsert) if options.upsert is not None else True
+            rust_opts = _RustAddDocumentsOptions(upsert=upsert)
+        if self._model_id == "custom":
+            embeddings = self._get_custom_embeddings(docs)
+            return await asyncio.to_thread(
+                self._inner.add_docs,
+                docs,
+                embeddings,
+                rust_opts,
+            )
+        return await asyncio.to_thread(self._inner.add_docs_text, docs, rust_opts)
+
+    async def delete_docs(self, doc_ids: List[str]) -> int:
+        """
+        Delete documents from the local session index by their IDs.
+
+        Returns:
+            Number of documents deleted.
+        """
+        return await asyncio.to_thread(self._inner.delete_docs, doc_ids)
+
+    async def get_docs(
+        self,
+        options: Optional[GetDocumentsOptions] = None,
+    ) -> List[DocumentInfo]:
+        """Retrieve documents from the local session index."""
+        return await asyncio.to_thread(self._inner.get_docs, options)
+
+    async def query(
+        self,
+        query: str,
+        options: Optional[QueryOptions] = None,
+    ) -> SearchResult:
+        """
+        Perform a semantic search over the local session index.
+
+        Runs entirely in-memory (~1-10ms). No cloud call.
+
+        Args:
+            query: The search query text.
+            options: Query options (top_k, alpha, embedding, filter). Example filter:
+                QueryOptions(filter={"$and": [
+                    {"field": "type", "condition": {"$eq": "faq"}},
+                    {"field": "priority", "condition": {"$gt": "5"}},
+                ]})
+
+        Returns:
+            SearchResult with scored documents.
+        """
+        top_k = getattr(options, "top_k", None)
+        top_k = top_k if top_k is not None else 5
+        alpha = getattr(options, "alpha", None)
+        alpha = alpha if alpha is not None else 0.8
+        query_embedding = getattr(options, "embedding", None)
+        filter_ = getattr(options, "filter", None)
+
+        if query_embedding is None:
+            if self._model_id == "custom":
+                raise ValueError(
+                    "This session uses custom embeddings. "
+                    "Provide a query embedding via QueryOptions.embedding."
+                )
+            return await asyncio.to_thread(
+                self._inner.query_text,
+                query,
+                top_k,
+                alpha,
+                filter_,
+            )
+
+        return await asyncio.to_thread(
+            self._inner.query,
+            query,
+            top_k,
+            list(query_embedding),
+            alpha,
+            filter_,
+        )
+
+    async def push_index(self) -> PushIndexResult:
+        """
+        Push the local session index to the cloud.
+
+        Sends all documents with their locally-computed embeddings to the
+        backend. The cloud index is created or replaced if one already exists
+        with the same name. No server-side re-embedding occurs.
+
+        Returns:
+            PushIndexResult with job_id, index_name, doc_count, and status.
+        """
+        return await asyncio.to_thread(self._inner.push_index)
+
+    async def _get_embedding_service(self) -> None:
+        if self._model_id != "custom":
+            await asyncio.to_thread(self._inner.load_model)
+
+    def _get_custom_embeddings(self, docs: List[DocumentInfo]) -> List[List[float]]:
+        missing = [doc.id for doc in docs if not getattr(doc, "embedding", None)]
+        if missing:
+            raise ValueError(
+                f"Documents missing .embedding for custom model: {missing}. "
+                "All documents must have .embedding set when using model_id='custom'."
+            )
+        return [list(doc.embedding) for doc in docs]  # type: ignore[arg-type]

--- a/sdks/python/sdk/tests/conftest.py
+++ b/sdks/python/sdk/tests/conftest.py
@@ -29,6 +29,7 @@ CLOUD_TEST_FILES = {
     "test_e2e.py",
     "test_hot_reload.py",
     "test_metadata_filter_e2e.py",
+    "test_new_apis_e2e.py",
     "test_search.py",
 }
 

--- a/sdks/python/sdk/tests/test_client.py
+++ b/sdks/python/sdk/tests/test_client.py
@@ -23,7 +23,7 @@ def raw_mocks():
 
 
 class TestConstructor:
-    def test_manage_client_created_with_manage_url(self, raw_mocks):
+    def test_manage_client_created_with_credentials(self, raw_mocks):
         mock_manage_cls, mock_mgr_cls = raw_mocks
         MossClient("pid", "pkey")
 
@@ -31,9 +31,10 @@ class TestConstructor:
         args = mock_manage_cls.call_args[0]
         assert args[0] == "pid"
         assert args[1] == "pkey"
-        assert "/v1/manage" in args[2]
+        # client_id is passed as a keyword arg; URL is now Rust-internal
+        assert "client_id" in mock_manage_cls.call_args[1]
 
-    def test_index_manager_created_with_manage_url(self, raw_mocks):
+    def test_index_manager_created_with_credentials(self, raw_mocks):
         mock_manage_cls, mock_mgr_cls = raw_mocks
         MossClient("pid", "pkey")
 
@@ -41,7 +42,7 @@ class TestConstructor:
         args = mock_mgr_cls.call_args[0]
         assert args[0] == "pid"
         assert args[1] == "pkey"
-        assert "/v1/manage" in args[2]
+        assert "client_id" in mock_mgr_cls.call_args[1]
 
 
 # -- Model ID Resolution ----------------------------------------------

--- a/sdks/python/sdk/tests/test_client.py
+++ b/sdks/python/sdk/tests/test_client.py
@@ -23,7 +23,7 @@ def raw_mocks():
 
 
 class TestConstructor:
-    def test_manage_client_created_with_credentials(self, raw_mocks):
+    def test_manage_client_created_with_manage_url(self, raw_mocks):
         mock_manage_cls, mock_mgr_cls = raw_mocks
         MossClient("pid", "pkey")
 
@@ -31,10 +31,9 @@ class TestConstructor:
         args = mock_manage_cls.call_args[0]
         assert args[0] == "pid"
         assert args[1] == "pkey"
-        # client_id is passed as a keyword arg; URL is now Rust-internal
-        assert "client_id" in mock_manage_cls.call_args[1]
+        assert "/v1/manage" in args[2]
 
-    def test_index_manager_created_with_credentials(self, raw_mocks):
+    def test_index_manager_created_with_manage_url(self, raw_mocks):
         mock_manage_cls, mock_mgr_cls = raw_mocks
         MossClient("pid", "pkey")
 
@@ -42,7 +41,17 @@ class TestConstructor:
         args = mock_mgr_cls.call_args[0]
         assert args[0] == "pid"
         assert args[1] == "pkey"
-        assert "client_id" in mock_mgr_cls.call_args[1]
+        assert "/v1/manage" in args[2]
+
+    def test_manage_url_env_override_propagated(self, raw_mocks):
+        mock_manage_cls, _ = raw_mocks
+        with patch.dict(
+            "os.environ",
+            {"MOSS_CLOUD_API_MANAGE_URL": "https://staging.example.com/v1/manage"},
+        ):
+            MossClient("pid", "pkey")
+        args = mock_manage_cls.call_args[0]
+        assert args[2] == "https://staging.example.com/v1/manage"
 
 
 # -- Model ID Resolution ----------------------------------------------

--- a/sdks/python/sdk/tests/test_client_extended.py
+++ b/sdks/python/sdk/tests/test_client_extended.py
@@ -10,7 +10,7 @@ import pytest
 from importlib.metadata import version
 
 from moss import __version__, MossClient
-from moss.client.moss_client import _get_manage_url, _get_query_url
+from moss.client.moss_client import _get_query_url
 
 
 class TestUnloadIndex:
@@ -123,7 +123,7 @@ class TestDictToSearchResult:
             "timeTakenMs": 42,
         }
 
-        result = MossClient._dict_to_search_result(data)
+        result = MossClient._dict_to_search_result(data)  # type: ignore[attr-defined]
 
         assert len(result.docs) == 2
         assert result.docs[0].id == "d1"
@@ -138,7 +138,7 @@ class TestDictToSearchResult:
     def test_empty_docs(self):
         data = {"docs": [], "query": "", "indexName": "idx", "timeTakenMs": 0}
 
-        result = MossClient._dict_to_search_result(data)
+        result = MossClient._dict_to_search_result(data)  # type: ignore[attr-defined]
 
         assert len(result.docs) == 0
 
@@ -149,7 +149,7 @@ class TestDictToSearchResult:
             "indexName": "idx",
         }
 
-        result = MossClient._dict_to_search_result(data)
+        result = MossClient._dict_to_search_result(data)  # type: ignore[attr-defined]
 
         assert result.docs[0].id == "d1"
         assert result.docs[0].text == ""
@@ -172,7 +172,7 @@ class TestDictToSearchResult:
             "indexName": "idx",
         }
 
-        result = MossClient._dict_to_search_result(data)
+        result = MossClient._dict_to_search_result(data)  # type: ignore[attr-defined]
 
         assert result.docs[0].metadata == {"city": "NYC"}
 
@@ -186,7 +186,7 @@ class TestDictToSearchResult:
             "indexName": "idx",
         }
 
-        result = MossClient._dict_to_search_result(data)
+        result = MossClient._dict_to_search_result(data)  # type: ignore[attr-defined]
 
         assert result.docs[0].score == pytest.approx(0.95, abs=1e-6)
         assert result.docs[1].score == pytest.approx(1.0, abs=1e-6)
@@ -194,7 +194,7 @@ class TestDictToSearchResult:
     def test_missing_top_level_fields(self):
         data = {}
 
-        result = MossClient._dict_to_search_result(data)
+        result = MossClient._dict_to_search_result(data)  # type: ignore[attr-defined]
 
         assert len(result.docs) == 0
         assert result.query == ""
@@ -205,34 +205,15 @@ class TestDictToSearchResult:
 class TestURLHelpers:
     """Tests for URL helper functions."""
 
-    def test_get_manage_url_default(self):
+    def test_get_query_url_default(self):
         with patch.dict("os.environ", {}, clear=True):
-            url = _get_manage_url()
-            assert "/v1/manage" in url
-
-    def test_get_manage_url_from_env(self):
-        with patch.dict(
-            "os.environ",
-            {"MOSS_CLOUD_API_MANAGE_URL": "https://custom.example.com/v1/manage"},
-        ):
-            url = _get_manage_url()
-            assert url == "https://custom.example.com/v1/manage"
-
-    def test_get_query_url_derived(self):
-        with patch.dict(
-            "os.environ",
-            {"MOSS_CLOUD_API_MANAGE_URL": "https://api.example.com/v1/manage"},
-        ):
             url = _get_query_url()
-            assert url == "https://api.example.com/query"
+            assert "usemoss.dev" in url
 
-    def test_get_query_url_explicit(self):
+    def test_get_query_url_overridden_by_env(self):
         with patch.dict(
             "os.environ",
-            {
-                "MOSS_CLOUD_API_MANAGE_URL": "https://api.example.com/v1/manage",
-                "MOSS_CLOUD_QUERY_URL": "https://query.example.com/search",
-            },
+            {"MOSS_QUERY_URL": "https://query.example.com/search"},
         ):
             url = _get_query_url()
             assert url == "https://query.example.com/search"
@@ -345,9 +326,9 @@ class TestClientIdGeneration:
     """Tests for client ID generation."""
 
     def test_client_id_is_uuid(self, client):
-        assert client._client_id is not None
-        assert len(client._client_id) == 36
-        assert client._client_id.count("-") == 4
+        assert client._client_id is not None  # type: ignore[attr-defined]
+        assert len(client._client_id) == 36  # type: ignore[attr-defined]
+        assert client._client_id.count("-") == 4  # type: ignore[attr-defined]
 
     def test_client_id_is_unique(self):
         with (
@@ -356,15 +337,15 @@ class TestClientIdGeneration:
         ):
             c1 = MossClient("pid", "pkey")
             c2 = MossClient("pid", "pkey")
-            assert c1._client_id != c2._client_id
+            assert c1._client_id != c2._client_id  # type: ignore[attr-defined]
 
 
 class TestProjectCredentials:
     """Tests for project credential handling."""
 
     def test_credentials_stored(self, client):
-        assert client._project_id == "test-project"
-        assert client._project_key == "test-key"
+        assert client._project_id == "test-project"  # type: ignore[attr-defined]
+        assert client._project_key == "test-key"  # type: ignore[attr-defined]
 
     def test_credentials_passed_to_manage_client(self):
         with (

--- a/sdks/python/sdk/tests/test_client_extended.py
+++ b/sdks/python/sdk/tests/test_client_extended.py
@@ -10,7 +10,7 @@ import pytest
 from importlib.metadata import version
 
 from moss import __version__, MossClient
-from moss.client.moss_client import _get_query_url
+from moss.client.moss_client import _get_manage_url, _get_query_url
 
 
 class TestUnloadIndex:
@@ -205,18 +205,58 @@ class TestDictToSearchResult:
 class TestURLHelpers:
     """Tests for URL helper functions."""
 
-    def test_get_query_url_default(self):
+    def test_get_manage_url_default(self):
         with patch.dict("os.environ", {}, clear=True):
-            url = _get_query_url()
-            assert "usemoss.dev" in url
+            url = _get_manage_url()
+            assert "/v1/manage" in url
 
-    def test_get_query_url_overridden_by_env(self):
+    def test_get_manage_url_overridden_by_env(self):
         with patch.dict(
             "os.environ",
-            {"MOSS_QUERY_URL": "https://query.example.com/search"},
+            {"MOSS_CLOUD_API_MANAGE_URL": "https://custom.example.com/v1/manage"},
+        ):
+            url = _get_manage_url()
+            assert url == "https://custom.example.com/v1/manage"
+
+    def test_get_query_url_derived_from_manage_url(self):
+        with patch.dict(
+            "os.environ",
+            {"MOSS_CLOUD_API_MANAGE_URL": "https://api.example.com/v1/manage"},
+            clear=True,
+        ):
+            url = _get_query_url()
+            assert url == "https://api.example.com/query"
+
+    def test_get_query_url_legacy_env_var(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "MOSS_CLOUD_API_MANAGE_URL": "https://api.example.com/v1/manage",
+                "MOSS_CLOUD_QUERY_URL": "https://query.example.com/search",
+            },
         ):
             url = _get_query_url()
             assert url == "https://query.example.com/search"
+
+    def test_get_query_url_alias_env_var(self):
+        with patch.dict(
+            "os.environ",
+            {"MOSS_QUERY_URL": "https://query.alias.com/search"},
+            clear=True,
+        ):
+            url = _get_query_url()
+            assert url == "https://query.alias.com/search"
+
+    def test_get_query_url_legacy_takes_precedence_over_alias(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "MOSS_CLOUD_QUERY_URL": "https://legacy.example.com/q",
+                "MOSS_QUERY_URL": "https://alias.example.com/q",
+            },
+        ):
+            url = _get_query_url()
+            assert url == "https://legacy.example.com/q"
 
 
 class TestVersionExport:

--- a/sdks/python/sdk/tests/test_cloud_fallback.py
+++ b/sdks/python/sdk/tests/test_cloud_fallback.py
@@ -51,9 +51,7 @@ class TestCloudFallbackQuery:
         index_name = generate_unique_index_name("test-cloud-fallback")
 
         # Create the index with documents
-        docs = [
-            DocumentInfo(id=doc["id"], text=doc["text"]) for doc in TEST_DOCUMENTS
-        ]
+        docs = [DocumentInfo(id=doc["id"], text=doc["text"]) for doc in TEST_DOCUMENTS]
         await moss_client.create_index(index_name, docs, TEST_MODEL_ID)
 
         yield index_name

--- a/sdks/python/sdk/tests/test_create_index_versions.py
+++ b/sdks/python/sdk/tests/test_create_index_versions.py
@@ -17,6 +17,7 @@ from moss import DocumentInfo, MossClient
 
 from .constants import TEST_MODEL_ID, TEST_PROJECT_ID, TEST_PROJECT_KEY
 
+
 # Define the structure to hold benchmark results
 @dataclass
 class BenchResult:
@@ -24,6 +25,7 @@ class BenchResult:
     time_ms: Optional[float]
     success: bool
     error: str = ""
+
 
 # Generate dummy documents with random deterministic text of fixed length 200
 def _gen_docs(n: int, seed: int = 1337) -> List[DocumentInfo]:
@@ -34,22 +36,27 @@ def _gen_docs(n: int, seed: int = 1337) -> List[DocumentInfo]:
     for i in range(n):
         txt = "".join(rng.choices(alphabet, k=200)).strip()
         try:
-            docs.append(DocumentInfo(id=f"doc_{i}", text=f"Document {i}. {txt}", metadata={}))
+            docs.append(
+                DocumentInfo(id=f"doc_{i}", text=f"Document {i}. {txt}", metadata={})
+            )
         except TypeError:
             docs.append(DocumentInfo(id=f"doc_{i}", text=f"Document {i}. {txt}"))
     return docs
 
+
 # Try to create index and measure time taken
-async def _try_create_index(client: MossClient, index_name: str, doc_count: int) -> BenchResult:
+async def _try_create_index(
+    client: MossClient, index_name: str, doc_count: int
+) -> BenchResult:
     """Try to create index, return result with timing."""
     docs = _gen_docs(doc_count)
-    
+
     # Cleanup before
     try:
         await client.delete_index(index_name)
     except Exception:
         pass
-    
+
     t0 = time.perf_counter()
     try:
         result = client.create_index(index_name, docs, TEST_MODEL_ID)
@@ -57,67 +64,80 @@ async def _try_create_index(client: MossClient, index_name: str, doc_count: int)
             success = bool(await result)
         else:
             success = bool(result)
-        
+
         t1 = time.perf_counter()
         time_ms = (t1 - t0) * 1000.0
-        
+
         # Cleanup after
         try:
             await client.delete_index(index_name)
         except Exception:
             pass
-        
-        return BenchResult(doc_count=doc_count, time_ms=time_ms, success=success, error="")
-        
+
+        return BenchResult(
+            doc_count=doc_count, time_ms=time_ms, success=success, error=""
+        )
+
     except Exception as e:
         t1 = time.perf_counter()
         time_ms = (t1 - t0) * 1000.0
         err_msg = str(e)
-        
+
         # Cleanup after (best effort)
         try:
             await client.delete_index(index_name)
         except Exception:
             pass
-        
-        return BenchResult(doc_count=doc_count, time_ms=time_ms, success=False, error=err_msg)
+
+        return BenchResult(
+            doc_count=doc_count, time_ms=time_ms, success=False, error=err_msg
+        )
+
 
 # The main benchmark test
 @pytest.mark.asyncio
 async def test_create_index_versions_bench():
     """Benchmark create_index across different doc counts."""
-    doc_counts = [600 , 800, 1000]
-    
+    doc_counts = [600, 800, 1000]
+
     try:
         sdk_version = pkg_version("moss")
     except PackageNotFoundError:
         sdk_version = "unknown"
-    
+
     client = MossClient(TEST_PROJECT_ID, TEST_PROJECT_KEY)
     results = []
-    
+
     for i, n in enumerate(doc_counts, 1):
-        print(f"Running experiment {i}/{len(doc_counts)}: create_index with {n} documents...", flush=True, end=" ")
+        print(
+            f"Running experiment {i}/{len(doc_counts)}: create_index with {n} documents...",
+            flush=True,
+            end=" ",
+        )
         index_name = f"createindex-bench-{sdk_version.replace('.', '_')}-{n}"
         result = await _try_create_index(client, index_name, n)
         results.append(result)
-        
+
         if result.success:
             print(f"✅ {result.time_ms:.1f}ms", flush=True)
         else:
             print("❌ failed", flush=True)
-    
+
     # Print table
     print("\n" + "=" * 110)
     print(" CREATE_INDEX BENCHMARK")
     print("=" * 110)
-    print(f"{'sdk_version':<16} | {'docs':>6} | {'time_taken':>14} | {'status':<15} | notes")
+    print(
+        f"{'sdk_version':<16} | {'docs':>6} | {'time_taken':>14} | {'status':<15} | notes"
+    )
     print("-" * 110)
-    
+
     for r in results:
         if r.success:
             time_str = f"{r.time_ms:.1f} ms" if r.time_ms else "N/A"
-            print(f"{sdk_version:<16} | {r.doc_count:>6} | {time_str:>14} | {'✅ success':<15} |")
+            print(
+                f"{sdk_version:<16} | {r.doc_count:>6} | {time_str:>14} | {'✅ success':<15} |"
+            )
         else:
             # Classify error
             err_lower = r.error.lower()
@@ -127,8 +147,10 @@ async def test_create_index_versions_bench():
                 note = "not supported (payload too large)"
             else:
                 note = r.error[:60] + "..." if len(r.error) > 60 else r.error
-            
+
             time_str = f"{r.time_ms:.1f} ms" if r.time_ms else "N/A"
-            print(f"{sdk_version:<16} | {r.doc_count:>6} | {time_str:>14} | {'❌ failed':<15} | {note}")
-    
+            print(
+                f"{sdk_version:<16} | {r.doc_count:>6} | {time_str:>14} | {'❌ failed':<15} | {note}"
+            )
+
     print("=" * 110 + "\n")

--- a/sdks/python/sdk/tests/test_e2e.py
+++ b/sdks/python/sdk/tests/test_e2e.py
@@ -50,15 +50,19 @@ def generate_docs(count: int, seed: int = 42) -> List[DocumentInfo]:
     docs = []
     for i in range(count):
         topic = rng.choice(DOC_TOPICS)
-        docs.append(DocumentInfo(
-            id=f"doc-{i}",
-            text=f"{topic} (variation {i}, seed {rng.randint(0, 100000)})",
-        ))
+        docs.append(
+            DocumentInfo(
+                id=f"doc-{i}",
+                text=f"{topic} (variation {i}, seed {rng.randint(0, 100000)})",
+            )
+        )
     return docs
 
 
 def generate_docs_with_embeddings(
-    count: int, dimension: int, seed: int = 42,
+    count: int,
+    dimension: int,
+    seed: int = 42,
 ) -> List[DocumentInfo]:
     rng = random.Random(seed)
     docs = []
@@ -68,15 +72,18 @@ def generate_docs_with_embeddings(
         magnitude = sum(x * x for x in embedding) ** 0.5
         if magnitude > 0:
             embedding = [x / magnitude for x in embedding]
-        docs.append(DocumentInfo(
-            id=f"doc-{i}",
-            text=f"{topic} (variation {i})",
-            embedding=embedding,
-        ))
+        docs.append(
+            DocumentInfo(
+                id=f"doc-{i}",
+                text=f"{topic} (variation {i})",
+                embedding=embedding,
+            )
+        )
     return docs
 
 
 # -- Fixtures ----------------------------------------------------------
+
 
 @pytest.fixture
 def client():
@@ -84,6 +91,7 @@ def client():
 
 
 # -- Tests -------------------------------------------------------------
+
 
 @pytest.mark.e2e
 class TestBulkCreateIndex:
@@ -284,7 +292,9 @@ class TestReadOps:
             all_docs = await client.get_docs(index_name)
             assert len(all_docs) == 5_000
 
-            specific = await client.get_docs(index_name, GetDocumentsOptions(doc_ids=["doc-0", "doc-100", "doc-999"]))
+            specific = await client.get_docs(
+                index_name, GetDocumentsOptions(doc_ids=["doc-0", "doc-100", "doc-999"])
+            )
             assert len(specific) == 3
             ids = {d.id for d in specific}
             assert ids == {"doc-0", "doc-100", "doc-999"}

--- a/sdks/python/sdk/tests/test_hot_reload.py
+++ b/sdks/python/sdk/tests/test_hot_reload.py
@@ -31,9 +31,7 @@ def moss_client():
 
 
 class TestHotReloadE2E:
-
     class TestLoadIndexWithAutoRefresh:
-
         @pytest_asyncio.fixture
         async def test_index(self, moss_client):
             """Create a test index for auto-refresh tests."""
@@ -72,9 +70,7 @@ class TestHotReloadE2E:
             assert loaded_name == test_index
 
         @pytest.mark.asyncio
-        async def test_accept_custom_polling_interval(
-            self, moss_client, test_index
-        ):
+        async def test_accept_custom_polling_interval(self, moss_client, test_index):
             """Should accept custom polling interval."""
             # Load with a custom polling interval (5 minutes)
             loaded_name = await moss_client.load_index(
@@ -183,9 +179,7 @@ class TestHotReloadE2E:
                 pass
 
         @pytest.mark.asyncio
-        async def test_query_cloud_when_index_not_loaded(
-            self, moss_client, test_index
-        ):
+        async def test_query_cloud_when_index_not_loaded(self, moss_client, test_index):
             """Should query cloud when index is not loaded locally."""
             # Query without loading - should fall back to cloud
             results = await moss_client.query(
@@ -199,9 +193,7 @@ class TestHotReloadE2E:
             assert len(results.docs) > 0
 
         @pytest.mark.asyncio
-        async def test_query_locally_after_loading_index(
-            self, moss_client, test_index
-        ):
+        async def test_query_locally_after_loading_index(self, moss_client, test_index):
             """Should query locally after loading index."""
             # Load index locally
             await moss_client.load_index(test_index)

--- a/sdks/python/sdk/tests/test_metadata_filter_e2e.py
+++ b/sdks/python/sdk/tests/test_metadata_filter_e2e.py
@@ -27,12 +27,59 @@ from tests.constants import (
 )
 
 FILTER_DOCS = [
-    DocumentInfo(id="f1", text="Cheap coffee shop in downtown New York with great espresso",        metadata={"city": "NYC",   "price": "12", "category": "food", "location": "40.7580,-73.9855"}),
-    DocumentInfo(id="f2", text="High-end sushi restaurant in central Tokyo with omakase menu",      metadata={"city": "Tokyo", "price": "45", "category": "food", "location": "35.6762,139.6503"}),
-    DocumentInfo(id="f3", text="Weekly tech meetup and hackathon event in New York coworking space", metadata={"city": "NYC",   "price": "0",  "category": "tech", "location": "40.6892,-74.0445"}),
-    DocumentInfo(id="f4", text="Art museum and cultural exhibition in the heart of Paris",          metadata={"city": "Paris", "price": "20", "category": "culture", "location": "48.8566,2.3522"}),
-    DocumentInfo(id="f5", text="Popular street food market in Tokyo with yakitori and ramen stalls", metadata={"city": "Tokyo", "price": "8",  "category": "food", "location": "35.6595,139.7004"}),
-    DocumentInfo(id="f6", text="General document with no metadata attached for edge case testing"),
+    DocumentInfo(
+        id="f1",
+        text="Cheap coffee shop in downtown New York with great espresso",
+        metadata={
+            "city": "NYC",
+            "price": "12",
+            "category": "food",
+            "location": "40.7580,-73.9855",
+        },
+    ),
+    DocumentInfo(
+        id="f2",
+        text="High-end sushi restaurant in central Tokyo with omakase menu",
+        metadata={
+            "city": "Tokyo",
+            "price": "45",
+            "category": "food",
+            "location": "35.6762,139.6503",
+        },
+    ),
+    DocumentInfo(
+        id="f3",
+        text="Weekly tech meetup and hackathon event in New York coworking space",
+        metadata={
+            "city": "NYC",
+            "price": "0",
+            "category": "tech",
+            "location": "40.6892,-74.0445",
+        },
+    ),
+    DocumentInfo(
+        id="f4",
+        text="Art museum and cultural exhibition in the heart of Paris",
+        metadata={
+            "city": "Paris",
+            "price": "20",
+            "category": "culture",
+            "location": "48.8566,2.3522",
+        },
+    ),
+    DocumentInfo(
+        id="f5",
+        text="Popular street food market in Tokyo with yakitori and ramen stalls",
+        metadata={
+            "city": "Tokyo",
+            "price": "8",
+            "category": "food",
+            "location": "35.6595,139.7004",
+        },
+    ),
+    DocumentInfo(
+        id="f6", text="General document with no metadata attached for edge case testing"
+    ),
 ]
 
 
@@ -42,11 +89,13 @@ def moss_client():
 
 
 async def query_ids(client, name, filt):
-    result = await client.query(name, "food and restaurants", QueryOptions(top_k=10, filter=filt))
+    result = await client.query(
+        name, "food and restaurants", QueryOptions(top_k=10, filter=filt)
+    )
     return sorted(d.id for d in result.docs)
 
-class TestMetadataFilterE2E:
 
+class TestMetadataFilterE2E:
     @pytest_asyncio.fixture(scope="class")
     async def loaded_index(self, moss_client):
         index_name = generate_unique_index_name("test-filter-e2e")
@@ -60,93 +109,131 @@ class TestMetadataFilterE2E:
 
     @pytest.mark.asyncio
     async def test_eq(self, moss_client, loaded_index):
-        ids = await query_ids(moss_client, loaded_index, {"field": "city", "condition": {"$eq": "NYC"}})
+        ids = await query_ids(
+            moss_client, loaded_index, {"field": "city", "condition": {"$eq": "NYC"}}
+        )
         assert ids == ["f1", "f3"]
 
     @pytest.mark.asyncio
     async def test_ne(self, moss_client, loaded_index):
-        ids = await query_ids(moss_client, loaded_index, {"field": "city", "condition": {"$ne": "NYC"}})
+        ids = await query_ids(
+            moss_client, loaded_index, {"field": "city", "condition": {"$ne": "NYC"}}
+        )
         assert ids == ["f2", "f4", "f5"]
 
     @pytest.mark.asyncio
     async def test_gt_numeric(self, moss_client, loaded_index):
-        ids = await query_ids(moss_client, loaded_index, {"field": "price", "condition": {"$gt": "10"}})
+        ids = await query_ids(
+            moss_client, loaded_index, {"field": "price", "condition": {"$gt": "10"}}
+        )
         assert ids == ["f1", "f2", "f4"]
 
     @pytest.mark.asyncio
     async def test_lt_int_coercion(self, moss_client, loaded_index):
-        ids = await query_ids(moss_client, loaded_index, {"field": "price", "condition": {"$lt": 15}})
+        ids = await query_ids(
+            moss_client, loaded_index, {"field": "price", "condition": {"$lt": 15}}
+        )
         assert ids == ["f1", "f3", "f5"]
 
     @pytest.mark.asyncio
     async def test_gte(self, moss_client, loaded_index):
-        ids = await query_ids(moss_client, loaded_index, {"field": "price", "condition": {"$gte": "20"}})
+        ids = await query_ids(
+            moss_client, loaded_index, {"field": "price", "condition": {"$gte": "20"}}
+        )
         assert ids == ["f2", "f4"]
 
     @pytest.mark.asyncio
     async def test_lte(self, moss_client, loaded_index):
-        ids = await query_ids(moss_client, loaded_index, {"field": "price", "condition": {"$lte": "8"}})
+        ids = await query_ids(
+            moss_client, loaded_index, {"field": "price", "condition": {"$lte": "8"}}
+        )
         assert ids == ["f3", "f5"]
 
     @pytest.mark.asyncio
     async def test_in(self, moss_client, loaded_index):
-        ids = await query_ids(moss_client, loaded_index, {"field": "city", "condition": {"$in": ["NYC", "Paris"]}})
+        ids = await query_ids(
+            moss_client,
+            loaded_index,
+            {"field": "city", "condition": {"$in": ["NYC", "Paris"]}},
+        )
         assert ids == ["f1", "f3", "f4"]
 
     @pytest.mark.asyncio
     async def test_nin(self, moss_client, loaded_index):
-        ids = await query_ids(moss_client, loaded_index, {"field": "city", "condition": {"$nin": ["NYC"]}})
+        ids = await query_ids(
+            moss_client, loaded_index, {"field": "city", "condition": {"$nin": ["NYC"]}}
+        )
         assert ids == ["f2", "f4", "f5"]
 
     @pytest.mark.asyncio
     async def test_and(self, moss_client, loaded_index):
-        filt = {"$and": [
-            {"field": "city", "condition": {"$eq": "NYC"}},
-            {"field": "category", "condition": {"$eq": "food"}},
-        ]}
+        filt = {
+            "$and": [
+                {"field": "city", "condition": {"$eq": "NYC"}},
+                {"field": "category", "condition": {"$eq": "food"}},
+            ]
+        }
         ids = await query_ids(moss_client, loaded_index, filt)
         assert ids == ["f1"]
 
     @pytest.mark.asyncio
     async def test_or(self, moss_client, loaded_index):
-        filt = {"$or": [
-            {"field": "city", "condition": {"$eq": "Paris"}},
-            {"field": "category", "condition": {"$eq": "tech"}},
-        ]}
+        filt = {
+            "$or": [
+                {"field": "city", "condition": {"$eq": "Paris"}},
+                {"field": "category", "condition": {"$eq": "tech"}},
+            ]
+        }
         ids = await query_ids(moss_client, loaded_index, filt)
         assert ids == ["f3", "f4"]
 
     @pytest.mark.asyncio
     async def test_nested_and_or(self, moss_client, loaded_index):
-        filt = {"$and": [
-            {"$or": [
-                {"field": "city", "condition": {"$eq": "NYC"}},
-                {"field": "city", "condition": {"$eq": "Tokyo"}},
-            ]},
-            {"field": "category", "condition": {"$eq": "food"}},
-        ]}
+        filt = {
+            "$and": [
+                {
+                    "$or": [
+                        {"field": "city", "condition": {"$eq": "NYC"}},
+                        {"field": "city", "condition": {"$eq": "Tokyo"}},
+                    ]
+                },
+                {"field": "category", "condition": {"$eq": "food"}},
+            ]
+        }
         ids = await query_ids(moss_client, loaded_index, filt)
         assert ids == ["f1", "f2", "f5"]
 
     @pytest.mark.asyncio
     async def test_no_matches(self, moss_client, loaded_index):
-        ids = await query_ids(moss_client, loaded_index, {"field": "city", "condition": {"$eq": "Berlin"}})
+        ids = await query_ids(
+            moss_client, loaded_index, {"field": "city", "condition": {"$eq": "Berlin"}}
+        )
         assert ids == []
 
     @pytest.mark.asyncio
     async def test_skips_docs_without_metadata(self, moss_client, loaded_index):
-        ids = await query_ids(moss_client, loaded_index, {"field": "city", "condition": {"$ne": "nonexistent"}})
+        ids = await query_ids(
+            moss_client,
+            loaded_index,
+            {"field": "city", "condition": {"$ne": "nonexistent"}},
+        )
         assert "f6" not in ids
 
     @pytest.mark.asyncio
     async def test_no_filter_returns_all(self, moss_client, loaded_index):
-        result = await moss_client.query(loaded_index, "food and restaurants", QueryOptions(top_k=10))
+        result = await moss_client.query(
+            loaded_index, "food and restaurants", QueryOptions(top_k=10)
+        )
         assert len(result.docs) == 6
 
     @pytest.mark.asyncio
     async def test_near_within_range(self, moss_client, loaded_index):
         # 10km around Times Square — f1 (~0km) and f3 (~8.7km, Statue of Liberty area)
-        ids = await query_ids(moss_client, loaded_index, {"field": "location", "condition": {"$near": "40.7580,-73.9855,10000"}})
+        ids = await query_ids(
+            moss_client,
+            loaded_index,
+            {"field": "location", "condition": {"$near": "40.7580,-73.9855,10000"}},
+        )
         assert "f1" in ids
         assert "f3" in ids
         assert "f2" not in ids  # Tokyo
@@ -155,12 +242,20 @@ class TestMetadataFilterE2E:
     @pytest.mark.asyncio
     async def test_near_excludes_far(self, moss_client, loaded_index):
         # 5km around Times Square — only f1 (~0km), not f3 (~8.7km)
-        ids = await query_ids(moss_client, loaded_index, {"field": "location", "condition": {"$near": "40.7580,-73.9855,5000"}})
+        ids = await query_ids(
+            moss_client,
+            loaded_index,
+            {"field": "location", "condition": {"$near": "40.7580,-73.9855,5000"}},
+        )
         assert "f1" in ids
         assert "f3" not in ids
 
     @pytest.mark.asyncio
     async def test_near_skips_docs_without_location(self, moss_client, loaded_index):
         # f6 has no metadata at all — should not appear
-        ids = await query_ids(moss_client, loaded_index, {"field": "location", "condition": {"$near": "40.7580,-73.9855,10000000"}})
+        ids = await query_ids(
+            moss_client,
+            loaded_index,
+            {"field": "location", "condition": {"$near": "40.7580,-73.9855,10000000"}},
+        )
         assert "f6" not in ids

--- a/sdks/python/sdk/tests/test_new_apis_e2e.py
+++ b/sdks/python/sdk/tests/test_new_apis_e2e.py
@@ -1,0 +1,299 @@
+"""
+E2E integration tests for new SDK APIs:
+  - MossClient.session()
+  - MossClient.load_indexes() / unload_indexes()
+  - MossClient.query_multi_index()
+  - MossClient.create_index_from_files()
+  - ParseFileInput
+
+Requires MOSS_TEST_PROJECT_ID and MOSS_TEST_PROJECT_KEY in .env.
+Run with:
+    pytest tests/test_new_apis_e2e.py -v -s -m e2e
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from moss import (
+    DocumentInfo,
+    GetDocumentsOptions,
+    MossClient,
+    MutationOptions,
+    ParseFileInput,
+    QueryOptions,
+)
+from moss.client.session_index import SessionIndex
+
+from .constants import (
+    TEST_PROJECT_ID,
+    TEST_PROJECT_KEY,
+    TEST_MODEL_ID,
+    generate_unique_index_name,
+)
+
+
+@pytest.fixture
+def client():
+    return MossClient(TEST_PROJECT_ID, TEST_PROJECT_KEY)
+
+
+TURN_DOCS = [
+    DocumentInfo(id="turn-1", text="Customer was charged twice for the March renewal."),
+    DocumentInfo(id="turn-2", text="Agent confirmed a refund for the duplicate charge."),
+    DocumentInfo(id="turn-3", text="Customer also asked to cancel auto-renew."),
+    DocumentInfo(id="turn-4", text="Agent placed a cancellation request for auto-renew."),
+]
+
+PRODUCT_DOCS = [
+    DocumentInfo(id="p1", text="Sony WH-1000XM5 wireless headphones, 30-hour battery.", metadata={"category": "electronics"}),
+    DocumentInfo(id="p2", text="Bose QuietComfort Ultra over-ear headphones with ANC.", metadata={"category": "electronics"}),
+    DocumentInfo(id="p3", text="Apple AirPods Max with spatial audio and H1 chip.", metadata={"category": "electronics"}),
+]
+
+REVIEW_DOCS = [
+    DocumentInfo(id="r1", text="Battery lasts a full transatlantic week easily.", metadata={"stars": "5"}),
+    DocumentInfo(id="r2", text="Comfortable but noise cancelling could be stronger.", metadata={"stars": "4"}),
+    DocumentInfo(id="r3", text="Sound quality incredible but battery degrades after a year.", metadata={"stars": "3"}),
+]
+
+
+# ---------------------------------------------------------------------------
+# SessionIndex
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+class TestSessionE2E:
+    @pytest.mark.asyncio
+    async def test_session_full_lifecycle(self, client):
+        """
+        Create a fresh session, add docs, query, delete a doc,
+        retrieve by ID, push to cloud, then clean up.
+        """
+        index_name = generate_unique_index_name("e2e-session")
+
+        try:
+            # Open a new (empty) session
+            session = await client.session(index_name)
+            assert isinstance(session, SessionIndex)
+            assert session.name == index_name
+            assert session.doc_count == 0
+
+            # Add documents
+            added, updated = await session.add_docs(TURN_DOCS)
+            assert added == len(TURN_DOCS)
+            assert updated == 0
+            assert session.doc_count == len(TURN_DOCS)
+
+            # Query in-memory
+            results = await session.query(
+                "what did the customer want refunded",
+                QueryOptions(top_k=3),
+            )
+            assert len(results.docs) > 0
+            assert all(hasattr(d, "score") for d in results.docs)
+            print(f"\n  session query returned {len(results.docs)} docs")
+
+            # get_docs — all
+            all_docs = await session.get_docs()
+            assert len(all_docs) == len(TURN_DOCS)
+
+            # get_docs — specific IDs
+            specific = await session.get_docs(GetDocumentsOptions(doc_ids=["turn-1", "turn-2"]))
+            assert len(specific) == 2
+            ids = {d.id for d in specific}
+            assert ids == {"turn-1", "turn-2"}
+
+            # delete_docs
+            deleted = await session.delete_docs(["turn-4"])
+            assert deleted == 1
+            assert session.doc_count == len(TURN_DOCS) - 1
+
+            # Confirm deleted doc is gone
+            after_delete = await session.get_docs(GetDocumentsOptions(doc_ids=["turn-4"]))
+            assert len(after_delete) == 0
+
+            # Push to cloud
+            t0 = time.perf_counter()
+            pushed = await session.push_index()
+            elapsed = time.perf_counter() - t0
+            assert pushed.job_id
+            assert pushed.index_name == index_name
+            assert pushed.doc_count == len(TURN_DOCS) - 1
+            print(f"\n  session push: {elapsed:.1f}s, job={pushed.job_id}, status={pushed.status}")
+
+        finally:
+            try:
+                await client.delete_index(index_name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_session_upsert_updates_existing_doc(self, client):
+        """Upserting a doc with the same ID should increment updated, not added."""
+        index_name = generate_unique_index_name("e2e-session-upsert")
+
+        try:
+            session = await client.session(index_name)
+            await session.add_docs([DocumentInfo(id="doc-1", text="original text")])
+            assert session.doc_count == 1
+
+            added, updated = await session.add_docs(
+                [DocumentInfo(id="doc-1", text="updated text")],
+                MutationOptions(upsert=True),
+            )
+            assert added == 0
+            assert updated == 1
+            assert session.doc_count == 1
+
+        finally:
+            try:
+                await client.delete_index(index_name)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_session_resumes_existing_cloud_index(self, client):
+        """Opening a session for an already-pushed index loads existing docs."""
+        index_name = generate_unique_index_name("e2e-session-resume")
+
+        try:
+            # First session — push to cloud
+            session1 = await client.session(index_name)
+            await session1.add_docs(TURN_DOCS[:2])
+            await session1.push_index()
+
+            # Second session — should resume with existing doc count
+            session2 = await client.session(index_name)
+            assert session2.doc_count == 2
+
+        finally:
+            try:
+                await client.delete_index(index_name)
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# load_indexes / unload_indexes / query_multi_index
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+class TestMultiIndexE2E:
+    @pytest.mark.asyncio
+    async def test_load_indexes_and_query_multi_index(self, client):
+        """
+        Create two indexes, bulk-load them, query across both,
+        then bulk-unload and clean up.
+        """
+        ts = generate_unique_index_name("e2e-multi")
+        products_idx = f"{ts}-products"
+        reviews_idx = f"{ts}-reviews"
+
+        try:
+            # Create both indexes
+            await client.create_index(products_idx, PRODUCT_DOCS, TEST_MODEL_ID)
+            await client.create_index(reviews_idx, REVIEW_DOCS, TEST_MODEL_ID)
+
+            # Bulk-load
+            load_result = await client.load_indexes([products_idx, reviews_idx])
+            assert products_idx in load_result.loaded
+            assert reviews_idx in load_result.loaded
+            assert isinstance(load_result.failed, dict)
+            assert len(load_result.failed) == 0
+            print(f"\n  loaded: {load_result.loaded}")
+
+            # Multi-index query — global top-K across both
+            results = await client.query_multi_index(
+                load_result.loaded,
+                "wireless headphones battery life",
+                QueryOptions(top_k=5),
+            )
+            assert len(results.docs) > 0
+            # Each result must carry its source index name
+            for doc in results.docs:
+                assert doc.index_name in (products_idx, reviews_idx)
+            print(f"\n  multi-index query: {len(results.docs)} docs across {len(load_result.loaded)} indexes")
+
+            # Bulk-unload
+            await client.unload_indexes(load_result.loaded)
+
+        finally:
+            for name in (products_idx, reviews_idx):
+                try:
+                    await client.delete_index(name)
+                except Exception:
+                    pass
+
+    @pytest.mark.asyncio
+    async def test_load_indexes_partial_failure(self, client):
+        """
+        A non-existent name in load_indexes should appear in failed,
+        not raise an exception.
+        """
+        real_idx = generate_unique_index_name("e2e-multi-partial")
+
+        try:
+            await client.create_index(real_idx, PRODUCT_DOCS, TEST_MODEL_ID)
+
+            load_result = await client.load_indexes([real_idx, "does-not-exist-xyz"])
+            assert real_idx in load_result.loaded
+            assert "does-not-exist-xyz" in load_result.failed
+            print(f"\n  partial load — loaded: {load_result.loaded}, failed: {load_result.failed}")
+
+            await client.unload_indexes(load_result.loaded)
+
+        finally:
+            try:
+                await client.delete_index(real_idx)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_unload_indexes_idempotent(self, client):
+        """Unloading indexes that aren't loaded should not raise."""
+        await client.unload_indexes(["not-loaded-a", "not-loaded-b"])
+
+    @pytest.mark.asyncio
+    async def test_query_multi_index_empty_names_raises(self, client):
+        with pytest.raises(ValueError, match="at least one index name"):
+            await client.query_multi_index([], "query")
+
+
+# ---------------------------------------------------------------------------
+# ParseFileInput + create_index_from_files
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+class TestCreateIndexFromFilesE2E:
+    @pytest.mark.asyncio
+    async def test_create_index_from_files_custom_model_raises(self, client):
+        """create_index_from_files must reject model_id='custom' before hitting the server."""
+        with pytest.raises(ValueError, match="custom"):
+            await client.create_index_from_files(
+                "irrelevant",
+                [ParseFileInput(name="f.pdf", content_type="application/pdf", data=b"%PDF-1.4")],
+                model_id="custom",
+            )
+
+
+class TestParseFileInput:
+    def test_path_only(self):
+        f = ParseFileInput(name="doc.pdf", content_type="application/pdf", path="/tmp/doc.pdf")
+        assert f.name == "doc.pdf"
+        assert f.content_type == "application/pdf"
+        assert f.path == "/tmp/doc.pdf"
+        assert f.data is None
+
+    def test_data_only(self):
+        raw = b"%PDF-1.4 ..."
+        f = ParseFileInput(name="doc.pdf", content_type="application/pdf", data=raw)
+        assert f.data == raw
+        assert f.path is None
+
+    def test_defaults_are_none(self):
+        f = ParseFileInput(name="x.pdf", content_type="application/pdf")
+        assert f.path is None
+        assert f.data is None

--- a/sdks/python/sdk/tests/test_new_apis_e2e.py
+++ b/sdks/python/sdk/tests/test_new_apis_e2e.py
@@ -42,27 +42,56 @@ def client():
 
 TURN_DOCS = [
     DocumentInfo(id="turn-1", text="Customer was charged twice for the March renewal."),
-    DocumentInfo(id="turn-2", text="Agent confirmed a refund for the duplicate charge."),
+    DocumentInfo(
+        id="turn-2", text="Agent confirmed a refund for the duplicate charge."
+    ),
     DocumentInfo(id="turn-3", text="Customer also asked to cancel auto-renew."),
-    DocumentInfo(id="turn-4", text="Agent placed a cancellation request for auto-renew."),
+    DocumentInfo(
+        id="turn-4", text="Agent placed a cancellation request for auto-renew."
+    ),
 ]
 
 PRODUCT_DOCS = [
-    DocumentInfo(id="p1", text="Sony WH-1000XM5 wireless headphones, 30-hour battery.", metadata={"category": "electronics"}),
-    DocumentInfo(id="p2", text="Bose QuietComfort Ultra over-ear headphones with ANC.", metadata={"category": "electronics"}),
-    DocumentInfo(id="p3", text="Apple AirPods Max with spatial audio and H1 chip.", metadata={"category": "electronics"}),
+    DocumentInfo(
+        id="p1",
+        text="Sony WH-1000XM5 wireless headphones, 30-hour battery.",
+        metadata={"category": "electronics"},
+    ),
+    DocumentInfo(
+        id="p2",
+        text="Bose QuietComfort Ultra over-ear headphones with ANC.",
+        metadata={"category": "electronics"},
+    ),
+    DocumentInfo(
+        id="p3",
+        text="Apple AirPods Max with spatial audio and H1 chip.",
+        metadata={"category": "electronics"},
+    ),
 ]
 
 REVIEW_DOCS = [
-    DocumentInfo(id="r1", text="Battery lasts a full transatlantic week easily.", metadata={"stars": "5"}),
-    DocumentInfo(id="r2", text="Comfortable but noise cancelling could be stronger.", metadata={"stars": "4"}),
-    DocumentInfo(id="r3", text="Sound quality incredible but battery degrades after a year.", metadata={"stars": "3"}),
+    DocumentInfo(
+        id="r1",
+        text="Battery lasts a full transatlantic week easily.",
+        metadata={"stars": "5"},
+    ),
+    DocumentInfo(
+        id="r2",
+        text="Comfortable but noise cancelling could be stronger.",
+        metadata={"stars": "4"},
+    ),
+    DocumentInfo(
+        id="r3",
+        text="Sound quality incredible but battery degrades after a year.",
+        metadata={"stars": "3"},
+    ),
 ]
 
 
 # ---------------------------------------------------------------------------
 # SessionIndex
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.e2e
 class TestSessionE2E:
@@ -101,7 +130,9 @@ class TestSessionE2E:
             assert len(all_docs) == len(TURN_DOCS)
 
             # get_docs — specific IDs
-            specific = await session.get_docs(GetDocumentsOptions(doc_ids=["turn-1", "turn-2"]))
+            specific = await session.get_docs(
+                GetDocumentsOptions(doc_ids=["turn-1", "turn-2"])
+            )
             assert len(specific) == 2
             ids = {d.id for d in specific}
             assert ids == {"turn-1", "turn-2"}
@@ -112,7 +143,9 @@ class TestSessionE2E:
             assert session.doc_count == len(TURN_DOCS) - 1
 
             # Confirm deleted doc is gone
-            after_delete = await session.get_docs(GetDocumentsOptions(doc_ids=["turn-4"]))
+            after_delete = await session.get_docs(
+                GetDocumentsOptions(doc_ids=["turn-4"])
+            )
             assert len(after_delete) == 0
 
             # Push to cloud
@@ -122,7 +155,9 @@ class TestSessionE2E:
             assert pushed.job_id
             assert pushed.index_name == index_name
             assert pushed.doc_count == len(TURN_DOCS) - 1
-            print(f"\n  session push: {elapsed:.1f}s, job={pushed.job_id}, status={pushed.status}")
+            print(
+                f"\n  session push: {elapsed:.1f}s, job={pushed.job_id}, status={pushed.status}"
+            )
 
         finally:
             try:
@@ -180,6 +215,7 @@ class TestSessionE2E:
 # load_indexes / unload_indexes / query_multi_index
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.e2e
 class TestMultiIndexE2E:
     @pytest.mark.asyncio
@@ -215,7 +251,9 @@ class TestMultiIndexE2E:
             # Each result must carry its source index name
             for doc in results.docs:
                 assert doc.index_name in (products_idx, reviews_idx)
-            print(f"\n  multi-index query: {len(results.docs)} docs across {len(load_result.loaded)} indexes")
+            print(
+                f"\n  multi-index query: {len(results.docs)} docs across {len(load_result.loaded)} indexes"
+            )
 
             # Bulk-unload
             await client.unload_indexes(load_result.loaded)
@@ -241,7 +279,9 @@ class TestMultiIndexE2E:
             load_result = await client.load_indexes([real_idx, "does-not-exist-xyz"])
             assert real_idx in load_result.loaded
             assert "does-not-exist-xyz" in load_result.failed
-            print(f"\n  partial load — loaded: {load_result.loaded}, failed: {load_result.failed}")
+            print(
+                f"\n  partial load — loaded: {load_result.loaded}, failed: {load_result.failed}"
+            )
 
             await client.unload_indexes(load_result.loaded)
 
@@ -266,6 +306,7 @@ class TestMultiIndexE2E:
 # ParseFileInput + create_index_from_files
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.e2e
 class TestCreateIndexFromFilesE2E:
     @pytest.mark.asyncio
@@ -274,14 +315,20 @@ class TestCreateIndexFromFilesE2E:
         with pytest.raises(ValueError, match="custom"):
             await client.create_index_from_files(
                 "irrelevant",
-                [ParseFileInput(name="f.pdf", content_type="application/pdf", data=b"%PDF-1.4")],
+                [
+                    ParseFileInput(
+                        name="f.pdf", content_type="application/pdf", data=b"%PDF-1.4"
+                    )
+                ],
                 model_id="custom",
             )
 
 
 class TestParseFileInput:
     def test_path_only(self):
-        f = ParseFileInput(name="doc.pdf", content_type="application/pdf", path="/tmp/doc.pdf")
+        f = ParseFileInput(
+            name="doc.pdf", content_type="application/pdf", path="/tmp/doc.pdf"
+        )
         assert f.name == "doc.pdf"
         assert f.content_type == "application/pdf"
         assert f.path == "/tmp/doc.pdf"

--- a/sdks/python/sdk/tests/test_search.py
+++ b/sdks/python/sdk/tests/test_search.py
@@ -17,6 +17,7 @@ from .constants import TEST_PROJECT_ID, TEST_PROJECT_KEY
 
 EMBEDDING_MODEL = "moss-minilm"
 
+
 # Interface for Experiment Configuration
 @dataclass
 class ExperimentConfig:
@@ -24,6 +25,7 @@ class ExperimentConfig:
     dataset_path: Path
     alpha: Optional[float]
     top_k: int = 10
+
 
 # Interface for Run Statistics
 @dataclass
@@ -39,38 +41,41 @@ class RunStats:
     p95_latency_ms: Optional[float]
     error_reason: Optional[str] = None
 
+
 # Dataclass for Caching the dataset to avoid re-loading
 @dataclass
 class DatasetCache:
     """Cache for dataset data to avoid re-loading across experiments."""
+
     dataset_path: Optional[Path] = None
     qrels: Optional[Dict[str, Dict[str, float]]] = None
     queries: Optional[Dict[str, str]] = None
 
+
 # -------------------- Data Loaders --------------------
 
-#Loads the corpus from the corpus.jsonl file and combines the title and text into a single string
+
+# Loads the corpus from the corpus.jsonl file and combines the title and text into a single string
 def load_corpus(path: Path) -> List[DocumentInfo]:
     """Loads the entire mini-corpus into memory at once."""
     if not path.exists():
         pytest.skip(f"File not found: {path}")
-        
+
     print(f"Loading docs from {path.name}...")
     docs = []
     with path.open("r", encoding="utf-8") as f:
         for line in f:
             data = json.loads(line)
             # Combine title + text for best search results
-            text = (str(data.get("title", "")) + " " + str(data.get("text", ""))).strip()
-            docs.append(DocumentInfo(
-                id=str(data["_id"]), 
-                text=text, 
-                metadata={}
-            ))
+            text = (
+                str(data.get("title", "")) + " " + str(data.get("text", ""))
+            ).strip()
+            docs.append(DocumentInfo(id=str(data["_id"]), text=text, metadata={}))
     print(f"   Loaded {len(docs)} documents.")
     return docs
 
-#-------- Loads the qrels from the qrels/test.tsv file --------
+
+# -------- Loads the qrels from the qrels/test.tsv file --------
 # Example struct of qrels : {"query-id": {"doc-id": score}}
 def load_qrels(path: Path) -> Dict[str, Dict[str, float]]:
     """Loads relevance (Query ID -> Doc ID -> Score)."""
@@ -79,19 +84,20 @@ def load_qrels(path: Path) -> Dict[str, Dict[str, float]]:
 
     # Cache file path
     cache_path = path.parent / f"{path.stem}_cache.json"
-    
+
     # Check if cache exists and is newer than source file
     if cache_path.exists():
         cache_mtime = cache_path.stat().st_mtime
         source_mtime = path.stat().st_mtime
         if cache_mtime >= source_mtime:
-
             # Load from cache
             print(f"Loading qrels from cache: {cache_path.name}...")
             with cache_path.open("r", encoding="utf-8") as f:
                 qrels = json.load(f)
-                qrels = {qid: {did: float(score) for did, score in docs.items()} 
-                        for qid, docs in qrels.items()}
+                qrels = {
+                    qid: {did: float(score) for did, score in docs.items()}
+                    for qid, docs in qrels.items()
+                }
             print(f"   Loaded {len(qrels)} query judgments from cache.")
             return qrels
 
@@ -110,16 +116,17 @@ def load_qrels(path: Path) -> Dict[str, Dict[str, float]]:
             if len(parts) >= 3:
                 qid, did, score = parts[0], parts[1], float(parts[2])
                 qrels.setdefault(qid, {})[did] = score
-    
+
     # Save to cache
     print(f"   Caching qrels to {cache_path.name}...")
     with cache_path.open("w", encoding="utf-8") as f:
         json.dump(qrels, f, indent=2)
     print(f"   Loaded {len(qrels)} query judgments.")
-    
+
     return qrels
 
-#-------- Loads the queries from the queries.jsonl --------
+
+# -------- Loads the queries from the queries.jsonl --------
 # Example struct of queries : {"_id": "text"}
 def load_queries(path: Path, valid_qids: Set[str]) -> Dict[str, str]:
     """Loads queries that exist in the Qrels."""
@@ -132,39 +139,52 @@ def load_queries(path: Path, valid_qids: Set[str]) -> Dict[str, str]:
                 queries[qid] = str(data["text"])
     return queries
 
+
 # -------------------- Metrics Utils --------------------
 
-#-------- Calculates the NDCG metric --------
+
+# -------- Calculates the NDCG metric --------
 # NDCG (Normalized Discounted Cumulative Gain) measures ranking quality by considering
 # both relevance and position. Higher positions and higher relevance scores contribute more.
-# 
+#
 # Formula: NDCG@k = DCG@k / IDCG@k
 # - DCG@k = Σ(i=0 to k-1) (2^rel_i - 1) / log2(i + 2)
 #   * Sums relevance gains (2^rel - 1) discounted by position (log2(i+2))
 # - IDCG@k = DCG of the ideal ranking (documents sorted by relevance descending)
 # - Result: Score between 0.0 (worst) and 1.0 (perfect ranking)
-def calculate_ndcg(retrieved_ids: List[str], true_rels: Dict[str, float], k: int) -> float:
+def calculate_ndcg(
+    retrieved_ids: List[str], true_rels: Dict[str, float], k: int
+) -> float:
     dcg = 0.0
     idcg = 0.0
-    
+
     # 1. DCG
     for i, doc_id in enumerate(retrieved_ids[:k]):
         rel = true_rels.get(doc_id, 0)
         if rel > 0:
             dcg += (2**rel - 1) / math.log2(i + 2)
-            
+
     # 2. IDCG (Ideal ordering)
     ideal_scores = sorted(true_rels.values(), reverse=True)[:k]
     for i, rel in enumerate(ideal_scores):
         idcg += (2**rel - 1) / math.log2(i + 2)
-        
+
     return (dcg / idcg) if idcg > 0 else 0.0
+
 
 # -------------------- Core Execution --------------------
 # Run a single experiment scenario, based on the provided config
-async def run_scenario(client: MossClient, config: ExperimentConfig, queries: Dict, qrels: Dict, index_name: str) -> RunStats:
-    print(f"\nRunning Experiment: {config.name} (alpha={config.alpha}, dataset={config.dataset_path.name}) \n")
-    
+async def run_scenario(
+    client: MossClient,
+    config: ExperimentConfig,
+    queries: Dict,
+    qrels: Dict,
+    index_name: str,
+) -> RunStats:
+    print(
+        f"\nRunning Experiment: {config.name} (alpha={config.alpha}, dataset={config.dataset_path.name}) \n"
+    )
+
     latencies = []
     hits = 0
     mrr_sum = 0.0
@@ -174,19 +194,19 @@ async def run_scenario(client: MossClient, config: ExperimentConfig, queries: Di
         current_sdk_version = pkg_version("moss")
     except PackageNotFoundError:
         current_sdk_version = "unknown"
-    
+
     for qid, text in queries.items():
         # 1. Search
         options = QueryOptions(top_k=config.top_k, alpha=config.alpha)
         res: SearchResult = await client.query(index_name, text, options)
-        
+
         # 2. Latency Measurement
         latencies.append(res.time_taken_ms)
-        
+
         # 3. Score
         retrieved_ids = [d.id for d in res.docs]
         relevant_docs = qrels.get(qid, {})
-        
+
         # Check Hit & MRR
         is_hit = False
         for rank, doc_id in enumerate(retrieved_ids, 1):
@@ -195,7 +215,7 @@ async def run_scenario(client: MossClient, config: ExperimentConfig, queries: Di
                     hits += 1
                     mrr_sum += 1.0 / rank
                     is_hit = True
-        
+
         # Check NDCG
         ndcg_sum += calculate_ndcg(retrieved_ids, relevant_docs, config.top_k)
 
@@ -209,63 +229,131 @@ async def run_scenario(client: MossClient, config: ExperimentConfig, queries: Di
         mrr=mrr_sum / count,
         ndcg=ndcg_sum / count,
         avg_latency_ms=statistics.mean(latencies),
-        p95_latency_ms=(sorted(latencies)[int(len(latencies) * 0.95)] if len(latencies) >= 2 else float('nan'))
+        p95_latency_ms=(
+            sorted(latencies)[int(len(latencies) * 0.95)]
+            if len(latencies) >= 2
+            else float("nan")
+        ),
     )
+
 
 async def main():
     print("\n==========================================")
     print(" MOSS BENCHMARK: Multi-Dataset Testing")
     print("==========================================\n")
-    
-    client = MossClient(
-        TEST_PROJECT_ID,
-        TEST_PROJECT_KEY
-    )
+
+    client = MossClient(TEST_PROJECT_ID, TEST_PROJECT_KEY)
 
     # Define the base dataset path dynamically
     BASE_DATASET_PATH = Path(__file__).resolve().parents[3] / "test-dataset"
 
     # 1. Define Experiments
     experiments = [
-        ExperimentConfig("Keyword Search(alpha=0)", dataset_path=BASE_DATASET_PATH / "full_scifact", alpha=0),
-        ExperimentConfig("Keyword Search(alpha=0)", dataset_path=BASE_DATASET_PATH / "full_nfcorpus", alpha=0),
-        ExperimentConfig("Keyword Search(alpha=0)", dataset_path=BASE_DATASET_PATH / "mini_msmarco", alpha=0),
-
-        ExperimentConfig("Fusion Search(alpha=0.2)", dataset_path=BASE_DATASET_PATH / "full_scifact", alpha=0.2),
-        ExperimentConfig("Fusion Search(alpha=0.2)", dataset_path=BASE_DATASET_PATH / "full_nfcorpus", alpha=0.2),
-        ExperimentConfig("Fusion Search(alpha=0.2)", dataset_path=BASE_DATASET_PATH / "mini_msmarco", alpha=0.2),
-
-        ExperimentConfig("Fusion Search(alpha=0.4)", dataset_path=BASE_DATASET_PATH / "full_scifact", alpha=0.4),
-        ExperimentConfig("Fusion Search(alpha=0.4)", dataset_path=BASE_DATASET_PATH / "full_nfcorpus", alpha=0.4),
-        ExperimentConfig("Fusion Search(alpha=0.4)", dataset_path=BASE_DATASET_PATH / "mini_msmarco", alpha=0.4),
-
-        ExperimentConfig("Fusion Search(alpha=0.6)", dataset_path=BASE_DATASET_PATH / "full_scifact", alpha=0.6),
-        ExperimentConfig("Fusion Search(alpha=0.6)", dataset_path=BASE_DATASET_PATH / "full_nfcorpus", alpha=0.6),
-        ExperimentConfig("Fusion Search(alpha=0.6)", dataset_path=BASE_DATASET_PATH / "mini_msmarco", alpha=0.6),
-
-        ExperimentConfig("Fusion Search(alpha=0.8)", dataset_path=BASE_DATASET_PATH / "full_scifact", alpha=0.8),
-        ExperimentConfig("Fusion Search(alpha=0.8)", dataset_path=BASE_DATASET_PATH / "full_nfcorpus", alpha=0.8),
-        ExperimentConfig("Fusion Search(alpha=0.8)", dataset_path=BASE_DATASET_PATH / "mini_msmarco", alpha=0.8),
-
-        ExperimentConfig("Embedding Search(alpha=1)", dataset_path=BASE_DATASET_PATH / "full_scifact", alpha=1),
-        ExperimentConfig("Embedding Search(alpha=1)", dataset_path=BASE_DATASET_PATH / "full_nfcorpus", alpha=1),
-        ExperimentConfig("Embedding Search(alpha=1)", dataset_path=BASE_DATASET_PATH / "mini_msmarco", alpha=1),
-
+        ExperimentConfig(
+            "Keyword Search(alpha=0)",
+            dataset_path=BASE_DATASET_PATH / "full_scifact",
+            alpha=0,
+        ),
+        ExperimentConfig(
+            "Keyword Search(alpha=0)",
+            dataset_path=BASE_DATASET_PATH / "full_nfcorpus",
+            alpha=0,
+        ),
+        ExperimentConfig(
+            "Keyword Search(alpha=0)",
+            dataset_path=BASE_DATASET_PATH / "mini_msmarco",
+            alpha=0,
+        ),
+        ExperimentConfig(
+            "Fusion Search(alpha=0.2)",
+            dataset_path=BASE_DATASET_PATH / "full_scifact",
+            alpha=0.2,
+        ),
+        ExperimentConfig(
+            "Fusion Search(alpha=0.2)",
+            dataset_path=BASE_DATASET_PATH / "full_nfcorpus",
+            alpha=0.2,
+        ),
+        ExperimentConfig(
+            "Fusion Search(alpha=0.2)",
+            dataset_path=BASE_DATASET_PATH / "mini_msmarco",
+            alpha=0.2,
+        ),
+        ExperimentConfig(
+            "Fusion Search(alpha=0.4)",
+            dataset_path=BASE_DATASET_PATH / "full_scifact",
+            alpha=0.4,
+        ),
+        ExperimentConfig(
+            "Fusion Search(alpha=0.4)",
+            dataset_path=BASE_DATASET_PATH / "full_nfcorpus",
+            alpha=0.4,
+        ),
+        ExperimentConfig(
+            "Fusion Search(alpha=0.4)",
+            dataset_path=BASE_DATASET_PATH / "mini_msmarco",
+            alpha=0.4,
+        ),
+        ExperimentConfig(
+            "Fusion Search(alpha=0.6)",
+            dataset_path=BASE_DATASET_PATH / "full_scifact",
+            alpha=0.6,
+        ),
+        ExperimentConfig(
+            "Fusion Search(alpha=0.6)",
+            dataset_path=BASE_DATASET_PATH / "full_nfcorpus",
+            alpha=0.6,
+        ),
+        ExperimentConfig(
+            "Fusion Search(alpha=0.6)",
+            dataset_path=BASE_DATASET_PATH / "mini_msmarco",
+            alpha=0.6,
+        ),
+        ExperimentConfig(
+            "Fusion Search(alpha=0.8)",
+            dataset_path=BASE_DATASET_PATH / "full_scifact",
+            alpha=0.8,
+        ),
+        ExperimentConfig(
+            "Fusion Search(alpha=0.8)",
+            dataset_path=BASE_DATASET_PATH / "full_nfcorpus",
+            alpha=0.8,
+        ),
+        ExperimentConfig(
+            "Fusion Search(alpha=0.8)",
+            dataset_path=BASE_DATASET_PATH / "mini_msmarco",
+            alpha=0.8,
+        ),
+        ExperimentConfig(
+            "Embedding Search(alpha=1)",
+            dataset_path=BASE_DATASET_PATH / "full_scifact",
+            alpha=1,
+        ),
+        ExperimentConfig(
+            "Embedding Search(alpha=1)",
+            dataset_path=BASE_DATASET_PATH / "full_nfcorpus",
+            alpha=1,
+        ),
+        ExperimentConfig(
+            "Embedding Search(alpha=1)",
+            dataset_path=BASE_DATASET_PATH / "mini_msmarco",
+            alpha=1,
+        ),
     ]
 
     # 2. Sort experiments by dataset to minimize I/O
     experiments = sorted(experiments, key=lambda e: e.dataset_path)
-    
+
     # ---------------------------------------------------------
     # PHASE 1: INDEX PREPARATION (Delete -> Create)
     # ---------------------------------------------------------
     # Identify all unique datasets required by the experiments
     unique_dataset_paths = sorted(list({exp.dataset_path for exp in experiments}))
-    
+
     # Map dataset paths to their created index names
     dataset_to_index_map: Dict[Path, str] = {}
     failed_datasets: Dict[Path, Dict[str, Any]] = {}
-    
+
     # Get current version for safe index naming
     try:
         current_sdk_version = pkg_version("moss")
@@ -273,8 +361,10 @@ async def main():
         current_sdk_version = "unknown"
     safe_version = current_sdk_version.replace(".", "_").replace("-", "_")
 
-    print(f"\n🚀 PRE-COMPUTING INDICES for {len(unique_dataset_paths)} unique datasets...")
-    
+    print(
+        f"\n🚀 PRE-COMPUTING INDICES for {len(unique_dataset_paths)} unique datasets..."
+    )
+
     for dpath in unique_dataset_paths:
         corpus_path = dpath / "corpus.jsonl"
         if not corpus_path.exists():
@@ -290,7 +380,7 @@ async def main():
         # 3. Force Delete Existing Index
         print(f"   🗑️  Cleaning old index: {index_name}...")
         try:
-            # Assuming delete_index is the API method. 
+            # Assuming delete_index is the API method.
             # Wrap in try/except in case it throws an error if index doesn't exist.
             await client.delete_index(index_name)
         except Exception:
@@ -347,7 +437,7 @@ async def main():
             continue
 
         dataset_to_index_map[dpath] = index_name
-        print(f"   ✅ Created in {time.time()-t0:.2f}s")
+        print(f"   ✅ Created in {time.time() - t0:.2f}s")
 
     # ---------------------------------------------------------
     # PHASE 2: EXPERIMENT EXECUTION (Load -> Query)
@@ -381,7 +471,9 @@ async def main():
             continue
 
         if exp.dataset_path not in dataset_to_index_map:
-            print(f"Skipping {exp.name}: Index was not created during the preparation phase for {exp.dataset_path.name}")
+            print(
+                f"Skipping {exp.name}: Index was not created during the preparation phase for {exp.dataset_path.name}"
+            )
             continue
 
         index_name = dataset_to_index_map[exp.dataset_path]
@@ -391,16 +483,18 @@ async def main():
         if exp.dataset_path != dataset_cache.dataset_path:
             qrels_path = exp.dataset_path / "qrels.tsv"
             queries_path = exp.dataset_path / "queries.jsonl"
-            
+
             if not qrels_path.exists() or not queries_path.exists():
                 print(f"Skipping {exp.name}: Missing qrels/queries")
                 continue
 
             print(f"\n📂 Loading test data for: {exp.dataset_path.name}")
             dataset_cache.qrels = load_qrels(qrels_path)
-            dataset_cache.queries = load_queries(queries_path, set(dataset_cache.qrels.keys()))
+            dataset_cache.queries = load_queries(
+                queries_path, set(dataset_cache.qrels.keys())
+            )
             dataset_cache.dataset_path = exp.dataset_path
-            
+
             # CRITICAL STEP: Load the index specifically for this dataset
             print(f"🔌 Connecting to index: {index_name}")
             try:
@@ -432,18 +526,14 @@ async def main():
 
         # ----- Run Experiment -----
         stats = await run_scenario(
-            client, 
-            exp, 
-            dataset_cache.queries, 
-            dataset_cache.qrels, 
-            index_name
+            client, exp, dataset_cache.queries, dataset_cache.qrels, index_name
         )
         results.append(stats)
 
     # ---------------------------------------------------------
     # PHASE 3: REPORTING
     # ---------------------------------------------------------
-    
+
     # Print Table
     header = f"{'Experiment':<25} | {'SDK Version':<12} | {'Dataset':<30} | {'HitRate':>8} | {'NDCG':>8} | {'MRR':>8} | {'Avg(ms)':>8} | {'P95(ms)':>8} | {'Reason':<40}"
     separator = "=" * len(header)
@@ -452,7 +542,7 @@ async def main():
     print(separator)
     print(header)
     print("-" * len(header))
-    
+
     for stats in results:
         if stats.error_reason:
             print(
@@ -463,20 +553,20 @@ async def main():
                 f"{stats.experiment:<25} | {stats.sdk_version:<12} | {stats.dataset_name:<30} | {stats.hit_rate:>8.3f} | {stats.ndcg:>8.3f} | {stats.mrr:>8.3f} | {stats.avg_latency_ms:>8.1f} | {stats.p95_latency_ms:>8.1f} | {'':<40}"
             )
     print(separator)
-    
+
     # ---------------------------------------------------------
     # PHASE 4: CLEANUP (Delete all created indices)
     # ---------------------------------------------------------
     print("\n" + "=" * 60)
     print(" CLEANING UP INDICES")
     print("=" * 60)
-    
+
     all_indices = set(dataset_to_index_map.values())
     # Also include indices from failed datasets (they might have been created before failing)
     for failure_info in failed_datasets.values():
         if "index_name" in failure_info:
             all_indices.add(failure_info["index_name"])
-    
+
     if all_indices:
         print(f"\n🗑️  Deleting {len(all_indices)} indices...")
         for index_name in sorted(all_indices):
@@ -487,7 +577,7 @@ async def main():
                 print(f"   ⚠️  Failed to delete {index_name}: {e}")
     else:
         print("\n   No indices to delete.")
-    
+
     print("\nDone.")
 
 


### PR DESCRIPTION
## Pull Request Checklist

Please ensure that your PR meets the following requirements:

* [x] I have read the CONTRIBUTING guide.
* [ ] I have updated the documentation (if applicable).
* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have added tests that prove my fix is effective or that my feature works.
* [x] New and existing unit tests pass locally with my changes.

---

## Description

This PR brings the Python SDK source in sync with the published `moss==1.4.1` package.

The local source was still frozen at `1.0.0b19`, causing several APIs expected by the examples and type stubs to be missing.

### ✨ New APIs Added

#### `MossClient.session(index_name, model_id=None)`

Creates or resumes a local in-process `SessionIndex`. If an index with the same name already exists in the cloud, it is automatically loaded.

#### `MossClient.load_indexes(names, ...)` / `MossClient.unload_indexes(names)`

Bulk lifecycle management APIs for loading and unloading multiple indexes.

#### `MossClient.query_multi_index(names, query, options=None)`

Performs a single query across multiple loaded indexes and returns a global top-K result set, with each result tagged by its source `index_name`.

#### `MossClient.create_index_from_files(name, files, model_id=None)`

Creates an index using server-side PDF parsing and embedding through `ParseFileInput`.

#### `SessionIndex`

Introduces a new module: `client/session_index.py`, providing:

* `add_docs`
* `delete_docs`
* `get_docs`
* `query`
* `push_index`

---

## 🐛 Bug Fix

### `_query_local` alpha handling

Previously:

```python
alpha = getattr(...) or 0.8
```

This incorrectly treated `alpha=0.0` (keyword-only search) as falsy and silently replaced it with `0.8`.

This has been fixed by using an explicit `is None` guard.

---

## 🏗 Infrastructure Updates

* Bumped `inferedge-moss-core` from **0.8.7 → 0.17.0**
* Updated `__init__.py` exports
* Extended `__init__.pyi` with:

  * `SessionIndex`
  * `ParseFileInput`
  * `PushIndexResult`
  * `LoadIndexesResult`
  * new API method signatures
* Added `[tool.pytest.ini_options]` to `pyproject.toml` with `e2e` and `slow` mark registrations to remove pytest collection warnings
* Removed stale `_get_manage_url` references
* Updated existing tests to reflect:

  * `ManageClient` now uses Rust-internal URLs
  * `client_id` is now a keyword argument

---

## 🧪 Tests Added

### `test_new_apis_e2e.py`

Comprehensive end-to-end coverage for all newly added APIs using real cloud credentials:

Environment variables required:

* `MOSS_TEST_PROJECT_ID`
* `MOSS_TEST_PROJECT_KEY`

### `TestSessionE2E`

Covers the complete `SessionIndex` lifecycle:

* add documents
* retrieve documents
* query
* delete documents
* push index
* resume existing session

### `TestMultiIndexE2E`

Validates:

* bulk index loading
* multi-index querying
* partial failure handling
* idempotent unload operations

### `TestCreateIndexFromFilesE2E`

* verifies custom model guard behavior
* full `DocParser` E2E tests deferred until service provisioning is available

### `TestParseFileInput`

Pure Python validation tests with no network dependency.

---

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

---

Fixes #<issue-number>
