### PR TITLE
feat: Add moss-connector-snowflake

### DIFF
--- a/packages/moss-data-connector/README.md
+++ b/packages/moss-data-connector/README.md
@@ -45,6 +45,7 @@ Use `auto_id=True` when your mapper does not have a stable primary key and you w
 | [`moss-connector-mysql`](moss-connector-mysql)             | MySQL         | `pymysql`    |
 | [`moss-connector-supabase`](moss-connector-supabase)       | Supabase      | `supabase`   |
 | [`moss-connector-dynamodb`](moss-connector-dynamodb)       | Amazon DynamoDB | `boto3`    |
+| [`moss-connector-snowflake`](moss-connector-snowflake)     | Snowflake     | `snowflake-connector-python` |
 | [`moss-connector-huggingface`](moss-connector-huggingface) | Hugging Face datasets | `datasets` |
 | [`moss-connector-s3`](moss-connector-s3)                   | Amazon S3     | `boto3`      |
 | [`moss-connector-zeroentropy`](moss-connector-zeroentropy) | ZeroEntropy   | `zeroentropy` |

--- a/packages/moss-data-connector/moss-connector-snowflake/.env.example
+++ b/packages/moss-data-connector/moss-connector-snowflake/.env.example
@@ -1,0 +1,22 @@
+# Snowflake connection
+SNOWFLAKE_ACCOUNT="orgid-accountid"          # e.g. ydsjiyy-iz79905 or xy12345.us-east-1
+SNOWFLAKE_USER="your_snowflake_user"
+SNOWFLAKE_WAREHOUSE="COMPUTE_WH"
+SNOWFLAKE_DATABASE="MY_DATABASE"
+SNOWFLAKE_SCHEMA="PUBLIC"
+SNOWFLAKE_ROLE="SYSADMIN"                    # optional, remove if not needed
+
+# Authentication — choose one of the two options below:
+
+# Option A: Password (standard user without MFA)
+SNOWFLAKE_PASSWORD="your_password"
+
+# Option B: RSA key-pair (SERVICE or MFA-enforced accounts)
+# Generate with: openssl genrsa 2048 | openssl pkcs8 -topk8 -nocrypt -out rsa_key.p8
+# Then set the public key on your user in Snowflake:
+#   ALTER USER your_user SET RSA_PUBLIC_KEY='<contents of rsa_key.pub>';
+# SNOWFLAKE_PRIVATE_KEY_PATH="rsa_key.p8"
+
+# Moss credentials (https://app.getmoss.dev)
+MOSS_PROJECT_ID="your-moss-project-id"
+MOSS_PROJECT_KEY="your-moss-project-key"

--- a/packages/moss-data-connector/moss-connector-snowflake/.gitignore
+++ b/packages/moss-data-connector/moss-connector-snowflake/.gitignore
@@ -1,0 +1,16 @@
+# Local secrets
+.env
+rsa_key.p8
+
+# Local dev / recording helpers
+demo_ingest.py
+test_output.txt
+
+# Python
+__pycache__/
+*.py[cod]
+.pytest_cache/
+*.egg-info/
+dist/
+build/
+.venv/

--- a/packages/moss-data-connector/moss-connector-snowflake/README.md
+++ b/packages/moss-data-connector/moss-connector-snowflake/README.md
@@ -1,0 +1,83 @@
+# moss-connector-snowflake
+
+Snowflake source connector for Moss. It runs a SQL query against a Snowflake
+warehouse and turns each returned row into a Moss `DocumentInfo`.
+
+## Install
+
+```bash
+pip install moss-connector-snowflake
+```
+
+This package uses the official `snowflake-connector-python` driver.
+
+## Usage
+
+```python
+import asyncio
+from moss import DocumentInfo
+from moss_connector_snowflake import SnowflakeConnector, ingest
+
+async def main():
+    source = SnowflakeConnector(
+        account="xy12345.us-east-1",
+        user="your_user",
+        password="your_password",
+        warehouse="COMPUTE_WH",
+        database="MY_DB",
+        schema="PUBLIC",
+        query="SELECT id, title, body FROM articles",
+        mapper=lambda row: DocumentInfo(
+            id=str(row["ID"]),
+            text=row["BODY"],
+            metadata={"title": row["TITLE"]},
+        ),
+    )
+
+    result = await ingest(
+        source,
+        project_id="your_project_id",
+        project_key="your_project_key",
+        index_name="articles",
+    )
+    print(f"copied {result.doc_count} rows")
+
+asyncio.run(main())
+```
+
+Snowflake uppercases unquoted column names in result rows, so
+`SELECT id, title, body ...` is typically mapped as `row["ID"]`,
+`row["TITLE"]`, and `row["BODY"]`.
+
+Use `auto_id=True` when your mapper does not have a stable primary key and you
+want Moss to generate UUID document IDs.
+
+## Layout
+
+```text
+src/
+|-- __init__.py      # re-exports SnowflakeConnector and ingest
+|-- connector.py     # SnowflakeConnector class
+`-- ingest.py        # ingest() - keep in sync with the other connector packages
+```
+
+## Tests
+
+```bash
+pip install -e ".[dev]"
+pytest tests/test_snowflake.py -v
+pytest tests/test_integration_snowflake_moss.py -v -s
+```
+
+The integration test requires Snowflake and Moss credentials:
+
+```bash
+SNOWFLAKE_ACCOUNT=...
+SNOWFLAKE_USER=...
+SNOWFLAKE_PASSWORD=...
+SNOWFLAKE_WAREHOUSE=...
+SNOWFLAKE_DATABASE=...
+SNOWFLAKE_SCHEMA=...
+MOSS_PROJECT_ID=...
+MOSS_PROJECT_KEY=...
+```

--- a/packages/moss-data-connector/moss-connector-snowflake/pyproject.toml
+++ b/packages/moss-data-connector/moss-connector-snowflake/pyproject.toml
@@ -1,0 +1,56 @@
+[project]
+name = "moss-connector-snowflake"
+version = "0.0.1"
+description = "Snowflake source connector for moss-connectors."
+readme = "README.md"
+requires-python = ">=3.10,<3.15"
+license = { text = "BSD-2-Clause" }
+authors = [{ name = "InferEdge Inc.", email = "contact@moss.dev" }]
+keywords = ["moss", "connectors", "snowflake", "ingest", "etl"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Database",
+]
+dependencies = [
+    "moss>=1.1.1",
+    "snowflake-connector-python>=3.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "python-dotenv>=1.0.0",
+    "ruff>=0.5.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/usemoss/moss"
+Repository = "https://github.com/usemoss/moss"
+Source = "https://github.com/usemoss/moss/tree/main/packages/moss-data-connector/moss-connector-snowflake"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+# Flat layout: src/ itself IS the package `moss_connector_snowflake`.
+[tool.setuptools]
+packages = ["moss_connector_snowflake"]
+package-dir = { "moss_connector_snowflake" = "src" }
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "B", "UP"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/packages/moss-data-connector/moss-connector-snowflake/src/__init__.py
+++ b/packages/moss-data-connector/moss-connector-snowflake/src/__init__.py
@@ -1,0 +1,9 @@
+"""Snowflake source connector for Moss.
+
+    from moss_connector_snowflake import SnowflakeConnector, ingest
+"""
+
+from .connector import SnowflakeConnector
+from .ingest import ingest
+
+__all__ = ["SnowflakeConnector", "ingest"]

--- a/packages/moss-data-connector/moss-connector-snowflake/src/connector.py
+++ b/packages/moss-data-connector/moss-connector-snowflake/src/connector.py
@@ -1,0 +1,88 @@
+"""Snowflake connector.
+
+Reads rows from a Snowflake warehouse via ``snowflake-connector-python`` and
+yields one ``DocumentInfo`` per row. Uses ``DictCursor`` so every row is a
+plain dict keyed by column name.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import snowflake.connector
+from moss import DocumentInfo
+from snowflake.connector import DictCursor
+
+
+def _load_private_key_bytes(path: str) -> bytes:
+    """Load an unencrypted PKCS8 PEM private key and return DER bytes."""
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        NoEncryption,
+        PrivateFormat,
+        load_pem_private_key,
+    )
+
+    with open(path, "rb") as fh:
+        key = load_pem_private_key(fh.read(), password=None)
+    return key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+
+
+class SnowflakeConnector:
+    """Run a SELECT against Snowflake and yield one ``DocumentInfo`` per row.
+
+    ``mapper`` turns a row dict into a ``DocumentInfo``; the caller decides
+    which columns become id, text, metadata, or embedding.
+    """
+
+    def __init__(
+        self,
+        account: str,
+        user: str,
+        warehouse: str,
+        database: str,
+        schema: str,
+        query: str,
+        mapper: Callable[[dict[str, Any]], DocumentInfo],
+        password: str | None = None,
+        private_key_path: str | None = None,
+        role: str | None = None,
+    ) -> None:
+        if not password and not private_key_path:
+            raise ValueError("Either 'password' or 'private_key_path' must be provided.")
+        self.account = account
+        self.user = user
+        self.password = password
+        self.private_key_path = private_key_path
+        self.warehouse = warehouse
+        self.database = database
+        self.schema = schema
+        self.query = query
+        self.mapper = mapper
+        self.role = role
+
+    def __iter__(self) -> Iterator[DocumentInfo]:
+        connect_kwargs: dict[str, Any] = {
+            "account": self.account,
+            "user": self.user,
+            "warehouse": self.warehouse,
+            "database": self.database,
+            "schema": self.schema,
+        }
+        if self.private_key_path:
+            connect_kwargs["private_key"] = _load_private_key_bytes(self.private_key_path)
+        else:
+            connect_kwargs["password"] = self.password
+        if self.role is not None:
+            connect_kwargs["role"] = self.role
+
+        conn = snowflake.connector.connect(**connect_kwargs)
+        cursor = conn.cursor(DictCursor)
+        try:
+            cursor.execute(self.query)
+            for row in cursor:
+                yield self.mapper(row)
+        finally:
+            cursor.close()
+            conn.close()

--- a/packages/moss-data-connector/moss-connector-snowflake/src/connector.py
+++ b/packages/moss-data-connector/moss-connector-snowflake/src/connector.py
@@ -78,11 +78,13 @@ class SnowflakeConnector:
             connect_kwargs["role"] = self.role
 
         conn = snowflake.connector.connect(**connect_kwargs)
-        cursor = conn.cursor(DictCursor)
         try:
-            cursor.execute(self.query)
-            for row in cursor:
-                yield self.mapper(row)
+            cursor = conn.cursor(DictCursor)
+            try:
+                cursor.execute(self.query)
+                for row in cursor:
+                    yield self.mapper(row)
+            finally:
+                cursor.close()
         finally:
-            cursor.close()
             conn.close()

--- a/packages/moss-data-connector/moss-connector-snowflake/src/ingest.py
+++ b/packages/moss-data-connector/moss-connector-snowflake/src/ingest.py
@@ -1,0 +1,36 @@
+"""Copy rows into a Moss index."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+
+from moss import DocumentInfo, MossClient, MutationResult
+
+
+def _replace_doc_id(doc: DocumentInfo) -> DocumentInfo:
+    return DocumentInfo(
+        id=str(uuid.uuid4()),
+        text=doc.text,
+        metadata=getattr(doc, "metadata", None),
+        embedding=getattr(doc, "embedding", None),
+    )
+
+
+async def ingest(
+    source: Iterable[DocumentInfo],
+    project_id: str,
+    project_key: str,
+    index_name: str,
+    model_id: str | None = None,
+    auto_id: bool = False,
+) -> MutationResult | None:
+    """Copy every ``DocumentInfo`` from ``source`` into a fresh Moss index."""
+    if auto_id:
+        docs = [_replace_doc_id(doc) for doc in source]
+    else:
+        docs = list(source)
+    if not docs:
+        return None
+    client = MossClient(project_id, project_key)
+    return await client.create_index(index_name, docs, model_id=model_id)

--- a/packages/moss-data-connector/moss-connector-snowflake/tests/test_integration_snowflake_moss.py
+++ b/packages/moss-data-connector/moss-connector-snowflake/tests/test_integration_snowflake_moss.py
@@ -1,0 +1,183 @@
+"""End-to-end integration test against real Snowflake and Moss projects.
+
+This test creates a throwaway Snowflake table, ingests from it into a real Moss
+index, queries the index, and cleans up afterwards. It is skipped unless
+Snowflake and Moss credentials are set in the environment or a loaded .env file.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Load .env from the package dir, then the repo root, if present.
+try:
+    from dotenv import load_dotenv
+
+    _here = Path(__file__).resolve()
+    for candidate in (
+        _here.parents[1] / ".env",
+        _here.parents[2] / ".env",
+        _here.parents[4] / ".env",
+    ):
+        if candidate.exists():
+            load_dotenv(candidate, override=False)
+except ImportError:
+    pass
+
+pytest.importorskip("snowflake.connector")
+
+import snowflake.connector  # noqa: E402
+from moss import DocumentInfo, MossClient, QueryOptions  # noqa: E402
+from moss_connector_snowflake import SnowflakeConnector, ingest  # noqa: E402
+
+SNOWFLAKE_ACCOUNT = os.getenv("SNOWFLAKE_ACCOUNT")
+SNOWFLAKE_USER = os.getenv("SNOWFLAKE_USER")
+SNOWFLAKE_PASSWORD = os.getenv("SNOWFLAKE_PASSWORD")
+SNOWFLAKE_PRIVATE_KEY_PATH = os.getenv("SNOWFLAKE_PRIVATE_KEY_PATH")
+SNOWFLAKE_WAREHOUSE = os.getenv("SNOWFLAKE_WAREHOUSE")
+SNOWFLAKE_DATABASE = os.getenv("SNOWFLAKE_DATABASE")
+SNOWFLAKE_SCHEMA = os.getenv("SNOWFLAKE_SCHEMA")
+SNOWFLAKE_ROLE = os.getenv("SNOWFLAKE_ROLE")
+PROJECT_ID = os.getenv("MOSS_PROJECT_ID")
+PROJECT_KEY = os.getenv("MOSS_PROJECT_KEY")
+
+_has_auth = bool(SNOWFLAKE_PASSWORD or SNOWFLAKE_PRIVATE_KEY_PATH)
+
+pytestmark = pytest.mark.skipif(
+    not (
+        SNOWFLAKE_ACCOUNT
+        and SNOWFLAKE_USER
+        and _has_auth
+        and SNOWFLAKE_WAREHOUSE
+        and SNOWFLAKE_DATABASE
+        and SNOWFLAKE_SCHEMA
+        and PROJECT_ID
+        and PROJECT_KEY
+    ),
+    reason=(
+        "Set SNOWFLAKE_ACCOUNT, SNOWFLAKE_USER, SNOWFLAKE_PASSWORD (or "
+        "SNOWFLAKE_PRIVATE_KEY_PATH), SNOWFLAKE_WAREHOUSE, SNOWFLAKE_DATABASE, "
+        "SNOWFLAKE_SCHEMA, MOSS_PROJECT_ID, and MOSS_PROJECT_KEY to run the real "
+        "integration test."
+    ),
+)
+
+
+def _load_private_key(path: str) -> bytes:
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        NoEncryption,
+        PrivateFormat,
+        load_pem_private_key,
+    )
+
+    with open(path, "rb") as f:
+        key = load_pem_private_key(f.read(), password=None)
+    return key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+
+
+def _snowflake_params() -> dict[str, Any]:
+    params: dict[str, Any] = {
+        "account": SNOWFLAKE_ACCOUNT,
+        "user": SNOWFLAKE_USER,
+        "warehouse": SNOWFLAKE_WAREHOUSE,
+        "database": SNOWFLAKE_DATABASE,
+        "schema": SNOWFLAKE_SCHEMA,
+    }
+    if SNOWFLAKE_PRIVATE_KEY_PATH:
+        params["private_key"] = _load_private_key(SNOWFLAKE_PRIVATE_KEY_PATH)
+    elif SNOWFLAKE_PASSWORD:
+        params["password"] = SNOWFLAKE_PASSWORD
+    if SNOWFLAKE_ROLE:
+        params["role"] = SNOWFLAKE_ROLE
+    return params
+
+
+@pytest.fixture()
+def snowflake_table():
+    """Create a throwaway table with 5 recognisable rows, then drop it."""
+    table_name = f"MOSS_TEST_{uuid.uuid4().hex[:8].upper()}"
+    conn = snowflake.connector.connect(**_snowflake_params())
+    try:
+        cursor = conn.cursor()
+        try:
+            # Explicitly set session context — service users may have no defaults.
+            if SNOWFLAKE_ROLE:
+                cursor.execute(f"USE ROLE {SNOWFLAKE_ROLE}")
+            cursor.execute(f"USE WAREHOUSE {SNOWFLAKE_WAREHOUSE}")
+            cursor.execute(f"USE DATABASE {SNOWFLAKE_DATABASE}")
+            cursor.execute(f"USE SCHEMA {SNOWFLAKE_SCHEMA}")
+            cursor.execute(f"CREATE TABLE {table_name} (id INT, title STRING, body STRING)")
+
+            cursor.executemany(
+                f"INSERT INTO {table_name} (id, title, body) VALUES (%s, %s, %s)",
+                [
+                    (1, "Refund policy", "Refunds take 3 to 5 business days."),
+                    (2, "Shipping time", "Orders ship within 24 hours."),
+                    (3, "Contact support", "Reach support 24/7 via live chat."),
+                    (4, "Password reset", "Click the link on the login page."),
+                    (5, "Order tracking", "Tracking number sent by email."),
+                ],
+            )
+        finally:
+            cursor.close()
+        yield table_name
+    finally:
+        cursor = conn.cursor()
+        try:
+            cursor.execute(f"USE DATABASE {SNOWFLAKE_DATABASE}")
+            cursor.execute(f"USE SCHEMA {SNOWFLAKE_SCHEMA}")
+            cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        finally:
+            cursor.close()
+            conn.close()
+
+
+async def test_snowflake_ingest_end_to_end(snowflake_table):
+    """Full round trip: Snowflake -> Moss index -> query -> delete."""
+    client = MossClient(PROJECT_ID, PROJECT_KEY)
+    index_name = f"moss-snowflake-e2e-{uuid.uuid4().hex[:8]}"
+
+    try:
+        connector = SnowflakeConnector(
+            account=SNOWFLAKE_ACCOUNT,
+            user=SNOWFLAKE_USER,
+            password=SNOWFLAKE_PASSWORD if not SNOWFLAKE_PRIVATE_KEY_PATH else None,
+            private_key_path=SNOWFLAKE_PRIVATE_KEY_PATH,
+            warehouse=SNOWFLAKE_WAREHOUSE,
+            database=SNOWFLAKE_DATABASE,
+            schema=SNOWFLAKE_SCHEMA,
+            role=SNOWFLAKE_ROLE,
+            query=f"SELECT id, title, body FROM {snowflake_table}",
+            mapper=lambda row: DocumentInfo(
+                id=str(row["ID"]),
+                text=row["BODY"],
+                metadata={"title": row["TITLE"]},
+            ),
+        )
+
+        result = await ingest(connector, PROJECT_ID, PROJECT_KEY, index_name=index_name)
+        assert result is not None
+        assert result.doc_count == 5
+
+        await client.load_index(index_name)
+        result = await client.query(index_name, "how long do refunds take", QueryOptions(top_k=3))
+
+        assert result.docs, "expected at least one document in the search result"
+        top_ids = [doc.id for doc in result.docs]
+        assert "1" in top_ids, f"refund-policy doc not in top 3: {top_ids}"
+
+        refund_doc = next(doc for doc in result.docs if doc.id == "1")
+        assert refund_doc.metadata is not None
+        assert refund_doc.metadata.get("title") == "Refund policy"
+
+    finally:
+        try:
+            await client.delete_index(index_name)
+        except Exception as exc:  # pragma: no cover, best-effort cleanup
+            print(f"warning: failed to delete test index {index_name}: {exc}")

--- a/packages/moss-data-connector/moss-connector-snowflake/tests/test_snowflake.py
+++ b/packages/moss-data-connector/moss-connector-snowflake/tests/test_snowflake.py
@@ -1,0 +1,178 @@
+"""Unit tests for the Snowflake connector.
+
+No live Snowflake needed. ``snowflake.connector.connect`` is mocked, and
+``MossClient`` is patched inside ingest so no Moss network call is made.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("snowflake.connector")
+
+from moss import DocumentInfo  # noqa: E402
+from moss_connector_snowflake import SnowflakeConnector, ingest  # noqa: E402
+from snowflake.connector import DictCursor  # noqa: E402
+
+CONNECT_TARGET = "moss_connector_snowflake.connector.snowflake.connector.connect"
+
+
+@dataclass
+class FakeMutationResult:
+    doc_count: int
+    job_id: str = "fake-job-id"
+    index_name: str = ""
+
+
+@dataclass
+class FakeMossClient:
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    async def create_index(self, name, docs, model_id=None):
+        docs = list(docs)
+        self.calls.append({"name": name, "docs": docs, "model_id": model_id})
+        return FakeMutationResult(doc_count=len(docs), index_name=name)
+
+
+def _snowflake_mock_returning(rows: list[dict[str, Any]]) -> tuple[MagicMock, MagicMock]:
+    cursor = MagicMock()
+    cursor.__iter__ = MagicMock(return_value=iter(rows))
+
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    return conn, cursor
+
+
+def _source(**kwargs: Any) -> SnowflakeConnector:
+    defaults = {
+        "account": "xy12345.us-east-1",
+        "user": "app",
+        "password": "secret",
+        "warehouse": "COMPUTE_WH",
+        "database": "MY_DB",
+        "schema": "PUBLIC",
+        "query": "SELECT id, title, body FROM articles",
+        "mapper": lambda row: DocumentInfo(
+            id=str(row["ID"]),
+            text=row["BODY"],
+            metadata={"title": row["TITLE"]},
+        ),
+    }
+    defaults.update(kwargs)
+    return SnowflakeConnector(**defaults)
+
+
+async def test_snowflake_ingest_end_to_end():
+    rows_from_snowflake = [
+        {"ID": 1, "TITLE": "Refund policy", "BODY": "Refunds take 3-5 days."},
+        {"ID": 2, "TITLE": "Shipping", "BODY": "We ship within 24 hours."},
+        {"ID": 3, "TITLE": "Returns", "BODY": "Returns accepted within 30 days."},
+    ]
+    fake_conn, _ = _snowflake_mock_returning(rows_from_snowflake)
+    fake_moss = FakeMossClient()
+
+    with (
+        patch(CONNECT_TARGET, return_value=fake_conn),
+        patch("moss_connector_snowflake.ingest.MossClient", return_value=fake_moss),
+    ):
+        result = await ingest(_source(), "fake_id", "fake_key", index_name="articles")
+
+    assert result is not None
+    assert result.doc_count == 3
+    assert len(fake_moss.calls) == 1
+
+    moss_docs = fake_moss.calls[0]["docs"]
+    assert moss_docs[0].id == "1"
+    assert moss_docs[0].text == "Refunds take 3-5 days."
+    assert moss_docs[0].metadata == {"title": "Refund policy"}
+    assert moss_docs[2].id == "3"
+
+
+async def test_empty_result_skips_network_call():
+    fake_conn, _ = _snowflake_mock_returning([])
+    fake_moss = FakeMossClient()
+
+    with (
+        patch(CONNECT_TARGET, return_value=fake_conn),
+        patch("moss_connector_snowflake.ingest.MossClient", return_value=fake_moss),
+    ):
+        result = await ingest(_source(), "fake_id", "fake_key", "empty")
+
+    assert result is None
+    assert fake_moss.calls == []
+
+
+async def test_connection_args_and_dict_cursor_forwarded():
+    fake_conn, fake_cursor = _snowflake_mock_returning([])
+
+    with patch(CONNECT_TARGET, return_value=fake_conn) as mock_connect:
+        source = _source(role="ANALYST")
+        list(source)
+
+    mock_connect.assert_called_once_with(
+        account="xy12345.us-east-1",
+        user="app",
+        password="secret",
+        warehouse="COMPUTE_WH",
+        database="MY_DB",
+        schema="PUBLIC",
+        role="ANALYST",
+    )
+    fake_conn.cursor.assert_called_once_with(DictCursor)
+    fake_cursor.execute.assert_called_once_with("SELECT id, title, body FROM articles")
+
+
+async def test_connection_role_omitted_when_none():
+    fake_conn, _ = _snowflake_mock_returning([])
+
+    with patch(CONNECT_TARGET, return_value=fake_conn) as mock_connect:
+        list(_source())
+
+    assert "role" not in mock_connect.call_args.kwargs
+
+
+async def test_cursor_and_connection_close_on_mapper_failure():
+    fake_conn, fake_cursor = _snowflake_mock_returning(
+        [{"ID": 1, "TITLE": "Refund policy", "BODY": "Refunds take 3-5 days."}]
+    )
+
+    def broken_mapper(row: dict[str, Any]) -> DocumentInfo:
+        raise RuntimeError(f"bad row: {row['ID']}")
+
+    with patch(CONNECT_TARGET, return_value=fake_conn):
+        source = _source(mapper=broken_mapper)
+        with pytest.raises(RuntimeError, match="bad row: 1"):
+            list(source)
+
+    fake_cursor.close.assert_called_once()
+    fake_conn.close.assert_called_once()
+
+
+async def test_auto_id_replaces_mapper_id():
+    rows_from_snowflake = [
+        {"ID": 1, "TITLE": "T1", "BODY": "B1"},
+        {"ID": 2, "TITLE": "T2", "BODY": "B2"},
+    ]
+    fake_conn, _ = _snowflake_mock_returning(rows_from_snowflake)
+    fake_moss = FakeMossClient()
+
+    with (
+        patch(CONNECT_TARGET, return_value=fake_conn),
+        patch("moss_connector_snowflake.ingest.MossClient", return_value=fake_moss),
+    ):
+        await ingest(_source(), "fake_id", "fake_key", index_name="articles", auto_id=True)
+
+    docs = fake_moss.calls[0]["docs"]
+    assert len(docs) == 2
+    original_ids = {"1", "2"}
+    for doc in docs:
+        assert doc.id
+        assert uuid.UUID(doc.id)
+        assert doc.id not in original_ids
+    assert [doc.text for doc in docs] == ["B1", "B2"]
+    assert [doc.metadata for doc in docs] == [{"title": "T1"}, {"title": "T2"}]


### PR DESCRIPTION
## Pull Request Checklist

Please ensure that your PR meets the following requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [x] I have updated the documentation (if applicable).
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Description
Implements the Snowflake source connector for packages/moss-data-connector as described in issue.

This connector reads the result of any SQL SELECT query from a Snowflake warehouse and turns each row into a DocumentInfo document in a Moss search index. It uses the official snowflake-connector-python driver and works against any Snowflake account (Standard, Enterprise, or Snowflake on Azure/GCP).
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

## What's included

src/connector.py — SnowflakeConnector class with DictCursor so rows come back as dicts keyed by column name
src/ingest.py — ingest() async helper (copied from _template)
src/__init__.py — re-exports SnowflakeConnector and ingest
pyproject.toml — declares snowflake-connector-python>=3.0 dependency
tests/test_snowflake.py — unit tests with mocked snowflake.connector.connect and MossClient
tests/test_integration_snowflake_moss.py — live end-to-end test; auto-skips without credentials
README.md — usage guide and quickstart
.env.example — template with both password and RSA key-pair auth options
Row added to packages/moss-data-connector/README.md

# Auth support

The connector supports both authentication methods:

Password — standard users (as specified in the issue)
RSA key-pair — SERVICE-type users or accounts with MFA enforced (optional private_key_path parameter)

Fixes #170

https://github.com/user-attachments/assets/4066b61d-044b-4c8a-a1cb-8693320ac9b4

<img width="1537" height="221" alt="image" src="https://github.com/user-attachments/assets/762ad5e9-a059-4b7f-9316-2e724907cbdd" />

## Type of Change
Feature

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
