### PR TITLE
feat: add Notion connector

### DIFF
--- a/packages/moss-data-connector/README.md
+++ b/packages/moss-data-connector/README.md
@@ -10,6 +10,7 @@ moss-data-connector/
 ├── moss-connector-sqlite/      # SQLite source (stdlib, no driver)
 ├── moss-connector-mongodb/     # MongoDB source (requires pymongo)
 ├── moss-connector-mysql/       # MySQL / MariaDB source (requires pymysql)
+├── moss-connector-notion/      # Notion source (requires notion-client)
 ├── moss-connector-supabase/    # Supabase source (requires supabase)
 └── moss-connector-dynamodb/    # Amazon DynamoDB source (requires boto3)
 ```
@@ -35,13 +36,14 @@ Use `auto_id=True` when your mapper does not have a stable primary key and you w
 
 ## Available connectors
 
-| Package                                                    | Source        | Extra driver |
-| ---------------------------------------------------------- | ------------- | ------------ |
-| [`moss-connector-sqlite`](moss-connector-sqlite)           | SQLite        | —            |
-| [`moss-connector-mongodb`](moss-connector-mongodb)         | MongoDB       | `pymongo`    |
-| [`moss-connector-mysql`](moss-connector-mysql)             | MySQL         | `pymysql`    |
-| [`moss-connector-supabase`](moss-connector-supabase)       | Supabase      | `supabase`   |
-| [`moss-connector-dynamodb`](moss-connector-dynamodb)       | Amazon DynamoDB | `boto3`    |
+| Package | Source | Extra driver |
+| --- | --- | --- |
+| [`moss-connector-sqlite`](moss-connector-sqlite) | SQLite | — |
+| [`moss-connector-mongodb`](moss-connector-mongodb) | MongoDB | `pymongo` |
+| [`moss-connector-mysql`](moss-connector-mysql) | MySQL | `pymysql` |
+| [`moss-connector-notion`](moss-connector-notion) | Notion | `notion-client` |
+| [`moss-connector-supabase`](moss-connector-supabase) | Supabase | `supabase` |
+| [`moss-connector-dynamodb`](moss-connector-dynamodb) | Amazon DynamoDB | `boto3` |
 
 ## Adding a new connector
 

--- a/packages/moss-data-connector/moss-connector-notion/.gitignore
+++ b/packages/moss-data-connector/moss-connector-notion/.gitignore
@@ -1,0 +1,10 @@
+build/
+dist/
+*.egg-info/
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.env

--- a/packages/moss-data-connector/moss-connector-notion/README.md
+++ b/packages/moss-data-connector/moss-connector-notion/README.md
@@ -1,0 +1,212 @@
+# moss-connector-notion
+
+Notion source connector for Moss. Uses the official [notion-client](https://github.com/ramnes/notion-sdk-py) to read pages from a Notion workspace and ingest them into a Moss index.
+
+## Install
+
+```bash
+pip install moss-connector-notion
+```
+
+This installs `notion-client` automatically.
+
+## Usage
+
+```python
+import asyncio
+
+from moss import DocumentInfo
+from moss_connector_notion import NotionConnector, ingest
+
+
+def flatten_blocks(blocks: list[dict]) -> str:
+    lines = []
+
+    def visit(block):
+        block_type = block.get("type")
+
+        if block_type:
+            payload = block.get(block_type, {})
+            rich_text = payload.get("rich_text", [])
+
+            if rich_text:
+                lines.append(
+                    "".join(part.get("plain_text", "") for part in rich_text)
+                )
+
+        for child in block.get("children", []):
+            visit(child)
+
+    for block in blocks:
+        visit(block)
+
+    return "\n".join(lines)
+
+
+async def main():
+    source = NotionConnector(
+        token="your_notion_token",
+        query="Rust",
+        mapper=lambda page: DocumentInfo(
+            id=page["id"],
+            text=flatten_blocks(page["content"]),
+            metadata={
+                "url": page["url"],
+            },
+        ),
+    )
+
+    result = await ingest(
+        source,
+        project_id="your_project_id",
+        project_key="your_project_key",
+        index_name="notion-pages",
+    )
+
+    print(f"Copied {result.doc_count} pages")
+
+
+asyncio.run(main())
+```
+
+Use `auto_id=True` when your mapper does not have a stable document ID and you want Moss to generate UUID document IDs.
+
+## Data requirements
+
+The connector doesn't enforce a schema. Every Notion page is returned as a Python dictionary with one additional field:
+
+```python
+page["content"]
+```
+
+`content` contains the complete block tree for the page, including nested child blocks.
+
+The connector passes this page dictionary directly to your mapper. The mapper is responsible for converting it into a `DocumentInfo`.
+
+`DocumentInfo` fields:
+
+| Field | Type | Required? | Typical Notion value |
+| --- | --- | --- | --- |
+| `id` | `str` | yes | `page["id"]` |
+| `text` | `str` | yes | extracted text from `page["content"]` |
+| `metadata` | `Optional[Dict[str, str]]` | no | page URL, title, author, etc. |
+| `embedding` | `Optional[Sequence[float]]` | no | only when using `model_id="custom"` |
+
+A typical mapper looks like:
+
+```python
+mapper=lambda page: DocumentInfo(
+    id=page["id"],
+    text=flatten_blocks(page["content"]),
+    metadata={
+        "url": page["url"],
+    },
+)
+```
+
+## One gotcha: metadata values must be strings
+
+`DocumentInfo.metadata` expects `Dict[str, str]`.
+
+If you include values that are numbers, booleans or lists, convert them first.
+
+```python
+# Incorrect
+metadata={
+    "views": 42,
+    "published": True,
+}
+
+# Correct
+metadata={
+    "views": str(42),
+    "published": str(True),
+}
+```
+
+## Authentication
+
+Create a Notion integration and copy its internal integration token.
+
+The integration only has access to pages that have been explicitly shared with it.
+
+If a page doesn't appear during ingestion:
+
+1. Open the page in Notion.
+2. Click **Share**.
+3. Invite your integration.
+
+## Searching pages
+
+The connector optionally accepts a `query` argument.
+
+```python
+NotionConnector(
+    token=TOKEN,
+    query="Python",
+    ...
+)
+```
+
+This uses Notion's built-in search API and only returns matching pages.
+
+If `query` is omitted, every page visible to the integration is scanned.
+
+## Filtering
+
+The connector supports client-side filtering through `filter_fn`.
+
+```python
+source = NotionConnector(
+    token=TOKEN,
+    filter_fn=lambda page: page["url"].startswith("https://"),
+    mapper=...,
+)
+```
+
+The filter runs after the page and all of its blocks have been fetched.
+
+It receives the complete page dictionary, including the `content` field.
+
+## Nested blocks
+
+Notion pages can contain nested blocks (toggles, lists, callouts, etc.).
+
+The connector recursively fetches all child blocks before yielding the page, so `page["content"]` always contains the complete block tree.
+
+The connector does **not** flatten or modify the content. This is left to the mapper so applications can decide how much structure to preserve.
+
+## Pagination
+
+The connector handles pagination automatically.
+
+Both page search results and block children are fetched across multiple requests until all results have been retrieved.
+
+No additional configuration is required.
+
+## Layout
+
+```
+src/
+├── __init__.py      # re-exports NotionConnector and ingest
+├── connector.py     # NotionConnector class
+└── ingest.py        # ingest() - shared across connector packages
+```
+
+## Tests
+
+```bash
+pip install -e ".[dev]"
+
+pytest tests/test_notion.py -v
+pytest tests/test_notion_integration.py -v -s
+```
+
+The integration test requires:
+
+- `NOTION_TOKEN`
+- `NOTION_PARENT_PAGE_ID`
+- `MOSS_PROJECT_ID`
+- `MOSS_PROJECT_KEY`
+
+The test creates a temporary child page under `NOTION_PARENT_PAGE_ID`, ingests it into Moss, verifies semantic search, and archives the page after the test completes.

--- a/packages/moss-data-connector/moss-connector-notion/pyproject.toml
+++ b/packages/moss-data-connector/moss-connector-notion/pyproject.toml
@@ -1,0 +1,55 @@
+[project]
+name            = "moss-connector-notion"
+version         = "0.0.1"
+description     = "Notion data connector for Moss"
+readme          = "README.md"
+requires-python = ">=3.10,<3.15"
+license         = { text = "BSD-2-Clause" }
+authors         = [{ name = "InferEdge Inc.", email = "contact@moss.dev" }]
+keywords        = ["connectors", "ingest", "moss", "notion"]
+classifiers     = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: BSD License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Database",
+]
+dependencies    = [
+  "moss>=1.6",
+  "notion-client>=3.1",
+]
+
+  [project.urls]
+  Homepage   = "https://github.com/usemoss/moss"
+  Repository = "https://github.com/usemoss/moss"
+  Source     = "https://github.com/usemoss/moss/tree/main/packages/moss-data-connector/moss-connector-notion"
+
+  [project.optional-dependencies]
+  dev = [
+    "pytest>=9.0",
+    "pytest-asyncio>=1.0",
+    "python-dotenv>=1.0",
+    "ruff>=0.15",
+  ]
+
+[build-system]
+requires      = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
+[tool.ruff]
+line-length    = 100
+target-version = "py310"
+
+  [tool.ruff.lint]
+  select = ["E", "W", "F", "I", "B", "UP"]
+
+[tool.setuptools]
+packages    = ["moss_connector_notion"]
+package-dir = { "moss_connector_notion" = "src" }

--- a/packages/moss-data-connector/moss-connector-notion/src/__init__.py
+++ b/packages/moss-data-connector/moss-connector-notion/src/__init__.py
@@ -1,0 +1,4 @@
+from .connector import NotionConnector
+from .ingest import ingest
+
+__all__ = ["NotionConnector", "ingest"]

--- a/packages/moss-data-connector/moss-connector-notion/src/connector.py
+++ b/packages/moss-data-connector/moss-connector-notion/src/connector.py
@@ -34,10 +34,10 @@ class NotionConnector:
         cursor = None
 
         while True:
-            response = client.blocks.children.list(
-                block_id=block_id,
-                start_cursor=cursor,
-            )
+            kwargs: dict[str, Any] = {"block_id": block_id}
+            if cursor is not None:
+                kwargs["start_cursor"] = cursor
+            response = client.blocks.children.list(**kwargs)
 
             blocks = response["results"] or []
 

--- a/packages/moss-data-connector/moss-connector-notion/src/connector.py
+++ b/packages/moss-data-connector/moss-connector-notion/src/connector.py
@@ -89,7 +89,7 @@ class NotionConnector:
                 break
 
             for page in pages:
-                page: dict[Any | str, Any | list[dict[str, Any]]] = {
+                page = {
                     **page,
                     "content": self._fetch_blocks(
                         client,

--- a/packages/moss-data-connector/moss-connector-notion/src/connector.py
+++ b/packages/moss-data-connector/moss-connector-notion/src/connector.py
@@ -1,0 +1,108 @@
+"""Notion Connector for Moss."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from typing import Any
+
+from moss import DocumentInfo
+from notion_client import Client
+
+
+class NotionConnector:
+    """Read from Notion and yield DocumentInfo objects."""
+
+    def __init__(
+        self,
+        token: str,
+        mapper: Callable[[dict[str, Any]], DocumentInfo],
+        query: str | None = None,
+        filter_fn: Callable[[dict[str, Any]], bool] | None = None,
+    ) -> None:
+        self.token = token
+        self.query = query
+        self.mapper = mapper
+        self.filter_fn = filter_fn
+
+    def _fetch_blocks(
+        self,
+        client: Client,
+        block_id: str,
+    ) -> list[dict[str, Any]]:
+        all_blocks: list[dict[str, Any]] = []
+
+        cursor = None
+
+        while True:
+            response = client.blocks.children.list(
+                block_id=block_id,
+                start_cursor=cursor,
+            )
+
+            blocks = response["results"] or []
+
+            for block in blocks:
+                if block.get("has_children"):
+                    block = {
+                        **block,
+                        "children": self._fetch_blocks(
+                            client,
+                            block["id"],
+                        ),
+                    }
+
+                all_blocks.append(block)
+
+            if not response["has_more"]:
+                break
+
+            cursor = response["next_cursor"]
+
+        return all_blocks
+
+    def __iter__(self) -> Iterator[DocumentInfo]:
+        FILTER = {
+            "property": "object",
+            "value": "page",
+        }
+
+        client = Client(auth=self.token)
+
+        page_cursor = None
+
+        while True:
+            kwargs: dict[str, Any] = {
+                "filter": FILTER,
+            }
+
+            if self.query is not None:
+                kwargs["query"] = self.query
+
+            if page_cursor is not None:
+                kwargs["start_cursor"] = page_cursor
+
+            search_response = client.search(**kwargs)
+
+            pages = search_response["results"] or []
+
+            if not pages:
+                break
+
+            for page in pages:
+                page: dict[Any | str, Any | list[dict[str, Any]]] = {
+                    **page,
+                    "content": self._fetch_blocks(
+                        client,
+                        page["id"],
+                    ),
+                }
+
+                if self.filter_fn is not None and not self.filter_fn(page):
+                    continue
+
+                yield self.mapper(page)
+
+            if not search_response["has_more"]:
+                break
+
+            page_cursor = search_response["next_cursor"]

--- a/packages/moss-data-connector/moss-connector-notion/src/ingest.py
+++ b/packages/moss-data-connector/moss-connector-notion/src/ingest.py
@@ -1,0 +1,36 @@
+"""Copy rows into a Moss index."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+
+from moss import DocumentInfo, MossClient, MutationResult
+
+
+def _replace_doc_id(doc: DocumentInfo) -> DocumentInfo:
+    return DocumentInfo(
+        id=str(uuid.uuid4()),
+        text=doc.text,
+        metadata=getattr(doc, "metadata", None),
+        embedding=getattr(doc, "embedding", None),
+    )
+
+
+async def ingest(
+    source: Iterable[DocumentInfo],
+    project_id: str,
+    project_key: str,
+    index_name: str,
+    model_id: str | None = None,
+    auto_id: bool = False,
+) -> MutationResult | None:
+    """Copy every `DocumentInfo` from `source` into a fresh Moss index."""
+    if auto_id:
+        docs = [_replace_doc_id(doc) for doc in source]
+    else:
+        docs = list(source)
+    if not docs:
+        return None
+    client = MossClient(project_id, project_key)
+    return await client.create_index(index_name, docs, model_id=model_id)

--- a/packages/moss-data-connector/moss-connector-notion/tests/test_notion.py
+++ b/packages/moss-data-connector/moss-connector-notion/tests/test_notion.py
@@ -1,4 +1,4 @@
-"""Template unit test. Rename to test_<source>.py and adapt."""
+"""Unit tests for moss-connector-notion."""
 
 from __future__ import annotations
 

--- a/packages/moss-data-connector/moss-connector-notion/tests/test_notion.py
+++ b/packages/moss-data-connector/moss-connector-notion/tests/test_notion.py
@@ -1,0 +1,371 @@
+"""Template unit test. Rename to test_<source>.py and adapt."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest  # noqa: F401
+
+pytest.importorskip("notion_client")
+
+from moss import DocumentInfo  # noqa: F401
+from moss_connector_notion import NotionConnector, ingest
+
+
+@dataclass
+class FakeMutationResult:
+    doc_count: int
+    job_id: str = "fake-job-id"
+    index_name: str = ""
+
+
+@dataclass
+class FakeMossClient:
+    """Records create_index calls without hitting the network."""
+
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    async def create_index(self, name, docs, model_id=None):
+        self.calls.append({"name": name, "docs": list(docs), "model_id": model_id})
+        return FakeMutationResult(doc_count=len(docs), index_name=name)
+
+
+async def test_notion_ingest_end_to_end():
+    fake_client = MagicMock()
+
+    fake_client.search.return_value = {
+        "results": [
+            {
+                "id": "page1",
+                "url": "https://notion.so/page1",
+            },
+            {
+                "id": "page2",
+                "url": "https://notion.so/page2",
+            },
+        ],
+        "has_more": False,
+        "next_cursor": None,
+    }
+
+    fake_client.blocks.children.list.side_effect = [
+        {
+            "results": [
+                {
+                    "id": "block1",
+                    "type": "paragraph",
+                    "has_children": False,
+                }
+            ],
+            "has_more": False,
+            "next_cursor": None,
+        },
+        {
+            "results": [
+                {
+                    "id": "block2",
+                    "type": "paragraph",
+                    "has_children": False,
+                }
+            ],
+            "has_more": False,
+            "next_cursor": None,
+        },
+    ]
+
+    fake_moss = FakeMossClient()
+
+    with (
+        patch(
+            "moss_connector_notion.connector.Client",
+            return_value=fake_client,
+        ),
+        patch(
+            "moss_connector_notion.ingest.MossClient",
+            return_value=fake_moss,
+        ),
+    ):
+        source = NotionConnector(
+            token="fake-token",
+            mapper=lambda page: DocumentInfo(
+                id=page["id"],
+                text=str(page["content"]),
+                metadata={
+                    "url": page["url"],
+                },
+            ),
+        )
+
+        result = await ingest(
+            source,
+            "fake_project",
+            "fake_key",
+            "notion",
+        )
+
+    assert result is not None
+    assert result.doc_count == 2
+
+    assert len(fake_moss.calls) == 1
+
+    docs = fake_moss.calls[0]["docs"]
+
+    assert docs[0].id == "page1"
+    assert docs[1].id == "page2"
+
+    assert docs[0].metadata == {
+        "url": "https://notion.so/page1",
+    }
+
+    assert docs[1].metadata == {
+        "url": "https://notion.so/page2",
+    }
+
+    assert docs[0].text
+    assert docs[1].text
+
+    assert fake_client.search.call_count == 1
+    assert fake_client.blocks.children.list.call_count == 2
+
+
+async def test_search_pagination():
+    fake_client = MagicMock()
+
+    fake_client.search.side_effect = [
+        {
+            "results": [
+                {
+                    "id": "page1",
+                    "url": "u1",
+                }
+            ],
+            "has_more": True,
+            "next_cursor": "cursor1",
+        },
+        {
+            "results": [
+                {
+                    "id": "page2",
+                    "url": "u2",
+                }
+            ],
+            "has_more": False,
+            "next_cursor": None,
+        },
+    ]
+
+    fake_client.blocks.children.list.side_effect = [
+        {
+            "results": [],
+            "has_more": False,
+            "next_cursor": None,
+        },
+        {
+            "results": [],
+            "has_more": False,
+            "next_cursor": None,
+        },
+    ]
+
+    fake_moss = FakeMossClient()
+
+    with (
+        patch(
+            "moss_connector_notion.connector.Client",
+            return_value=fake_client,
+        ),
+        patch(
+            "moss_connector_notion.ingest.MossClient",
+            return_value=fake_moss,
+        ),
+    ):
+        source = NotionConnector(
+            token="fake-token",
+            mapper=lambda page: DocumentInfo(
+                id=page["id"],
+                text="",
+            ),
+        )
+
+        result = await ingest(
+            source,
+            "fake_project",
+            "fake_key",
+            "notion",
+        )
+
+    assert result is not None
+    assert result.doc_count == 2
+
+    docs = fake_moss.calls[0]["docs"]
+
+    assert [doc.id for doc in docs] == [
+        "page1",
+        "page2",
+    ]
+
+    assert fake_client.search.call_count == 2
+
+    first_call = fake_client.search.call_args_list[0]
+    second_call = fake_client.search.call_args_list[1]
+
+    assert "start_cursor" not in first_call.kwargs
+    assert second_call.kwargs["start_cursor"] == "cursor1"
+
+
+async def test_block_pagination():
+    fake_client = MagicMock()
+
+    fake_client.search.return_value = {
+        "results": [
+            {
+                "id": "page1",
+                "url": "u1",
+            }
+        ],
+        "has_more": False,
+        "next_cursor": None,
+    }
+
+    fake_client.blocks.children.list.side_effect = [
+        {
+            "results": [
+                {
+                    "id": "block1",
+                    "type": "paragraph",
+                    "has_children": False,
+                },
+                {
+                    "id": "block2",
+                    "type": "paragraph",
+                    "has_children": False,
+                },
+            ],
+            "has_more": True,
+            "next_cursor": "cursor1",
+        },
+        {
+            "results": [
+                {
+                    "id": "block3",
+                    "type": "paragraph",
+                    "has_children": False,
+                },
+            ],
+            "has_more": False,
+            "next_cursor": None,
+        },
+    ]
+
+    source = NotionConnector(
+        token="fake-token",
+        mapper=lambda page: DocumentInfo(
+            id=page["id"],
+            text=" ".join(block["id"] for block in page["content"]),
+            metadata={
+                "page_id": page["id"],
+            },
+        ),
+    )
+
+    with patch(
+        "moss_connector_notion.connector.Client",
+        return_value=fake_client,
+    ):
+        docs = list(source)
+
+    assert len(docs) == 1
+    assert docs[0].id == "page1"
+    assert docs[0].text == "block1 block2 block3"
+
+    assert fake_client.blocks.children.list.call_count == 2
+
+    first = fake_client.blocks.children.list.call_args_list[0]
+    second = fake_client.blocks.children.list.call_args_list[1]
+
+    assert first.kwargs["block_id"] == "page1"
+    assert first.kwargs["start_cursor"] is None
+    assert second.kwargs["start_cursor"] == "cursor1"
+
+
+async def test_recursive_block_fetch():
+    fake_client = MagicMock()
+
+    fake_client.search.return_value = {
+        "results": [
+            {
+                "id": "page1",
+                "url": "u1",
+            }
+        ],
+        "has_more": False,
+        "next_cursor": None,
+    }
+
+    fake_client.blocks.children.list.side_effect = [
+        {
+            "results": [
+                {
+                    "id": "toggle1",
+                    "type": "toggle",
+                    "has_children": True,
+                }
+            ],
+            "has_more": False,
+            "next_cursor": None,
+        },
+        {
+            "results": [
+                {
+                    "id": "paragraph1",
+                    "type": "paragraph",
+                    "has_children": False,
+                },
+                {
+                    "id": "code1",
+                    "type": "code",
+                    "has_children": False,
+                },
+            ],
+            "has_more": False,
+            "next_cursor": None,
+        },
+    ]
+
+    def flatten(blocks):
+        out = []
+
+        def dfs(block):
+            out.append(block["id"])
+            for child in block.get("children", []):
+                dfs(child)
+
+        for block in blocks:
+            dfs(block)
+
+        return " ".join(out)
+
+    source = NotionConnector(
+        token="fake-token",
+        mapper=lambda page: DocumentInfo(
+            id=page["id"],
+            text=flatten(page["content"]),
+            metadata={
+                "page_id": page["id"],
+            },
+        ),
+    )
+
+    with patch(
+        "moss_connector_notion.connector.Client",
+        return_value=fake_client,
+    ):
+        docs = list(source)
+
+    assert len(docs) == 1
+    assert docs[0].id == "page1"
+    assert docs[0].text == "toggle1 paragraph1 code1"
+
+    assert fake_client.blocks.children.list.call_count == 2

--- a/packages/moss-data-connector/moss-connector-notion/tests/test_notion.py
+++ b/packages/moss-data-connector/moss-connector-notion/tests/test_notion.py
@@ -6,11 +6,11 @@ from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-import pytest  # noqa: F401
+import pytest
 
 pytest.importorskip("notion_client")
 
-from moss import DocumentInfo  # noqa: F401
+from moss import DocumentInfo
 from moss_connector_notion import NotionConnector, ingest
 
 

--- a/packages/moss-data-connector/moss-connector-notion/tests/test_notion.py
+++ b/packages/moss-data-connector/moss-connector-notion/tests/test_notion.py
@@ -286,7 +286,7 @@ async def test_block_pagination():
     second = fake_client.blocks.children.list.call_args_list[1]
 
     assert first.kwargs["block_id"] == "page1"
-    assert first.kwargs["start_cursor"] is None
+    assert "start_cursor" not in first.kwargs
     assert second.kwargs["start_cursor"] == "cursor1"
 
 

--- a/packages/moss-data-connector/moss-connector-notion/tests/test_notion_integration.py
+++ b/packages/moss-data-connector/moss-connector-notion/tests/test_notion_integration.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("notion_client")
+
+from moss import DocumentInfo, MossClient, QueryOptions
+from moss_connector_notion import NotionConnector, ingest
+from notion_client import Client
+
+try:
+    from dotenv import load_dotenv
+
+    _here = Path(__file__).resolve()
+    for candidate in (
+        _here.parents[1] / ".env",
+        _here.parents[2] / ".env",
+        _here.parents[4] / ".env",
+    ):
+        if candidate.exists():
+            load_dotenv(candidate, override=False)
+except ImportError:
+    pass
+
+NOTION_TOKEN = os.getenv("NOTION_TOKEN")
+NOTION_PARENT_PAGE_ID = os.getenv("NOTION_PARENT_PAGE_ID")
+MOSS_PROJECT_ID = os.getenv("MOSS_PROJECT_ID")
+MOSS_PROJECT_KEY = os.getenv("MOSS_PROJECT_KEY")
+
+pytestmark = pytest.mark.skipif(
+    not (NOTION_TOKEN and NOTION_PARENT_PAGE_ID and MOSS_PROJECT_ID and MOSS_PROJECT_KEY),
+    reason=("Set NOTION_TOKEN, NOTION_PARENT_PAGE_ID, MOSS_PROJECT_ID and MOSS_PROJECT_KEY."),
+)
+
+
+def flatten_blocks(blocks: list[dict]) -> str:
+    """Convert a Notion block tree into plain text."""
+
+    lines: list[str] = []
+
+    def visit(block: dict):
+        block_type = block.get("type")
+
+        if block_type:
+            payload = block.get(block_type, {})
+            rich_text = payload.get("rich_text", [])
+
+            if rich_text:
+                text = "".join(part.get("plain_text", "") for part in rich_text)
+
+                if text:
+                    lines.append(text)
+
+        for child in block.get("children", []):
+            visit(child)
+
+    for block in blocks:
+        visit(block)
+
+    return "\n".join(lines)
+
+
+async def test_notion_ingest_end_to_end():
+    notion = Client(auth=NOTION_TOKEN)
+    moss = MossClient(MOSS_PROJECT_ID, MOSS_PROJECT_KEY)
+
+    unique = uuid.uuid4().hex[:8]
+    title = f"Moss Integration Test {unique}"
+
+    page = notion.pages.create(
+        parent={
+            "type": "page_id",
+            "page_id": NOTION_PARENT_PAGE_ID,
+        },
+        properties={
+            "title": {
+                "title": [
+                    {
+                        "type": "text",
+                        "text": {
+                            "content": title,
+                        },
+                    }
+                ]
+            }
+        },
+    )
+
+    page_id = page["id"]
+
+    notion.blocks.children.append(
+        block_id=page_id,
+        children=[
+            {
+                "object": "block",
+                "type": "heading_1",
+                "heading_1": {
+                    "rich_text": [
+                        {
+                            "type": "text",
+                            "text": {
+                                "content": "Rust Learning Roadmap",
+                            },
+                        }
+                    ]
+                },
+            },
+            {
+                "object": "block",
+                "type": "paragraph",
+                "paragraph": {
+                    "rich_text": [
+                        {
+                            "type": "text",
+                            "text": {
+                                "content": (
+                                    "Study ownership, borrowing and lifetimes "
+                                    "before learning async Rust."
+                                ),
+                            },
+                        }
+                    ]
+                },
+            },
+            {
+                "object": "block",
+                "type": "heading_1",
+                "heading_1": {
+                    "rich_text": [
+                        {
+                            "type": "text",
+                            "text": {
+                                "content": "Competitive Programming",
+                            },
+                        }
+                    ]
+                },
+            },
+            {
+                "object": "block",
+                "type": "paragraph",
+                "paragraph": {
+                    "rich_text": [
+                        {
+                            "type": "text",
+                            "text": {
+                                "content": (
+                                    "Practice Fenwick Tree, Segment Tree and "
+                                    "Binary Lifting problems every weekend."
+                                ),
+                            },
+                        }
+                    ]
+                },
+            },
+            {
+                "object": "block",
+                "type": "heading_1",
+                "heading_1": {
+                    "rich_text": [
+                        {
+                            "type": "text",
+                            "text": {
+                                "content": "Backend Project",
+                            },
+                        }
+                    ]
+                },
+            },
+            {
+                "object": "block",
+                "type": "paragraph",
+                "paragraph": {
+                    "rich_text": [
+                        {
+                            "type": "text",
+                            "text": {
+                                "content": (
+                                    "Build a low-latency websocket server using Rust and Tokio."
+                                ),
+                            },
+                        }
+                    ]
+                },
+            },
+        ],
+    )
+
+    index_name = f"moss-notion-e2e-{uuid.uuid4().hex[:8]}"
+
+    try:
+        connector = NotionConnector(
+            token=NOTION_TOKEN,
+            query=title,
+            mapper=lambda page: DocumentInfo(
+                id=page["id"],
+                text=flatten_blocks(page["content"]),
+                metadata={
+                    "url": page["url"],
+                },
+            ),
+        )
+
+        result = await ingest(
+            connector,
+            MOSS_PROJECT_ID,
+            MOSS_PROJECT_KEY,
+            index_name=index_name,
+        )
+
+        assert result is not None
+        assert result.doc_count == 1
+
+        await moss.load_index(index_name)
+
+        result = await moss.query(
+            index_name,
+            "What concepts should I study before learning async Rust?",
+            QueryOptions(top_k=3),
+        )
+
+        assert result.docs, "Expected at least one search result."
+
+        top = result.docs[0].text.lower()
+
+        assert "ownership" in top
+        assert "borrowing" in top
+        assert "lifetimes" in top
+
+    finally:
+        try:
+            await moss.delete_index(index_name)
+        except Exception as exc:  # pragma: no cover
+            print(f"warning: failed to delete test index {index_name}: {exc}")
+
+        try:
+            notion.pages.update(
+                page_id=page_id,
+                archived=True,
+            )
+        except Exception as exc:  # pragma: no cover
+            print(f"warning: failed to archive test page {page_id}: {exc}")

--- a/packages/moss-data-connector/moss-connector-notion/tests/test_notion_integration.py
+++ b/packages/moss-data-connector/moss-connector-notion/tests/test_notion_integration.py
@@ -1,3 +1,5 @@
+"""Integration test for moss-connector-notion."""
+
 from __future__ import annotations
 
 import os

--- a/packages/moss-data-connector/moss-connector-notion/uv.lock
+++ b/packages/moss-data-connector/moss-connector-notion/uv.lock
@@ -1,0 +1,348 @@
+version = 1
+revision = 3
+requires-python = ">=3.10, <3.15"
+
+[[package]]
+name = "anyio"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
+]
+
+[[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "inferedge-moss-core"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/e3c69d17022dda698e2d891ed9fa2d1d4b3885671309d607e586f11ed312/inferedge_moss_core-0.19.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ec89c1b46d34edb4d46d29bcb5db94eea794a38ce74340ccd6274b8dc7da7b52", size = 3902715, upload-time = "2026-06-30T06:26:39.894Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/94/095971d60b11fb0ac5fdc5a3cc6c4564347803ba19b15ca989933c9f377b/inferedge_moss_core-0.19.0-cp310-cp310-manylinux_2_38_x86_64.whl", hash = "sha256:87f589d0e912d3b18dbb06be0b573aa3c7ed1877315b0ff04db7324ffc1066a9", size = 4883112, upload-time = "2026-06-30T06:26:51.376Z" },
+    { url = "https://files.pythonhosted.org/packages/03/18/24bff752ba37ece33b52c99bf17d482102546bc4b265d12f62dc236f63b2/inferedge_moss_core-0.19.0-cp310-cp310-manylinux_2_39_aarch64.whl", hash = "sha256:1fce99d5bdf77e1755a6f25e1f4ae84d6f0c8f382703b9ba8fa94b7b9e97b7d9", size = 4783581, upload-time = "2026-06-30T06:27:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/89/f1/4a26cd613e2195eca6eb01131b6f24cc726b24da5bdfd0621acddd82ccc1/inferedge_moss_core-0.19.0-cp310-cp310-win_amd64.whl", hash = "sha256:e32e9495025a486dab4d3dabf7101e6312129767bd38d1e64de297468ceec52f", size = 5281185, upload-time = "2026-06-30T06:30:10.426Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1f/a58c066727438a69d2b2219b0fdc4a0ee4a7a9c9c2904ada1a1fcc987eb8/inferedge_moss_core-0.19.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4e00b146f46ea41ae6ee1acbe662e4cf3cb5f43c543268d48a9c3648df9eb5f7", size = 3894194, upload-time = "2026-06-30T06:26:36.298Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7b/82ab84fcb9051cb32564d86e03135f9aea3f7b7a9d84bb496f0212822d74/inferedge_moss_core-0.19.0-cp311-cp311-manylinux_2_38_x86_64.whl", hash = "sha256:1155f6d8a2bce5808a793a7bb92fda3771d899d7424a4869782f139c49789a55", size = 4883477, upload-time = "2026-06-30T06:27:07.511Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/06/4a6f6a041c27213353a4ec8bde6e76498bbe14ae41b56b155e950cd45054/inferedge_moss_core-0.19.0-cp311-cp311-manylinux_2_39_aarch64.whl", hash = "sha256:d597bbc34d9ea561e5467d05af63f36a4778659a2b2a4f98ab075aae59e63a91", size = 4783229, upload-time = "2026-06-30T06:26:56.98Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9e/869f99de85c0934f13a84f24187835d742de7511eed4f713f7a1cf38b591/inferedge_moss_core-0.19.0-cp311-cp311-win_amd64.whl", hash = "sha256:c96ec698e045d8a92303af9460a61024e9c074856ee57802778951750c197901", size = 5284145, upload-time = "2026-06-30T06:30:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/33/99f186bff1867309db992a497f885e24ca6810b7e1437bcb0f6d356a23be/inferedge_moss_core-0.19.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbe76dd47c793a5444df528d5d45e0e932970b0f1d981e83d64666342a4fc06e", size = 3891883, upload-time = "2026-06-30T06:25:25.468Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/e7/c98a9fc445ef2c46a580f6c6b0ba770f4394edf1f274d3e9c505bc73ceaa/inferedge_moss_core-0.19.0-cp312-cp312-manylinux_2_38_x86_64.whl", hash = "sha256:b2b0a20b27d5b6543ae3364ecfd441949bf6e64ea6527a226f3ede2d6246b852", size = 4878148, upload-time = "2026-06-30T06:27:00.916Z" },
+    { url = "https://files.pythonhosted.org/packages/77/45/9cdcbf320c3cedaa822fe2addb77b8c06e43b45d577446c50f717f161450/inferedge_moss_core-0.19.0-cp312-cp312-manylinux_2_39_aarch64.whl", hash = "sha256:a1acf3887e6610cb203f883735b86ec41901103803ea2810890413b9469f4eff", size = 4780150, upload-time = "2026-06-30T06:26:36.909Z" },
+    { url = "https://files.pythonhosted.org/packages/84/3d/645f3198118882f469c2e4f4578025931e93a8f70a6aa2d25459a42ada2e/inferedge_moss_core-0.19.0-cp312-cp312-win_amd64.whl", hash = "sha256:919763dc89247cfe05f861d03d38fa1d18e3a987f1c9e9cb1281afb192dbe229", size = 5277617, upload-time = "2026-06-30T06:29:40.936Z" },
+    { url = "https://files.pythonhosted.org/packages/00/fa/8a58468f0e561edc052fad70d3807d713eb12d6edf37def4b419918b43d4/inferedge_moss_core-0.19.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afc9c5bdece568092e4ffedb0e42c668ba3d26bb705c45c1b5a4acd9809358d3", size = 3892031, upload-time = "2026-06-30T06:26:20.415Z" },
+    { url = "https://files.pythonhosted.org/packages/49/6c/d32df79133516bdacc6bcca5f3f8bdcfec5c7490e9c0ab1cdbdefb138716/inferedge_moss_core-0.19.0-cp313-cp313-manylinux_2_38_x86_64.whl", hash = "sha256:30cd2f4f253fc37d57e4947be84378dd5428e4d6f8de37bc865258d23f8f0644", size = 4878079, upload-time = "2026-06-30T06:27:01.06Z" },
+    { url = "https://files.pythonhosted.org/packages/60/b2/82d542538e5304075444b2872f0080fe9b6311ffd68d7d46d1360532fa55/inferedge_moss_core-0.19.0-cp313-cp313-manylinux_2_39_aarch64.whl", hash = "sha256:8a3332a9018393b285ef8f8e7797c8dc7b5bbb5222a1289a0ac0e7de744239f5", size = 4779942, upload-time = "2026-06-30T06:27:02.985Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/89/d2290108312fce0dd0edbc8fbd542e1ee3754e9eb250d0bc17aeb52402dd/inferedge_moss_core-0.19.0-cp313-cp313-win_amd64.whl", hash = "sha256:a44d6d4157782c28b34504944f620c880090bb61b7e163340bba5aadcd7bd752", size = 5278449, upload-time = "2026-06-30T06:29:46.43Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0d/86c3d23d256b7a60d4d974d16a7981a9ac651112f2b28e77bc8f4c2ecdbd/inferedge_moss_core-0.19.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:702caa2213d05d8bd2cba284000ba142ffad94add86d61393ec2456b8de0f2de", size = 3888298, upload-time = "2026-06-30T06:26:02.636Z" },
+    { url = "https://files.pythonhosted.org/packages/36/8e/bf7bbe34cc02c1d7758fe70af7e4808a72dd01265cc9b1187e8a7611f482/inferedge_moss_core-0.19.0-cp314-cp314-manylinux_2_38_x86_64.whl", hash = "sha256:c2e45d1bf75782c9b1bebb8eae0245c0fbb139da9b614186fbd97a655df3dfaf", size = 4863573, upload-time = "2026-06-30T06:27:05.33Z" },
+    { url = "https://files.pythonhosted.org/packages/90/2b/36e04788022b70b8788560f4d558e875f68bf67845dfc91251e8cd5d47c8/inferedge_moss_core-0.19.0-cp314-cp314-manylinux_2_39_aarch64.whl", hash = "sha256:b85748728b2fbf63f6ac6ff72e106a6c21e6908bbb4f0d4532aa25e4ba524bf5", size = 4763724, upload-time = "2026-06-30T06:26:54.37Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4e/f734b5d107584cd57bb4e2e2777530a968f044ea6d960a166a5997bff154/inferedge_moss_core-0.19.0-cp314-cp314-win_amd64.whl", hash = "sha256:bcbbad46dac1cb5bfb9e45e99207869a4ba82a4de0553258bfb2f799abd40d16", size = 5265334, upload-time = "2026-06-30T06:30:08.489Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "moss"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "inferedge-moss-core" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/50/e89d24c3073a40b73b788e53cefc07def4fbe842172271789b4ac7de426d/moss-1.6.0.tar.gz", hash = "sha256:2934d173ba28ef999875745b7bd715e74620ba4bdb36279ba873628b4f1114e6", size = 47939, upload-time = "2026-06-30T06:29:16.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/25/e60f953626096951eb6c1501734f508ee135cb3382e509a500f53f1f29a1/moss-1.6.0-py3-none-any.whl", hash = "sha256:c2ac8f1207e631a2245e4f964288d810729424779d31bbc5aef208c42e851c43", size = 17408, upload-time = "2026-06-30T06:29:14.974Z" },
+]
+
+[[package]]
+name = "moss-connector-notion"
+version = "0.0.1"
+source = { editable = "." }
+dependencies = [
+    { name = "moss" },
+    { name = "notion-client" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "python-dotenv" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "moss", specifier = ">=1.6" },
+    { name = "notion-client", specifier = ">=3.1" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0" },
+    { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "notion-client"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/e3/4ac01384e86e2c381c21b87a0fefcdfe6d65577ae3153fad27e7e96c5d9c/notion_client-3.1.0.tar.gz", hash = "sha256:516e31326f855ec34559289b57be4e27ad656062f51f594c8f4ee3a608ee333d", size = 38781, upload-time = "2026-05-12T08:54:44.363Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/08/12645b24044301cb0d7908ec068c55c0d5724f39372891a1a27d630fdf50/notion_client-3.1.0-py2.py3-none-any.whl", hash = "sha256:7e3935f4dbc11231d8ad1fe404112e278501520342eaa35f86456f0df44a8aca", size = 23092, upload-time = "2026-05-12T08:54:43.135Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]


### PR DESCRIPTION
## Pull Request Checklist

Please ensure that your PR meets the following requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [x] I have updated the documentation (if applicable).
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

---

## Description

### Summary

This PR adds a new `moss-connector-notion` package for ingesting Notion pages into Moss.

The connector:
- Uses the official `notion-client` SDK.
- Recursively fetches nested blocks for each page.
- Handles pagination for both page search results and block children.
- Supports optional search queries and client-side filtering.
- Includes unit tests, integration tests, and documentation.

### Fixes

Closes #352, closes #380

---

## Demo Video

https://github.com/user-attachments/assets/29a3d4ff-4abe-419a-bcb7-8954da6fcbe7

---

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update