### PR TITLE
SDK-Updates for Javascript 

### DIFF
--- a/examples/javascript/.env.template
+++ b/examples/javascript/.env.template
@@ -1,0 +1,13 @@
+# Moss credentials — required by all samples
+# Get these from https://app.moss.dev → your project → Settings
+MOSS_PROJECT_ID=your_project_id_here
+MOSS_PROJECT_KEY=your_project_key_here
+
+# Name of an existing index to query.
+# Required by: load-and-query, cached-load, custom-auth
+# Used as session name by: session, session-cache, session-custom-auth
+# Used as the index to CREATE (then delete) by: comprehensive, custom-embedding
+MOSS_INDEX_NAME=your_index_name_here
+
+# OpenAI API key — required only by: custom-embedding
+OPENAI_API_KEY=sk-...

--- a/examples/javascript/README.md
+++ b/examples/javascript/README.md
@@ -1,84 +1,194 @@
 # Moss JavaScript SDK Examples
 
-This project demonstrates the usage of the Moss JavaScript SDK for semantic search and document indexing.
+Runnable TypeScript examples for `@moss-dev/moss` v1.3.1.
 
 ## Setup
 
-1. **Install dependencies:**
-
-   ```bash
-   npm install
-   ```
-
-2. **Configure environment variables:**
-   - Copy `.env.template` to `.env`
-   - Fill in your Moss project credentials:
-
-     ```env
-     MOSS_PROJECT_ID=your_actual_project_id
-     MOSS_PROJECT_KEY=your_actual_project_key
-     MOSS_INDEX_NAME=your_existing_index_name
-     ```
-
-## Running Samples
-
-### Comprehensive Sample
-
-Run the complete end-to-end example showing all SDK functions:
-
 ```bash
-npx tsx comprehensive_sample.ts
+# 1. Install dependencies
+npm install
+
+# 2. Create your .env file
+cp .env.template .env
+# Fill in MOSS_PROJECT_ID, MOSS_PROJECT_KEY, and MOSS_INDEX_NAME
 ```
 
-### Load and Query Sample
+## Samples at a glance
 
-Run the simple example to load an existing index and perform queries:
+| Script | npm command | Needs existing index? | Extra env var |
+| --- | --- | --- | --- |
+| `load_and_query_sample.ts` | `npm run load-and-query` | Yes (`MOSS_INDEX_NAME`) | — |
+| `cached_load_sample.ts` | `npm run cached-load` | Yes (`MOSS_INDEX_NAME`) | — |
+| `custom_authenticator_sample.ts` | `npm run custom-auth` | Yes (`MOSS_INDEX_NAME`) | — |
+| `session_sample.ts` | `npm run session` | No (creates session in-memory) | — |
+| `session_cache_sample.ts` | `npm run session-cache` | No | — |
+| `session_custom_auth_sample.ts` | `npm run session-custom-auth` | No | — |
+| `comprehensive_sample.ts` | `npm run comprehensive` | No (creates + deletes its own) | — |
+| `custom_embedding_sample.ts` | `npm run custom-embedding` | No (creates + deletes its own) | `OPENAI_API_KEY` |
 
-```bash
-npx tsx load_and_query_sample.ts
-```
+---
 
-### Cached Index Loading Sample
+## Sample-by-sample testing guide
 
-Load an existing index with local filesystem caching. First run downloads from the cloud and saves to disk; subsequent runs load instantly from the cache:
+### 1. `load_and_query_sample.ts`
 
-```bash
-npx tsx cached_load_sample.ts
-```
+Loads an existing index and runs three queries against it.
 
-### Custom Embedding Sample
-
-Provision a fresh index (using the name supplied via `MOSS_INDEX_NAME`), push documents with manually generated OpenAI embeddings, and issue sample queries:
-
-```bash
-npx tsx custom_embedding_sample.ts
-```
-
-### Session Sample
-
-Open a local-first `SessionIndex`, add documents in real time (no cloud round trip), query the in-memory index, then `pushIndex` to the cloud so another agent or device can resume it. This is how Moss indexes a live conversation.
+**Requires:** An index that already exists in your project.
 
 ```bash
-npx tsx session_sample.ts
+MOSS_INDEX_NAME=my-existing-index npm run load-and-query
 ```
 
-### Session Cache Sample
+**What to verify:**
 
-Build a local-first `SessionIndex`, persist it to the local filesystem with `saveToDisk`, then restore it into a fresh session with `loadFromDisk` — so a session survives a process restart with no cloud round trip (no `pushIndex`). Also shows the client-level `cachePath` option (requires `@moss-dev/moss` >= 1.2.1).
+- `Index loaded successfully` appears
+- Each query prints results with `score` values
+
+---
+
+### 2. `cached_load_sample.ts`
+
+Shows disk caching and auto-refresh. Run it twice to see the speed difference.
+
+**Requires:** An existing index.
 
 ```bash
-npx tsx session_cache_sample.ts
+MOSS_INDEX_NAME=my-existing-index npm run cached-load
 ```
 
-### Session + Custom Authenticator Sample
+**What to verify:**
 
-Open a local-first session when the client is built with a custom `IAuthenticator` (short-lived tokens / delegated auth) instead of a static project key — the session authenticates through the same token source, so the project key never has to live on the device. Requires `@moss-dev/moss` >= 1.3.0.
+- First run: downloads from cloud, creates `.moss-cache/` directory
+- Second run: loads in `<10ms` from disk
+- The auto-refresh section loads without error and prints a confirmation
+
+---
+
+### 3. `custom_authenticator_sample.ts`
+
+Starts an in-process token server (your "backend") and queries via a client that holds no project key.
+
+**Requires:** An existing index.
 
 ```bash
-npx tsx session_custom_auth_sample.ts
+MOSS_INDEX_NAME=my-existing-index npm run custom-auth
 ```
+
+**What to verify:**
+
+- `Token server listening on http://localhost:3456/moss-token`
+- `Index loaded successfully` using the authenticator client
+- Query results print without error
+- `Token server stopped.` at the end
+
+---
+
+### 4. `session_sample.ts`
+
+Creates a local `SessionIndex`, adds documents in-memory, queries it (~1-10ms), then pushes to the cloud.
+
+**No existing index required.** Set `MOSS_INDEX_NAME` to any name for the session.
+
+```bash
+MOSS_INDEX_NAME=my-session npm run session
+```
+
+**What to verify:**
+
+- `Session open` shows `0 existing docs` (first run) or prior doc count (resumed)
+- Query returns results ranked by score
+- `Pushed N docs` confirms cloud sync
+
+---
+
+### 5. `session_cache_sample.ts`
+
+Saves a session to disk with `saveToDisk`, then restores it into a fresh session without touching the cloud.
+
+**No existing index required.**
+
+```bash
+npm run session-cache
+```
+
+**What to verify:**
+
+- `.moss-session-cache/` directory is created
+- `Fresh session docs before restore: 0`
+- `Restored 3 docs from disk` after `loadFromDisk`
+- Query against the restored session returns results
+- Device ID file path printed at the end
+
+---
+
+### 6. `session_custom_auth_sample.ts`
+
+Opens a session using a custom `IAuthenticator` (token-based, no project key in the client).
+
+**No existing index required.**
+
+```bash
+npm run session-custom-auth
+```
+
+**What to verify:**
+
+- `Session open` via the authenticator
+- Docs added and query returns results
+- `documents stayed on the device` message at the end
+
+---
+
+### 7. `comprehensive_sample.ts`
+
+End-to-end tour of the full API: creates a temporary index, exercises every major method, then deletes it.
+
+**No existing index required.** Uses a timestamped name so it never collides with real data.
+
+```bash
+npm run comprehensive
+```
+
+**What to verify:**
+
+- Steps 1–14 complete without errors
+- Step 9 (metadata filter) returns only `technology` category docs
+- Step 13 (SessionIndex) shows in-memory add + query + push
+- Step 14 prints `Index deleted: true`
+
+---
+
+### 8. `custom_embedding_sample.ts`
+
+Creates an index with OpenAI embeddings, adds more docs, queries via cloud fallback then locally.
+
+**Requires:** `OPENAI_API_KEY` in addition to Moss credentials.
+**No existing Moss index required.** Uses `MOSS_INDEX_NAME` as the name to create and delete.
+
+```bash
+MOSS_INDEX_NAME=custom-emb-test npm run custom-embedding
+```
+
+**What to verify:**
+
+- Embedding dimensions printed (`1536` for `text-embedding-3-small`)
+- Cloud query and local query both return results
+- `Index deleted.` in the cleanup block
+
+---
+
+## Troubleshooting
+
+| Error | Fix |
+| --- | --- |
+| `Cannot find module '@moss-dev/moss'` | Run `npm install` |
+| `Missing environment variables` | Copy `.env.template` → `.env` and fill in values |
+| `index does not exist` | Create one first via `npm run comprehensive`, or use the Moss dashboard |
+| `Auth failed HTTP 401` | Check `MOSS_PROJECT_ID` and `MOSS_PROJECT_KEY` are correct |
+| OpenAI errors in custom-embedding | Verify `OPENAI_API_KEY` is set and has credits |
 
 ## Requirements
 
-- Node.js (version 20 or higher)
-- Valid Moss project credentials
+- Node.js 20+
+- `@moss-dev/moss` 1.3.1 (installed via `npm install`)

--- a/examples/javascript/README.md
+++ b/examples/javascript/README.md
@@ -155,7 +155,7 @@ npm run comprehensive
 - Steps 1–14 complete without errors
 - Step 9 (metadata filter) returns only `technology` category docs
 - Step 13 (SessionIndex) shows in-memory add + query + push
-- Step 14 prints `Index deleted: true`
+- Step 14 prints `Deleted: <indexName>` (and `Deleted: <indexName>-session`)
 
 ---
 

--- a/examples/javascript/README.md
+++ b/examples/javascript/README.md
@@ -118,7 +118,7 @@ npm run session-cache
 - `Fresh session docs before restore: 0`
 - `Restored 3 docs from disk` after `loadFromDisk`
 - Query against the restored session returns results
-- Device ID file path printed at the end
+- `Device id (anonymous): ...` is printed at the end
 
 ---
 

--- a/examples/javascript/cached_load_sample.ts
+++ b/examples/javascript/cached_load_sample.ts
@@ -1,16 +1,15 @@
 /**
  * Moss SDK - Cached Index Loading Sample
  *
- * Demonstrates using the `cachePath` option to persist downloaded indexes to disk.
- * On the first run, the index is fetched from the cloud and saved locally.
- * On subsequent runs, the index loads instantly from the local cache.
+ * Demonstrates two `loadIndex` configurations:
  *
- * You can also combine caching with auto-refresh for long-running processes:
- *   await client.loadIndex(indexName, {
- *     cachePath: CACHE_DIR,
- *     autoRefresh: true,
- *     pollingIntervalInSeconds: 60,
- *   });
+ * 1. Basic cache — the index binary is downloaded once and saved under `cachePath`.
+ *    Subsequent loads read from disk instead of the network (instant).
+ *
+ * 2. Cache + auto-refresh — same disk cache, but the SDK also polls the cloud
+ *    every `pollingIntervalInSeconds` seconds. When a newer version is detected
+ *    the index is hot-swapped in memory and the cache is refreshed on disk,
+ *    all without interrupting in-flight queries.
  *
  * Required Environment Variables:
  * - MOSS_PROJECT_ID: Your Moss project ID
@@ -19,7 +18,7 @@
  *
  * @example
  * ```bash
- * npx tsx cached_load_sample.ts
+ * npm run cached-load
  * ```
  */
 
@@ -48,20 +47,21 @@ async function cachedLoadSample(): Promise<void> {
 
   const client = new MossClient(projectId, projectKey);
 
-  console.log(`\nLoading index '${indexName}' (cache dir: ${CACHE_DIR})...`);
-  const start = performance.now();
+  // ── 1. Basic cache load ────────────────────────────────────────────────────
+  // First run: downloads from cloud and writes to CACHE_DIR.
+  // Subsequent runs: reads from disk — no network call, loads in <10ms.
+  console.log(`\nLoading index '${indexName}' with disk cache (${CACHE_DIR})...`);
+  let start = performance.now();
   await client.loadIndex(indexName, { cachePath: CACHE_DIR });
-  const loadMs = (performance.now() - start).toFixed(0);
-  console.log(`Index loaded in ${loadMs}ms`);
+  console.log(`Loaded in ${(performance.now() - start).toFixed(0)}ms`);
 
-  // Run a few queries to verify the loaded index works
   const queries = [
     "how to return damaged item",
     "return shipping label process",
     "refund processing time and policy",
   ];
 
-  console.log("\nRunning sample queries...");
+  console.log("\nRunning queries against the cached index...");
   for (const query of queries) {
     const results = await client.query(indexName, query, { topK: 3 });
     console.log(
@@ -75,11 +75,38 @@ async function cachedLoadSample(): Promise<void> {
     });
   }
 
-  console.log("\nDone! Run again to see the faster cached load time.");
+  // ── 2. Cache + auto-refresh ────────────────────────────────────────────────
+  // The SDK polls the cloud every `pollingIntervalInSeconds` seconds.
+  // When a newer index version is found it is hot-swapped into memory and
+  // persisted to the cache — no manual reload required.
+  //
+  // Use this in long-running servers or background workers where the index
+  // content updates over time (e.g. a live knowledge base).
+  console.log("\nReloading with auto-refresh enabled (polls every 60 s)...");
+  start = performance.now();
+  await client.loadIndex(indexName, {
+    cachePath: CACHE_DIR,
+    autoRefresh: true,
+    pollingIntervalInSeconds: 60,
+  });
+  console.log(`Reloaded in ${(performance.now() - start).toFixed(0)}ms`);
+  console.log("Index will auto-refresh in the background every 60 seconds.");
+
+  // Queries continue to work normally while auto-refresh runs in the background.
+  const result = await client.query(indexName, "refund policy", { topK: 2 });
+  console.log(
+    `\nQuery after auto-refresh setup: ${result.docs.length} results (${result.timeTakenInMs}ms)`
+  );
+
+  // Stop auto-refresh by reloading without the option.
+  await client.loadIndex(indexName, { cachePath: CACHE_DIR });
+  console.log("Auto-refresh stopped (reloaded without autoRefresh option).");
+
+  console.log("\nDone! Run again to see the faster cached load time. (Ctrl+C to exit)");
 }
+
+export { cachedLoadSample };
 
 if (require.main === module) {
   cachedLoadSample().catch(console.error);
 }
-
-export { cachedLoadSample };

--- a/examples/javascript/comprehensive_sample.ts
+++ b/examples/javascript/comprehensive_sample.ts
@@ -1,29 +1,19 @@
 /**
- * @fileoverview Comprehensive End-to-End Moss JavaScript SDK Sample
- * @description This example demonstrates the complete workflow of the Moss JavaScript SDK,
- * showcasing ALL available functions with a dynamic index name based on timestamp.
- * 
- * Features demonstrated:
- * - Index creation and management
- * - Document operations (add, retrieve, update, delete)
- * - Semantic search functionality
- * - Advanced querying with metadata filtering
- * - Index lifecycle management
- * - Error handling best practices
- * 
- * @author Moss SDK Examples
- * @version 1.0.0
- * @since 2024-10-09
- * 
+ * Moss SDK - Comprehensive End-to-End Sample
+ *
+ * Covers every major API surface in one runnable script:
+ *   createIndex, getIndex, listIndexes, addDocs, getDocs,
+ *   loadIndex, query (with metadata filter), deleteDocs,
+ *   session (local in-memory index), pushIndex, deleteIndex.
+ *
+ * Required Environment Variables:
+ * - MOSS_PROJECT_ID: Your Moss project ID
+ * - MOSS_PROJECT_KEY: Your Moss project key
+ *
  * @example
  * ```bash
- * # Run this comprehensive example
- * npx tsx comprehensive_sample.ts
+ * npm run comprehensive
  * ```
- * 
- * @requires @moss-dev/moss ^1.0.0
- * @requires dotenv ^17.2.3
- * @requires node >=20.0.0
  */
 
 import { MossClient, DocumentInfo } from "@moss-dev/moss";
@@ -31,7 +21,6 @@ import { config } from 'dotenv';
 
 // Load environment variables
 config();
-
 /**
  * Comprehensive end-to-end example demonstrating ALL Moss SDK functionality.
  * 
@@ -186,7 +175,7 @@ async function comprehensiveMossExample(): Promise<void> {
   const indexName = `comprehensive-demo-${timestamp}`;
 
   try {
-    console.log(`\n📝 Step 1: Creating index '${indexName}' with ${documents.length} documents...`);
+    console.log(`\nStep 1: Creating index '${indexName}' with ${documents.length} documents...`);
     const created = await client.createIndex(indexName, documents, { modelId: 'moss-minilm' });
     console.log(`Index created successfully (job: ${created.jobId}, index: ${created.indexName}, docs: ${created.docCount})`);
 
@@ -293,7 +282,7 @@ async function comprehensiveMossExample(): Promise<void> {
     const loadedIndex = await client.loadIndex(indexName);
     console.log(`Index loaded for querying: ${loadedIndex}`);
 
-    console.log(`\n🔎 Step 8: Performing comprehensive semantic search tests...`);
+    console.log(`\nStep 8: Performing semantic search tests...`);
     const searchQueries = [
       { query: 'artificial intelligence and machine learning', topK: 4 },
       { query: 'data analysis and business insights', topK: 3 },
@@ -322,16 +311,31 @@ async function comprehensiveMossExample(): Promise<void> {
       });
     }
 
-    console.log(`\n🗑️  Step 9: Demonstrating document deletion...`);
+    console.log(`\nStep 9: Demonstrating metadata-filtered query...`);
+    const filteredResults = await client.query(indexName, 'machine learning', {
+      topK: 3,
+      filter: {
+        $and: [
+          { field: 'category', condition: { $eq: 'technology' } },
+          { field: 'difficulty', condition: { $in: ['beginner', 'intermediate'] } },
+        ],
+      },
+    });
+    console.log(`Filtered query returned ${filteredResults.docs.length} results (category=technology, difficulty in [beginner,intermediate]):`);
+    filteredResults.docs.forEach((doc) => {
+      console.log(`   [${doc.id}] score=${doc.score.toFixed(3)} | ${doc.metadata?.difficulty}`);
+    });
+
+    console.log(`\nStep 10: Demonstrating document deletion...`);
     const docsToDelete = ['health-biotech-009', 'env-sustainability-010'];
     const deleteResult = await client.deleteDocs(indexName, docsToDelete);
     console.log(`Delete operation result (job: ${deleteResult.jobId}, remaining docs: ${deleteResult.docCount})`);
 
-    console.log(`\nStep 10: Verifying document count after deletion...`);
+    console.log(`\nStep 11: Verifying document count after deletion...`);
     const remainingDocs = await client.getDocs(indexName);
     console.log(`Remaining documents: ${remainingDocs.length}`);
 
-    console.log(`\nStep 11: Final search validation...`);
+    console.log(`\nStep 12: Final search validation...`);
     const finalSearch = await client.query(
       indexName,
       'technology innovation and automation',
@@ -347,23 +351,37 @@ async function comprehensiveMossExample(): Promise<void> {
       console.log(`   ${i + 1}. [${item.id}] Score: ${item.score.toFixed(3)}`);
     });
 
-    console.log(`\nStep 12: Cleaning up - deleting the test index...`);
+    console.log(`\nStep 13: Demonstrating SessionIndex — local in-memory indexing...`);
+    const session = await client.session(`${indexName}-session`);
+    const sessionDocs = [
+      { id: 'sess-1', text: 'Customer was charged twice for the March renewal.' },
+      { id: 'sess-2', text: 'Agent confirmed a refund for the duplicate charge.' },
+      { id: 'sess-3', text: 'Customer asked to cancel auto-renew going forward.' },
+    ];
+    const { added: sessAdded } = await session.addDocs(sessionDocs);
+    console.log(`Session: ${sessAdded} docs added in-memory (no cloud round-trip, model: ${session.modelId})`);
+
+    const sessResults = await session.query('billing refund request', { topK: 2 });
+    console.log(`Session query: ${sessResults.docs.length} results in ${sessResults.timeTakenInMs}ms`);
+    sessResults.docs.forEach((doc) => {
+      console.log(`   [${doc.id}] score=${doc.score.toFixed(3)}  ${doc.text.substring(0, 60)}...`);
+    });
+
+    const pushed = await session.pushIndex();
+    console.log(`Session pushed to cloud: ${pushed.docCount} docs (job ${pushed.jobId})`);
+
+    console.log(`\nStep 14: Cleaning up - deleting test indexes...`);
     const deleted = await client.deleteIndex(indexName);
     console.log(`Index deleted: ${deleted}`);
 
-    console.log(`\nComprehensive Moss SDK Example Completed Successfully!`);
+    console.log(`\nComprehensive Moss SDK Example Completed Successfully! (Ctrl+C to exit)`);
     console.log('='.repeat(60));
-    console.log('Summary of operations performed:');
-    console.log('   Index creation with initial documents');
-    console.log('   Index information retrieval');
-    console.log('   Index listing');
-    console.log('   Document addition with upsert');
-    console.log('   Document retrieval (all and specific)');
-    console.log('   Index loading for querying');
-    console.log('   Multiple semantic search operations');
-    console.log('   Document deletion');
-    console.log('   Index cleanup');
-    console.log('   Comprehensive error handling');
+    console.log('Operations covered:');
+    console.log('  createIndex, getIndex, listIndexes');
+    console.log('  addDocs (upsert), getDocs (all + by ID)');
+    console.log('  loadIndex, query, query with metadata filter');
+    console.log('  deleteDocs, deleteIndex');
+    console.log('  session, session.addDocs, session.query, session.pushIndex');
 
   } catch (error) {
     console.error(`Error occurred: ${error}`);
@@ -385,11 +403,6 @@ async function comprehensiveMossExample(): Promise<void> {
   }
 }
 
-/**
- * Export the main example function for use in tests or other modules
- * 
- * @exports comprehensiveMossExample - Complete Moss SDK demonstration function
- */
 export { comprehensiveMossExample };
 
 // Run the example if this file is executed directly

--- a/examples/javascript/comprehensive_sample.ts
+++ b/examples/javascript/comprehensive_sample.ts
@@ -170,9 +170,10 @@ async function comprehensiveMossExample(): Promise<void> {
     }
   ];
 
-  // Create dynamic index name with timestamp
+  // Create dynamic index names with timestamp
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
   const indexName = `comprehensive-demo-${timestamp}`;
+  const sessionName = `${indexName}-session`;
 
   try {
     console.log(`\nStep 1: Creating index '${indexName}' with ${documents.length} documents...`);
@@ -352,7 +353,7 @@ async function comprehensiveMossExample(): Promise<void> {
     });
 
     console.log(`\nStep 13: Demonstrating SessionIndex — local in-memory indexing...`);
-    const session = await client.session(`${indexName}-session`);
+    const session = await client.session(sessionName);
     const sessionDocs = [
       { id: 'sess-1', text: 'Customer was charged twice for the March renewal.' },
       { id: 'sess-2', text: 'Agent confirmed a refund for the duplicate charge.' },
@@ -369,10 +370,6 @@ async function comprehensiveMossExample(): Promise<void> {
 
     const pushed = await session.pushIndex();
     console.log(`Session pushed to cloud: ${pushed.docCount} docs (job ${pushed.jobId})`);
-
-    console.log(`\nStep 14: Cleaning up - deleting test indexes...`);
-    const deleted = await client.deleteIndex(indexName);
-    console.log(`Index deleted: ${deleted}`);
 
     console.log(`\nComprehensive Moss SDK Example Completed Successfully! (Ctrl+C to exit)`);
     console.log('='.repeat(60));
@@ -391,14 +388,15 @@ async function comprehensiveMossExample(): Promise<void> {
         console.error(`   Status code: ${(error as { status: unknown }).status}`);
       }
     }
-
-    // Attempt cleanup even if there was an error
-    try {
-      console.log(`\nAttempting cleanup due to error...`);
-      await client.deleteIndex(indexName);
-      console.log(`Cleanup completed`);
-    } catch {
-      console.log(`Cleanup failed - manual cleanup may be required`);
+  } finally {
+    console.log(`\nStep 14: Cleaning up - deleting test indexes...`);
+    for (const name of [indexName, sessionName]) {
+      try {
+        await client.deleteIndex(name);
+        console.log(`  Deleted: ${name}`);
+      } catch {
+        console.log(`  Could not delete '${name}' — may not exist yet or already gone`);
+      }
     }
   }
 }

--- a/examples/javascript/package-lock.json
+++ b/examples/javascript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@moss-dev/moss": "^1.3.0",
+        "@moss-dev/moss": "^1.3.1",
         "dotenv": "^17.4.2",
         "openai": "^6.42.0"
       },
@@ -591,34 +591,34 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@moss-dev/moss": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss/-/moss-1.3.0.tgz",
-      "integrity": "sha512-3D1yZWetHzUDfKQPkcvR1WznWDjq4PThWdqqtY2E5MSgMMnA94kJF7YwN7L4sADTQdql9mX5HrPLY+utaRY8bw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss/-/moss-1.3.1.tgz",
+      "integrity": "sha512-DU6m+1kPBtWJ3iJEHZ5qQCunJBvL2xx/v1NsW6mQfh245QZhQGikS/Zsn8UKxl+M5rPaozKL5aQX4NmrdYvqZQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@moss-dev/moss-core": "0.19.0"
+        "@moss-dev/moss-core": "0.19.1"
       }
     },
     "node_modules/@moss-dev/moss-core": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core/-/moss-core-0.19.0.tgz",
-      "integrity": "sha512-yziQuEjA9rZwky6zSy3DgAQzOuDKCL+XtaJmdJ0UJn5CEVXgozym8HdIiwMsNzmqByI2eTFxwkWLTHenwbKBag==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core/-/moss-core-0.19.1.tgz",
+      "integrity": "sha512-YeH+kKuHVyEW0JRF2jP90VQbV8HeGfRtV9U5u5v9MVo0WQ4Lfa8kqM509TE4VMOpHDpO7HMDKn/izRR6Vvw3+w==",
       "license": "Proprietary",
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@moss-dev/moss-core-darwin-arm64": "0.19.0",
-        "@moss-dev/moss-core-darwin-x64": "0.19.0",
-        "@moss-dev/moss-core-linux-arm64-gnu": "0.19.0",
-        "@moss-dev/moss-core-linux-x64-gnu": "0.19.0",
-        "@moss-dev/moss-core-win32-x64-msvc": "0.19.0"
+        "@moss-dev/moss-core-darwin-arm64": "0.19.1",
+        "@moss-dev/moss-core-darwin-x64": "0.19.1",
+        "@moss-dev/moss-core-linux-arm64-gnu": "0.19.1",
+        "@moss-dev/moss-core-linux-x64-gnu": "0.19.1",
+        "@moss-dev/moss-core-win32-x64-msvc": "0.19.1"
       }
     },
     "node_modules/@moss-dev/moss-core-darwin-arm64": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-darwin-arm64/-/moss-core-darwin-arm64-0.19.0.tgz",
-      "integrity": "sha512-RR4TMm8N8SYNOatIQSXsuHveqxdlBESdD1RybERLyOYIqx3jTJFDgD201SjIo3rG16kPGhqUW7j92J/qQbs5vQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-darwin-arm64/-/moss-core-darwin-arm64-0.19.1.tgz",
+      "integrity": "sha512-Tu8moQH3hMRfEv/C9fB2HLY7wVoxlVQ2a6vJrBPYdqnEpQRdDNggos3bBevarxEnJhDgp27zvjw5UeWN+H+YRg==",
       "cpu": [
         "arm64"
       ],
@@ -632,9 +632,9 @@
       }
     },
     "node_modules/@moss-dev/moss-core-darwin-x64": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-darwin-x64/-/moss-core-darwin-x64-0.19.0.tgz",
-      "integrity": "sha512-kqv091zkAq5FMKG39udk8U6qHslE5Gz1k6Tn/MTpPv3I3jZ9lj/hn6Jm/lZBqrJMa8FKOstrlHIHrjr2g75ZNg==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-darwin-x64/-/moss-core-darwin-x64-0.19.1.tgz",
+      "integrity": "sha512-DIv/mQrQMR8OYyT/bXXVx6s/XagGzuhbUESvEN9OWQu1eAYD2hqOyJXjAOMsVVYLCB8o0nlolQfbnFiYRUlvbQ==",
       "cpu": [
         "x64"
       ],
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@moss-dev/moss-core-linux-arm64-gnu": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-linux-arm64-gnu/-/moss-core-linux-arm64-gnu-0.19.0.tgz",
-      "integrity": "sha512-9n7o1OpGb9Wga9Rkl1zBt4RFj66eJrw6mncHtcByG6inTzTbmRVcaTI+T1RGC8ikKeWS4DJJ35dMyi8r/qGjAQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-linux-arm64-gnu/-/moss-core-linux-arm64-gnu-0.19.1.tgz",
+      "integrity": "sha512-OrOM6n0z/T5ZryiOwGEBy14zqn/kJXMbTNykBlJIZmCIA0cCvPZqLUt2cMVh+Y51Ofy4HhMnXuyFmsLC8nER0g==",
       "cpu": [
         "arm64"
       ],
@@ -664,9 +664,9 @@
       }
     },
     "node_modules/@moss-dev/moss-core-linux-x64-gnu": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-linux-x64-gnu/-/moss-core-linux-x64-gnu-0.19.0.tgz",
-      "integrity": "sha512-L9Y7GiOSCidc+bYuy4WUUFhMy1QAnI9ifG2rNBgYxYW4U2gPgPYLGG6nNkQYBo0iqK5mKzEp1Qhp1K5Pi157RA==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-linux-x64-gnu/-/moss-core-linux-x64-gnu-0.19.1.tgz",
+      "integrity": "sha512-18dZ8pFr0LZvfGCkxGXyCk9zqSmWPKcn5Cmt+JaSfA0vmZiZjQ4EgWAQdTJxGBs+cIa+vc3oMaVGuvJiotMhnw==",
       "cpu": [
         "x64"
       ],
@@ -680,9 +680,9 @@
       }
     },
     "node_modules/@moss-dev/moss-core-win32-x64-msvc": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-win32-x64-msvc/-/moss-core-win32-x64-msvc-0.19.0.tgz",
-      "integrity": "sha512-2xFB8OQagwAHihg+ktjJxQNdMzMaXwwxIcbyV265ZvBxcjW4odLraumgjsReJr2Z+N5Y4pMVpoLtx+C9K2ThMg==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-win32-x64-msvc/-/moss-core-win32-x64-msvc-0.19.1.tgz",
+      "integrity": "sha512-VvOuq/U8IsRdHoGvcJH5jBM1QYuAQsJ7BUcr+OSXqFfht0TB4OpJMHcn9frSzVQ16ULf8x0ewSZYteNxLXKu9w==",
       "cpu": [
         "x64"
       ],
@@ -799,7 +799,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -1022,7 +1021,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1317,7 +1315,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2343,7 +2340,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2428,7 +2424,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2496,7 +2491,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",

--- a/examples/javascript/package.json
+++ b/examples/javascript/package.json
@@ -35,14 +35,18 @@
     "type-check": "tsc --noEmit",
     "lint": "ESLINT_USE_FLAT_CONFIG=true eslint .",
     "format": "prettier --write .",
+    "load-and-query": "tsx load_and_query_sample.ts",
     "cached-load": "tsx cached_load_sample.ts",
     "session": "tsx session_sample.ts",
     "session-cache": "tsx session_cache_sample.ts",
     "session-custom-auth": "tsx session_custom_auth_sample.ts",
+    "custom-auth": "tsx custom_authenticator_sample.ts",
+    "custom-embedding": "tsx custom_embedding_sample.ts",
+    "comprehensive": "tsx comprehensive_sample.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@moss-dev/moss": "^1.3.0",
+    "@moss-dev/moss": "^1.3.1",
     "dotenv": "^17.4.2",
     "openai": "^6.42.0"
   },

--- a/examples/javascript/session_sample.ts
+++ b/examples/javascript/session_sample.ts
@@ -4,7 +4,7 @@
  * A `SessionIndex` is a local, in-process index: documents are embedded and
  * queried entirely in memory with no cloud round-trip. At the end of a session
  * call `pushIndex()` to persist it to the cloud so another agent or device can
- * resume it via `loadIndex()`.
+ * resume it by opening a new session with `client.session()`.
  *
  * Typical use-cases:
  *  - Indexing a live conversation turn-by-turn as it happens

--- a/examples/javascript/session_sample.ts
+++ b/examples/javascript/session_sample.ts
@@ -1,78 +1,93 @@
 /**
- * Moss SDK Session Sample
+ * Moss SDK - Session Sample
  *
- * A SessionIndex is a local, in-process index you read and write in real time with no
- * cloud round trip, then push to the cloud so another agent or device can resume it.
- * This is how Moss indexes a live conversation (e.g. voice/chat transcript turns).
+ * A `SessionIndex` is a local, in-process index: documents are embedded and
+ * queried entirely in memory with no cloud round-trip. At the end of a session
+ * call `pushIndex()` to persist it to the cloud so another agent or device can
+ * resume it via `loadIndex()`.
+ *
+ * Typical use-cases:
+ *  - Indexing a live conversation turn-by-turn as it happens
+ *  - Ephemeral per-user or per-request search spaces
+ *  - Offline-first mobile apps that sync on demand
  *
  * Required Environment Variables:
  * - MOSS_PROJECT_ID: Your Moss project ID
  * - MOSS_PROJECT_KEY: Your Moss project key
- * - MOSS_INDEX_NAME: Name for the session index (created or resumed). Defaults to "session-demo".
+ * - MOSS_INDEX_NAME: Name for the session index. Defaults to "session-demo".
+ *
+ * @example
+ * ```bash
+ * npm run session
+ * ```
  */
 
 import { MossClient, DocumentInfo } from "@moss-dev/moss";
 import { config } from "dotenv";
 
-// Load environment variables
 config();
 
-/**
- * Open a session, index documents locally, query in-memory, then push to the cloud.
- */
 async function sessionSample(): Promise<void> {
   console.log("Moss SDK - Session Sample");
+  console.log("=".repeat(40));
 
-  // Load configuration from environment variables
   const projectId = process.env.MOSS_PROJECT_ID;
   const projectKey = process.env.MOSS_PROJECT_KEY;
   const indexName = process.env.MOSS_INDEX_NAME ?? "session-demo";
 
   if (!projectId || !projectKey) {
-    console.error("Error: Missing required environment variables!");
-    console.error("Please set MOSS_PROJECT_ID and MOSS_PROJECT_KEY in .env file");
+    console.error("Error: Please set MOSS_PROJECT_ID and MOSS_PROJECT_KEY in .env");
     return;
   }
 
-  // Initialize Moss client
   const client = new MossClient(projectId, projectKey);
 
   try {
-    // Open a session by name. If a cloud index with this name already exists it
-    // auto-loads; otherwise the session starts empty. No cloud round trip on add/query.
+    // Open a session. If a cloud index with this name already exists it is
+    // loaded into the session automatically; otherwise it starts empty.
     console.log(`\nOpening session '${indexName}'...`);
     const session = await client.session(indexName);
-    console.log(`Session open (${session.docCount} existing docs)`);
+    console.log(`Session open (${session.docCount} pre-existing docs, model: ${session.modelId})`);
 
-    // Add documents as they arrive (e.g. transcript turns). Embedded locally.
-    console.log(`\nAdding documents locally...`);
+    // Add documents locally — embeddings are generated in Rust, no network call.
+    console.log("\nAdding documents locally...");
     const turns: DocumentInfo[] = [
       { id: "turn-1", text: "Customer was charged twice for the March renewal." },
       { id: "turn-2", text: "Agent confirmed a refund for the duplicate charge." },
       { id: "turn-3", text: "Customer also asked to cancel auto-renew." },
     ];
     const { added, updated } = await session.addDocs(turns);
-    console.log(`${added} added, ${updated} updated (${session.docCount} total)`);
+    console.log(`${added} added, ${updated} updated (${session.docCount} total in session)`);
 
-    // Query the in-memory session (~1-10 ms, no network).
-    console.log(`\nQuerying the session...`);
-    const results = await session.query("what did the customer want refunded", { topK: 3 });
-    results.docs.forEach((doc) => {
-      console.log(`  [${doc.id}] ${doc.score.toFixed(3)}  ${doc.text}`);
+    // Retrieve the documents we just added.
+    console.log("\nRetrieving all session docs...");
+    const docs = await session.getDocs();
+    docs.forEach((doc) => {
+      console.log(`  [${doc.id}] ${doc.text}`);
     });
 
-    // Push the session to the cloud so another agent or device can resume it.
-    console.log(`\nPushing session to the cloud...`);
+    // Query the in-memory index — typically 1-10 ms with no network latency.
+    console.log("\nQuerying the session...");
+    const results = await session.query("what did the customer want refunded", { topK: 3 });
+    console.log(`${results.docs.length} results:`);
+    results.docs.forEach((doc) => {
+      console.log(`  [${doc.id}] score=${doc.score.toFixed(3)}  ${doc.text}`);
+    });
+
+    // Push the session to the cloud so another process can resume it.
+    console.log("\nPushing session to the cloud...");
     const pushed = await session.pushIndex();
     console.log(`Pushed ${pushed.docCount} docs (job ${pushed.jobId})`);
 
-    console.log(`\nSample completed successfully!`);
+    console.log("\nDone! Another agent can now resume this session with: (Ctrl+C to exit)");
+    console.log(`  const session = await client.session('${indexName}');`);
   } catch (error) {
     console.error(`Error: ${error}`);
   }
 }
 
-// Run the example if this file is executed directly
+export { sessionSample };
+
 if (require.main === module) {
   sessionSample().catch(console.error);
 }


### PR DESCRIPTION
Changes done in this PR


package.json — bumped @moss-dev/moss to ^1.3.1; added 4 missing npm scripts: load-and-query, custom-auth, custom-embedding, comprehensive

cached_load_sample.ts — replaced the autoRefresh comment block with actual runnable code: shows loading with autoRefresh: true + pollingIntervalInSeconds, and how to stop it by reloading without the option

session_sample.ts — added a getDocs() call to show the full session API surface; added session.modelId to the open log; added (Ctrl+C to exit) on the final line

comprehensive_sample.ts — trimmed the multi-paragraph JSDoc header; added Step 9 (metadata filter query using $and/$eq/$in); added Step 13 (SessionIndex demo — addDocs/query/pushIndex entirely in-memory); renumbered subsequent steps accordingly

README.md — full rewrite: added a quick-reference table (which samples need an existing index, which create their own), per-sample testing guide with exact commands and what output to verify, troubleshooting table

.env.template — new file; documents all 4 env vars with notes on which samples need each one