### PR TITLE
docs: add devcontainer for examples

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+{
+  "name": "Moss development",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.12"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    },
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.23"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "dbaeumer.vscode-eslint",
+        "golang.go"
+      ]
+    }
+  },
+  "postCreateCommand": "python -m pip install --upgrade pip && pip install -r examples/python/requirements.txt && npm ci && npm ci --prefix examples/javascript && go -C examples/go mod download",
+  "remoteEnv": {
+    "MOSS_PROJECT_ID": "${localEnv:MOSS_PROJECT_ID}",
+    "MOSS_PROJECT_KEY": "${localEnv:MOSS_PROJECT_KEY}"
+  },
+  "forwardPorts": [3000, 5173, 8000],
+  "portsAttributes": {
+    "3000": {
+      "label": "Web app"
+    },
+    "5173": {
+      "label": "Vite dev server"
+    },
+    "8000": {
+      "label": "Python app"
+    }
+  },
+  "remoteUser": "vscode"
+}
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
       ]
     }
   },
-  "postCreateCommand": "python -m pip install --upgrade pip && pip install -r examples/python/requirements.txt && npm ci && npm ci --prefix examples/javascript && go -C examples/go mod download",
+  "postCreateCommand": "python -m pip install --upgrade pip && python -m pip install -r examples/python/requirements.txt && npm ci && npm ci --prefix examples/javascript && go -C examples/go mod download",
   "remoteEnv": {
     "MOSS_PROJECT_ID": "${localEnv:MOSS_PROJECT_ID}",
     "MOSS_PROJECT_KEY": "${localEnv:MOSS_PROJECT_KEY}"


### PR DESCRIPTION
## Summary

Add a Dev Container configuration for Moss contributors.

## Changes

- Provide Python 3.12, Node.js 22, and Go 1.23 in Codespaces/dev containers.
- Install the root, Python example, JavaScript example, and Go example dependencies after container creation.
- Forward Moss credentials from the local environment without committing secrets.
- Include common VS Code language extensions and development ports.

## Testing

- Parsed and structurally validated `.devcontainer/devcontainer.json` locally.
- `git diff --check` passed.
- `npm run lint` was attempted but is blocked on Windows by the existing `ESLINT_USE_FLAT_CONFIG=true eslint .` script syntax before ESLint starts.
- Full container startup could not be run because Docker is not installed in the development environment.

Closes #378
