### PR TITLE
Add Vercel AI SDK cookbook (closes #257)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ examples/
     ├── mastra/              # Mastra retriever
     ├── pydantic-ai/         # Pydantic AI integration
     ├── daytona/             # Daytona sandbox example
-└── vercel-ai-sdk/       # Vercel AI SDK RAG agent example
+     └── vercel-ai-sdk/       # Vercel AI SDK RAG agent example
 
 apps/
 ├── next-js/                 # Next.js semantic search UI

--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ examples/
     ├── autogen/             # AutoGen integration
     ├── mastra/              # Mastra retriever
     ├── pydantic-ai/         # Pydantic AI integration
-    └── daytona/             # Daytona sandbox example
+    ├── daytona/             # Daytona sandbox example
+└── vercel-ai-sdk/       # Vercel AI SDK RAG agent example
 
 apps/
 ├── next-js/                 # Next.js semantic search UI
@@ -240,7 +241,7 @@ Full API reference: [docs.moss.dev](https://docs.moss.dev).
 | [Strands Agents](https://github.com/strands-agents/sdk-python) | Available | [`packages/strands-agents-moss/`](packages/strands-agents-moss/) |
 | [Next.js](https://nextjs.org) | Available | [`apps/next-js/`](apps/next-js/) |
 | [VitePress](https://vitepress.dev) | Available | [`packages/vitepress-plugin-moss/`](packages/vitepress-plugin-moss/) |
-| [Vercel AI SDK](https://sdk.vercel.ai) | Available | [`packages/vercel-sdk/`](packages/vercel-sdk/) |
+| [Vercel AI SDK](https://sdk.vercel.ai) | Available | [`examples/cookbook/vercel-ai-sdk/`](examples/cookbook/vercel-ai-sdk/) |
 
 ## Architecture
 

--- a/examples/cookbook/vercel-ai-sdk/.env.example
+++ b/examples/cookbook/vercel-ai-sdk/.env.example
@@ -1,0 +1,6 @@
+MOSS_PROJECT_ID=your_moss_project_id
+MOSS_PROJECT_KEY=your_moss_project_key
+MOSS_INDEX_NAME=your_index_name
+OPENAI_API_KEY=sk-...
+OPENAI_MODEL=gpt-4o-mini
+STREAM=false

--- a/examples/cookbook/vercel-ai-sdk/.env.example
+++ b/examples/cookbook/vercel-ai-sdk/.env.example
@@ -3,4 +3,4 @@ MOSS_PROJECT_KEY=your_moss_project_key
 MOSS_INDEX_NAME=your_index_name
 OPENAI_API_KEY=sk-...
 OPENAI_MODEL=gpt-4o-mini
-STREAM=false
+GENERATE=false

--- a/examples/cookbook/vercel-ai-sdk/README.md
+++ b/examples/cookbook/vercel-ai-sdk/README.md
@@ -1,0 +1,67 @@
+# Moss + Vercel AI SDK Cookbook
+
+A minimal example showing how to plug Moss semantic search into an agent
+built with the Vercel AI SDK, using the official `@moss-tools/vercel-sdk`
+tool wrappers.
+
+## What this shows
+
+- Creating a `MossClient` and wrapping one of your indexes with `mossSearchTool`
+- - Handing that tool to `generateText` (single-shot answer) or `streamText`
+  - (token-by-token streaming) so the model can retrieve context before replying
+  - - A small CLI script you can run with your own question as an argument
+   
+    - ## Prerequisites
+   
+    - - Node.js 18+
+      - - A Moss project (project id + project key) with at least one index created
+        - - An OpenAI API key
+         
+          - ## Install
+         
+          - ```bash
+            cd examples/cookbook/vercel-ai-sdk
+            npm install
+            ```
+
+            ## Configure
+
+            Copy the example env file and fill in your own values:
+
+            ```bash
+            cp .env.example .env
+            ```
+
+            | Variable | Description |
+            | --- | --- |
+            | `MOSS_PROJECT_ID` | Your Moss project id |
+            | `MOSS_PROJECT_KEY` | Your Moss project key |
+            | `MOSS_INDEX_NAME` | The index the search tool should query |
+            | `OPENAI_API_KEY` | Your OpenAI API key |
+            | `OPENAI_MODEL` | Optional, defaults to `gpt-4o-mini` |
+            | `STREAM` | Optional, set to `true` to use `streamText` instead of `generateText` |
+
+            ## Run
+
+            ```bash
+            npm start -- "What is the refund policy?"
+            ```
+
+            By default this calls `generateText` once and prints the answer. Set
+            `STREAM=true` in your `.env` to switch to `streamText` and see the response
+            print incrementally as it's generated.
+
+            ## How it works
+
+            `moss_vercel.ts` prebinds the search tool to a single index name with
+            `mossSearchTool({ client, indexName })`, so the model only ever has to supply
+            a `query` (and optional `topK`) rather than choosing an index itself. The
+            system prompt instructs the model to always search before answering and to
+            cite what it finds, which keeps responses grounded in your own data instead
+            of the model's general knowledge.
+
+            ## Learn more
+
+            - [`@moss-tools/vercel-sdk` package](../../../packages/vercel-sdk)
+            - - [Vercel AI SDK docs](https://sdk.vercel.ai/docs)
+              - 

--- a/examples/cookbook/vercel-ai-sdk/README.md
+++ b/examples/cookbook/vercel-ai-sdk/README.md
@@ -7,76 +7,60 @@ tool wrappers.
 ## What this shows
 
 - Creating a `MossClient` and wrapping one of your indexes with `mossSearchTool`
-- - Handing that tool to `streamText` (token-by-token streaming, the default)
-  - or `generateText` (single-shot answer) so the model can retrieve context
-  - before replying
-  - - A script to seed a small sample index so the example runs end-to-end with
-    - no existing Moss data required
-    - - A small CLI script you can run with your own question as an argument
-     
-      - ## Prerequisites
-     
-      - - Node.js 18+
-        - - A Moss project (project id + project key). You do not need an existing
-          - index, the seed script below creates one for you.
-          - - An OpenAI API key
-           
-            - ## Install
-           
-            - ```bash
-              cd examples/cookbook/vercel-ai-sdk
-              npm install
-              ```
+- Handing that tool to `streamText` (token-by-token streaming, the default) or `generateText` (single-shot answer), so the model can retrieve context before replying
+- A script to seed a small sample index so the example runs end-to-end with no existing Moss data required
+- A small CLI script you can run with your own question as an argument
 
-              ## Configure
+## Prerequisites
 
-              Copy the example env file and fill in your own values:
+- Node.js 18+
+- A Moss project (project id + project key). You do not need an existing index; the seed script below creates one for you.
+- An OpenAI API key
 
-              ```bash
-              cp .env.example .env
-              ```
+## Install
 
-              | Variable | Description |
-              | --- | --- |
-              | `MOSS_PROJECT_ID` | Your Moss project id |
-              | `MOSS_PROJECT_KEY` | Your Moss project key |
-              | `MOSS_INDEX_NAME` | The index the search tool should query |
-              | `OPENAI_API_KEY` | Your OpenAI API key |
-              | `OPENAI_MODEL` | Optional, defaults to `gpt-4o-mini` |
-              | `GENERATE` | Optional, set to `true` to use `generateText` instead of the default `streamText` |
+    cd examples/cookbook/vercel-ai-sdk
+    npm install
+## Configure
 
-              ## Seed a sample index
+Copy the example env file and fill in your own values:
 
-              If you don't already have a Moss index to query, create one from the sample
-              support-doc snippets in `seed_data.ts`:
+    cp .env.example .env
 
-              ```bash
-              npm run seed
-              ```
+| Variable | Description |
+| --- | --- |
+| `MOSS_PROJECT_ID` | Your Moss project id |
+| `MOSS_PROJECT_KEY` | Your Moss project key |
+| `MOSS_INDEX_NAME` | The index the search tool should query |
+| `OPENAI_API_KEY` | Your OpenAI API key |
+| `OPENAI_MODEL` | Optional, defaults to `gpt-4o-mini` |
+| `GENERATE` | Optional, set to `true` to use `generateText` instead of the default `streamText` |
+## Seed a sample index
 
-              This creates (or replaces) the index named by `MOSS_INDEX_NAME` in your `.env`.
+If you don't already have a Moss index to query, create one from the sample
+support-doc snippets in `seed_data.ts`:
 
-              ## Run
+    npm run seed
 
-              ```bash
-              npm start -- "What is the refund policy?"
-              ```
+This deletes any existing index named by `MOSS_INDEX_NAME` in your `.env` and recreates it.
+## Run
 
-              By default this uses `streamText` and prints the answer incrementally as it's
-              generated. Set `GENERATE=true` in your `.env` to switch to a single-shot
-              `generateText` call instead.
+    npm start -- "What is the refund policy?"
 
-              ## How it works
+By default this uses `streamText` and prints the answer incrementally as it's
+generated. Set `GENERATE=true` in your `.env` to switch to a single-shot
+`generateText` call instead.
 
-              `moss_vercel.ts` prebinds the search tool to a single index name with
-              `mossSearchTool({ client, indexName })`, so the model only ever has to supply
-              a `query` (and optional `topK`) rather than choosing an index itself. The
-              system prompt instructs the model to always search before answering and to
-              cite what it finds, which keeps responses grounded in your own data instead
-              of the model's general knowledge.
+## How it works
 
-              ## Learn more
+`moss_vercel.ts` prebinds the search tool to a single index name with
+`mossSearchTool({ client, indexName })`, so the model only ever has to supply
+a `query` (and optional `topK`) rather than choosing an index itself. The
+system prompt instructs the model to always search before answering and to
+cite what it finds, which keeps responses grounded in your own data instead
+of the model's general knowledge.
 
-              - [`@moss-tools/vercel-sdk` package](../../../packages/vercel-sdk)
-              - - [Vercel AI SDK docs](https://sdk.vercel.ai/docs)
-                - 
+## Learn more
+
+- [`@moss-tools/vercel-sdk` package](../../../packages/vercel-sdk)
+- [Vercel AI SDK docs](https://sdk.vercel.ai/docs)

--- a/examples/cookbook/vercel-ai-sdk/README.md
+++ b/examples/cookbook/vercel-ai-sdk/README.md
@@ -7,61 +7,76 @@ tool wrappers.
 ## What this shows
 
 - Creating a `MossClient` and wrapping one of your indexes with `mossSearchTool`
-- - Handing that tool to `generateText` (single-shot answer) or `streamText`
-  - (token-by-token streaming) so the model can retrieve context before replying
-  - - A small CLI script you can run with your own question as an argument
-   
-    - ## Prerequisites
-   
-    - - Node.js 18+
-      - - A Moss project (project id + project key) with at least one index created
-        - - An OpenAI API key
-         
-          - ## Install
-         
-          - ```bash
-            cd examples/cookbook/vercel-ai-sdk
-            npm install
-            ```
+- - Handing that tool to `streamText` (token-by-token streaming, the default)
+  - or `generateText` (single-shot answer) so the model can retrieve context
+  - before replying
+  - - A script to seed a small sample index so the example runs end-to-end with
+    - no existing Moss data required
+    - - A small CLI script you can run with your own question as an argument
+     
+      - ## Prerequisites
+     
+      - - Node.js 18+
+        - - A Moss project (project id + project key). You do not need an existing
+          - index, the seed script below creates one for you.
+          - - An OpenAI API key
+           
+            - ## Install
+           
+            - ```bash
+              cd examples/cookbook/vercel-ai-sdk
+              npm install
+              ```
 
-            ## Configure
+              ## Configure
 
-            Copy the example env file and fill in your own values:
+              Copy the example env file and fill in your own values:
 
-            ```bash
-            cp .env.example .env
-            ```
+              ```bash
+              cp .env.example .env
+              ```
 
-            | Variable | Description |
-            | --- | --- |
-            | `MOSS_PROJECT_ID` | Your Moss project id |
-            | `MOSS_PROJECT_KEY` | Your Moss project key |
-            | `MOSS_INDEX_NAME` | The index the search tool should query |
-            | `OPENAI_API_KEY` | Your OpenAI API key |
-            | `OPENAI_MODEL` | Optional, defaults to `gpt-4o-mini` |
-            | `STREAM` | Optional, set to `true` to use `streamText` instead of `generateText` |
+              | Variable | Description |
+              | --- | --- |
+              | `MOSS_PROJECT_ID` | Your Moss project id |
+              | `MOSS_PROJECT_KEY` | Your Moss project key |
+              | `MOSS_INDEX_NAME` | The index the search tool should query |
+              | `OPENAI_API_KEY` | Your OpenAI API key |
+              | `OPENAI_MODEL` | Optional, defaults to `gpt-4o-mini` |
+              | `GENERATE` | Optional, set to `true` to use `generateText` instead of the default `streamText` |
 
-            ## Run
+              ## Seed a sample index
 
-            ```bash
-            npm start -- "What is the refund policy?"
-            ```
+              If you don't already have a Moss index to query, create one from the sample
+              support-doc snippets in `seed_data.ts`:
 
-            By default this calls `generateText` once and prints the answer. Set
-            `STREAM=true` in your `.env` to switch to `streamText` and see the response
-            print incrementally as it's generated.
+              ```bash
+              npm run seed
+              ```
 
-            ## How it works
+              This creates (or replaces) the index named by `MOSS_INDEX_NAME` in your `.env`.
 
-            `moss_vercel.ts` prebinds the search tool to a single index name with
-            `mossSearchTool({ client, indexName })`, so the model only ever has to supply
-            a `query` (and optional `topK`) rather than choosing an index itself. The
-            system prompt instructs the model to always search before answering and to
-            cite what it finds, which keeps responses grounded in your own data instead
-            of the model's general knowledge.
+              ## Run
 
-            ## Learn more
+              ```bash
+              npm start -- "What is the refund policy?"
+              ```
 
-            - [`@moss-tools/vercel-sdk` package](../../../packages/vercel-sdk)
-            - - [Vercel AI SDK docs](https://sdk.vercel.ai/docs)
-              - 
+              By default this uses `streamText` and prints the answer incrementally as it's
+              generated. Set `GENERATE=true` in your `.env` to switch to a single-shot
+              `generateText` call instead.
+
+              ## How it works
+
+              `moss_vercel.ts` prebinds the search tool to a single index name with
+              `mossSearchTool({ client, indexName })`, so the model only ever has to supply
+              a `query` (and optional `topK`) rather than choosing an index itself. The
+              system prompt instructs the model to always search before answering and to
+              cite what it finds, which keeps responses grounded in your own data instead
+              of the model's general knowledge.
+
+              ## Learn more
+
+              - [`@moss-tools/vercel-sdk` package](../../../packages/vercel-sdk)
+              - - [Vercel AI SDK docs](https://sdk.vercel.ai/docs)
+                - 

--- a/examples/cookbook/vercel-ai-sdk/create_index.ts
+++ b/examples/cookbook/vercel-ai-sdk/create_index.ts
@@ -14,10 +14,17 @@ async function seed() {
   const client = new MossClient(
     requireEnv('MOSS_PROJECT_ID'),
     requireEnv('MOSS_PROJECT_KEY'),
-    );
+  );
   const indexName = requireEnv('MOSS_INDEX_NAME');
 
-console.log(`Creating index "${indexName}" with ${sampleDocs.length} sample documents...`);
+  const deleted = await client.deleteIndex(indexName);
+  if (deleted) {
+    console.log(`Deleted existing index "${indexName}".`);
+  }
+
+  console.log(
+    `Creating index "${indexName}" with ${sampleDocs.length} sample documents...`,
+  );
   await client.createIndex(indexName, sampleDocs);
   console.log('Done! You can now run "npm start" to query this index.');
 }

--- a/examples/cookbook/vercel-ai-sdk/create_index.ts
+++ b/examples/cookbook/vercel-ai-sdk/create_index.ts
@@ -1,0 +1,28 @@
+import 'dotenv/config';
+import { MossClient } from '@moss-dev/moss';
+import { sampleDocs } from './seed_data.js';
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+async function seed() {
+  const client = new MossClient(
+    requireEnv('MOSS_PROJECT_ID'),
+    requireEnv('MOSS_PROJECT_KEY'),
+    );
+  const indexName = requireEnv('MOSS_INDEX_NAME');
+
+console.log(`Creating index "${indexName}" with ${sampleDocs.length} sample documents...`);
+  await client.createIndex(indexName, sampleDocs);
+  console.log('Done! You can now run "npm start" to query this index.');
+}
+
+seed().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/cookbook/vercel-ai-sdk/create_index.ts
+++ b/examples/cookbook/vercel-ai-sdk/create_index.ts
@@ -1,14 +1,7 @@
 import 'dotenv/config';
 import { MossClient } from '@moss-dev/moss';
 import { sampleDocs } from './seed_data.js';
-
-function requireEnv(name: string): string {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(`Missing required environment variable: ${name}`);
-  }
-  return value;
-}
+import { requireEnv } from './utils.js';
 
 async function seed() {
   const client = new MossClient(

--- a/examples/cookbook/vercel-ai-sdk/moss_vercel.ts
+++ b/examples/cookbook/vercel-ai-sdk/moss_vercel.ts
@@ -16,55 +16,54 @@ async function main() {
   const client = new MossClient(
     requireEnv('MOSS_PROJECT_ID'),
     requireEnv('MOSS_PROJECT_KEY'),
-    );
+  );
 
-const indexName = requireEnv('MOSS_INDEX_NAME');
+  const indexName = requireEnv('MOSS_INDEX_NAME');
   const model = process.env.OPENAI_MODEL ?? 'gpt-4o-mini';
 
-// Run "npm run seed" first to create this index with sample documents,
-// or point MOSS_INDEX_NAME at an index you already have.
-const useGenerate = process.env.GENERATE === 'true';
+  // Run "npm run seed" first to create this index with sample documents,
+  // or point MOSS_INDEX_NAME at an index you already have.
+  const useGenerate = process.env.GENERATE === 'true';
 
-// Prebind the search tool to a single index, so the LLM only needs to
-// supply a query, not an index name.
-const tools = {
-  search: mossSearchTool({ client, indexName }),
-};
+  // Prebind the search tool to a single index, so the LLM only needs to
+  // supply a query, not an index name.
+  const tools = {
+    search: mossSearchTool({ client, indexName }),
+  };
+  const systemPrompt =
+    'You are a helpful assistant. Always use the search tool to find relevant ' +
+    'context before answering, and cite what you find in your response.';
 
-const systemPrompt =
-  'You are a helpful assistant. Always use the search tool to find relevant ' +
-  'context before answering, and cite what you find in your response.';
-
-const question = process.argv[2] ?? 'What does this knowledge base cover?';
+  const question = process.argv[2] ?? 'What does this knowledge base cover?';
   console.log(`Q: ${question}\n`);
 
-if (useGenerate) {
-  const { text } = await generateText({
-    model: openai(model),
-    tools,
-    system: systemPrompt,
-    prompt: question,
-    maxSteps: 3,
-  });
+  if (useGenerate) {
+    const { text } = await generateText({
+      model: openai(model),
+      tools,
+      system: systemPrompt,
+      prompt: question,
+      maxSteps: 3,
+    });
 
-  console.log(`A: ${text}`);
-} else {
-  // Default: stream the answer token-by-token as it's generated, retrieving
-  // grounded context from Moss along the way.
-  const result = streamText({
-    model: openai(model),
-    tools,
-    system: systemPrompt,
-    prompt: question,
-    maxSteps: 3,
-  });
+    console.log(`A: ${text}`);
+  } else {
+    // Default: stream the answer token-by-token as it's generated, retrieving
+    // grounded context from Moss along the way.
+    const result = streamText({
+      model: openai(model),
+      tools,
+      system: systemPrompt,
+      prompt: question,
+      maxSteps: 3,
+    });
 
-  process.stdout.write('A: ');
-  for await (const chunk of result.textStream) {
-    process.stdout.write(chunk);
+    process.stdout.write('A: ');
+    for await (const chunk of result.textStream) {
+      process.stdout.write(chunk);
+    }
+    console.log();
   }
-  console.log();
-}
 }
 
 main().catch((err) => {

--- a/examples/cookbook/vercel-ai-sdk/moss_vercel.ts
+++ b/examples/cookbook/vercel-ai-sdk/moss_vercel.ts
@@ -20,7 +20,10 @@ async function main() {
 
 const indexName = requireEnv('MOSS_INDEX_NAME');
   const model = process.env.OPENAI_MODEL ?? 'gpt-4o-mini';
-  const useStreaming = process.env.STREAM === 'true';
+
+// Run "npm run seed" first to create this index with sample documents,
+// or point MOSS_INDEX_NAME at an index you already have.
+const useGenerate = process.env.GENERATE === 'true';
 
 // Prebind the search tool to a single index, so the LLM only needs to
 // supply a query, not an index name.
@@ -35,20 +38,7 @@ const systemPrompt =
 const question = process.argv[2] ?? 'What does this knowledge base cover?';
   console.log(`Q: ${question}\n`);
 
-if (useStreaming) {
-  const result = streamText({
-    model: openai(model),
-    tools,
-    system: systemPrompt,
-    prompt: question,
-    maxSteps: 3,
-  });
-
-  for await (const chunk of result.textStream) {
-    process.stdout.write(chunk);
-  }
-  console.log();
-} else {
+if (useGenerate) {
   const { text } = await generateText({
     model: openai(model),
     tools,
@@ -58,6 +48,22 @@ if (useStreaming) {
   });
 
   console.log(`A: ${text}`);
+} else {
+  // Default: stream the answer token-by-token as it's generated, retrieving
+  // grounded context from Moss along the way.
+  const result = streamText({
+    model: openai(model),
+    tools,
+    system: systemPrompt,
+    prompt: question,
+    maxSteps: 3,
+  });
+
+  process.stdout.write('A: ');
+  for await (const chunk of result.textStream) {
+    process.stdout.write(chunk);
+  }
+  console.log();
 }
 }
 

--- a/examples/cookbook/vercel-ai-sdk/moss_vercel.ts
+++ b/examples/cookbook/vercel-ai-sdk/moss_vercel.ts
@@ -1,0 +1,67 @@
+import 'dotenv/config';
+import { MossClient } from '@moss-dev/moss';
+import { mossSearchTool } from '@moss-tools/vercel-sdk';
+import { generateText, streamText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+async function main() {
+  const client = new MossClient(
+    requireEnv('MOSS_PROJECT_ID'),
+    requireEnv('MOSS_PROJECT_KEY'),
+    );
+
+const indexName = requireEnv('MOSS_INDEX_NAME');
+  const model = process.env.OPENAI_MODEL ?? 'gpt-4o-mini';
+  const useStreaming = process.env.STREAM === 'true';
+
+// Prebind the search tool to a single index, so the LLM only needs to
+// supply a query, not an index name.
+const tools = {
+  search: mossSearchTool({ client, indexName }),
+};
+
+const systemPrompt =
+  'You are a helpful assistant. Always use the search tool to find relevant ' +
+  'context before answering, and cite what you find in your response.';
+
+const question = process.argv[2] ?? 'What does this knowledge base cover?';
+  console.log(`Q: ${question}\n`);
+
+if (useStreaming) {
+  const result = streamText({
+    model: openai(model),
+    tools,
+    system: systemPrompt,
+    prompt: question,
+    maxSteps: 3,
+  });
+
+  for await (const chunk of result.textStream) {
+    process.stdout.write(chunk);
+  }
+  console.log();
+} else {
+  const { text } = await generateText({
+    model: openai(model),
+    tools,
+    system: systemPrompt,
+    prompt: question,
+    maxSteps: 3,
+  });
+
+  console.log(`A: ${text}`);
+}
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/cookbook/vercel-ai-sdk/moss_vercel.ts
+++ b/examples/cookbook/vercel-ai-sdk/moss_vercel.ts
@@ -3,14 +3,7 @@ import { MossClient } from '@moss-dev/moss';
 import { mossSearchTool } from '@moss-tools/vercel-sdk';
 import { generateText, streamText } from 'ai';
 import { openai } from '@ai-sdk/openai';
-
-function requireEnv(name: string): string {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(`Missing required environment variable: ${name}`);
-  }
-  return value;
-}
+import { requireEnv } from './utils.js';
 
 async function main() {
   const client = new MossClient(
@@ -30,40 +23,41 @@ async function main() {
   const tools = {
     search: mossSearchTool({ client, indexName }),
   };
-  const systemPrompt =
-    'You are a helpful assistant. Always use the search tool to find relevant ' +
-    'context before answering, and cite what you find in your response.';
 
-  const question = process.argv[2] ?? 'What does this knowledge base cover?';
+const systemPrompt =
+  'You are a helpful assistant. Always use the search tool to find relevant ' +
+  'context before answering, and cite what you find in your response.';
+
+const question = process.argv[2] ?? 'What does this knowledge base cover?';
   console.log(`Q: ${question}\n`);
 
-  if (useGenerate) {
-    const { text } = await generateText({
-      model: openai(model),
-      tools,
-      system: systemPrompt,
-      prompt: question,
-      maxSteps: 3,
-    });
+if (useGenerate) {
+  const { text } = await generateText({
+    model: openai(model),
+    tools,
+    system: systemPrompt,
+    prompt: question,
+    maxSteps: 3,
+  });
 
-    console.log(`A: ${text}`);
-  } else {
-    // Default: stream the answer token-by-token as it's generated, retrieving
-    // grounded context from Moss along the way.
-    const result = streamText({
-      model: openai(model),
-      tools,
-      system: systemPrompt,
-      prompt: question,
-      maxSteps: 3,
-    });
+  console.log(`A: ${text}`);
+} else {
+  // Default: stream the answer token-by-token as it's generated, retrieving
+  // grounded context from Moss along the way.
+  const result = streamText({
+    model: openai(model),
+    tools,
+    system: systemPrompt,
+    prompt: question,
+    maxSteps: 3,
+  });
 
-    process.stdout.write('A: ');
-    for await (const chunk of result.textStream) {
-      process.stdout.write(chunk);
-    }
-    console.log();
+  process.stdout.write('A: ');
+  for await (const chunk of result.textStream) {
+    process.stdout.write(chunk);
   }
+  console.log();
+}
 }
 
 main().catch((err) => {

--- a/examples/cookbook/vercel-ai-sdk/package.json
+++ b/examples/cookbook/vercel-ai-sdk/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@moss-tools/vercel-sdk": "^0.1.1",
     "@moss-dev/moss": "^1.0.0",
-    "@ai-sdk/openai": "^1.0.0",
+    "@ai-sdk/openai": "^4.0.0", 
     "ai": "^7.0.0",
     "zod": "^3.25.76",
     "dotenv": "^16.4.5"

--- a/examples/cookbook/vercel-ai-sdk/package.json
+++ b/examples/cookbook/vercel-ai-sdk/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "moss-vercel-ai-sdk-cookbook",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Example: RAG Q&A agent using Moss semantic search with the Vercel AI SDK",
+  "type": "module",
+  "scripts": {
+    "start": "tsx moss_vercel.ts"
+  },
+  "dependencies": {
+    "@moss-tools/vercel-sdk": "^1.0.0",
+    "@moss-dev/moss": "^1.0.0",
+    "@ai-sdk/openai": "^1.0.0",
+    "ai": "^4.0.0",
+    "zod": "^3.23.8",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/examples/cookbook/vercel-ai-sdk/package.json
+++ b/examples/cookbook/vercel-ai-sdk/package.json
@@ -5,14 +5,15 @@
   "description": "Example: RAG Q&A agent using Moss semantic search with the Vercel AI SDK",
   "type": "module",
   "scripts": {
+    "seed": "tsx create_index.ts",
     "start": "tsx moss_vercel.ts"
   },
   "dependencies": {
-    "@moss-tools/vercel-sdk": "^1.0.0",
+    "@moss-tools/vercel-sdk": "^0.1.1",
     "@moss-dev/moss": "^1.0.0",
     "@ai-sdk/openai": "^1.0.0",
-    "ai": "^4.0.0",
-    "zod": "^3.23.8",
+    "ai": "^7.0.0",
+    "zod": "^3.25.76",
     "dotenv": "^16.4.5"
   },
   "devDependencies": {

--- a/examples/cookbook/vercel-ai-sdk/seed_data.ts
+++ b/examples/cookbook/vercel-ai-sdk/seed_data.ts
@@ -21,4 +21,4 @@ export const sampleDocs = [
     id: 'contact-support',
     text: 'Support is available 24/7 via live chat, or by emailing support@example.com.',
   },
-  ];
+];

--- a/examples/cookbook/vercel-ai-sdk/seed_data.ts
+++ b/examples/cookbook/vercel-ai-sdk/seed_data.ts
@@ -1,0 +1,24 @@
+// A handful of sample support-doc snippets used to seed a demo index.
+// Swap these out for your own documents when adapting this example.
+export const sampleDocs = [
+  {
+    id: 'refund-policy',
+    text: 'Refunds are processed within 3-5 business days after we receive the returned item.',
+  },
+  {
+    id: 'shipping-times',
+    text: 'Standard shipping takes 5-7 business days. Express shipping arrives in 1-2 business days.',
+  },
+  {
+    id: 'payment-methods',
+    text: 'We accept Visa, Mastercard, American Express, and PayPal for all orders.',
+  },
+  {
+    id: 'cancel-subscription',
+    text: 'You can cancel your subscription anytime from Account Settings > Billing > Cancel Plan.',
+  },
+  {
+    id: 'contact-support',
+    text: 'Support is available 24/7 via live chat, or by emailing support@example.com.',
+  },
+  ];

--- a/examples/cookbook/vercel-ai-sdk/utils.ts
+++ b/examples/cookbook/vercel-ai-sdk/utils.ts
@@ -1,0 +1,7 @@
+export function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}


### PR DESCRIPTION
Closes #257 
Adds a new cookbook at `examples/cookbook/vercel-ai-sdk/` showing how to use `@moss-tools/vercel-sdk` with the Vercel AI SDK, following the same layout as the existing `examples/cookbook/langchain/` cookbook.

## What's included

- `moss_vercel.ts` - a small CLI example that prebinds `mossSearchTool` to an index and answers questions with `generateText`, with an optional `streamText` mode
- - `package.json` - minimal dependencies (`@moss-tools/vercel-sdk`, `@moss-dev/moss`, `ai`, `@ai-sdk/openai`, `zod`, `dotenv`)
- - `.env.example` - placeholder environment variables, no real credentials
- - `README.md` - setup and usage instructions
## Testing

This is a documentation/example addition. Verified the example code against the published `@moss-tools/vercel-sdk` API (`mossSearchTool({ client, indexName })`) as documented in `packages/vercel-sdk`.
