### PR TITLE
Address review findings on #324: restore CI/vercel-sdk, fix error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
       matrix:
         include:
           - node-version: '20'
-            ai-version: '^6.0.0'
+            ai-version: '6.0.97'
           - node-version: '22'
             ai-version: '7.0.8'
     name: vercel-sdk-test (ai@${{ matrix.ai-version }}, node@${{ matrix.node-version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,17 +125,28 @@ jobs:
 
   vercel-sdk-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - node-version: '20'
+            ai-version: '^6.0.0'
+          - node-version: '22'
+            ai-version: '7.0.8'
+    name: vercel-sdk-test (ai@${{ matrix.ai-version }}, node@${{ matrix.node-version }})
     steps:
     - uses: actions/checkout@v4
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: ${{ matrix.node-version }}
         cache: 'npm'
         cache-dependency-path: packages/vercel-sdk/package-lock.json
     - name: Install dependencies
       working-directory: packages/vercel-sdk
       run: npm ci
+    - name: Override ai version
+      working-directory: packages/vercel-sdk
+      run: npm install --no-save ai@${{ matrix.ai-version }}
     - name: Build
       working-directory: packages/vercel-sdk
       run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       run: npm ci
     - name: Override ai version
       working-directory: packages/vercel-sdk
-      run: npm install --no-save ai@${{ matrix.ai-version }}
+      run: npm install --no-save --no-package-lock ai@${{ matrix.ai-version }} && npm ls ai
     - name: Build
       working-directory: packages/vercel-sdk
       run: npm run build

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,259 @@
+name: Codex PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: codex-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  authorize:
+    # Trigger gate: PR events always, comment events only for "@codex review" from a
+    # trusted commenter. The step then restricts to same-repo (non-fork) PRs so a
+    # public fork can never reach the privileged checkout below.
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '@codex review') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      ok: ${{ steps.gate.outputs.ok }}
+      pr: ${{ steps.gate.outputs.pr }}
+    steps:
+      - id: gate
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const prNum = context.payload.pull_request?.number ?? context.payload.issue?.number;
+            if (!prNum) { core.setOutput('ok', 'false'); return; }
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner, repo: context.repo.repo, pull_number: prNum,
+            });
+            const sameRepo = !!pr.head.repo && pr.head.repo.full_name === pr.base.repo.full_name;
+            core.setOutput('pr', String(prNum));
+            core.setOutput('ok', sameRepo ? 'true' : 'false');
+            if (!sameRepo) {
+              core.notice(`Skipping Codex review: PR #${prNum} is from a fork; only same-repo branches are reviewed.`);
+            }
+
+  review:
+    needs: authorize
+    if: needs.authorize.outputs.ok == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      result: ${{ steps.run_codex.outputs.final-message }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ needs.authorize.outputs.pr }}/merge
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run Codex
+        id: run_codex
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          model: gpt-5.5
+          effort: xhigh
+          sandbox: read-only
+          output-schema: |
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "summary": { "type": "string" },
+                "findings": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "path": { "type": "string" },
+                      "line": { "type": "integer" },
+                      "severity": { "type": "string", "enum": ["blocking", "consider"] },
+                      "comment": { "type": "string" }
+                    },
+                    "required": ["path", "line", "severity", "comment"]
+                  }
+                }
+              },
+              "required": ["summary", "findings"]
+            }
+          prompt: |
+            You are reviewing pull request #${{ needs.authorize.outputs.pr }} in ${{ github.repository }}.
+
+            The PR's changes are exactly the diff between the merge commit's two parents.
+            Run `git diff HEAD^1 HEAD^2` to see everything that changed, and
+            `git diff HEAD^1 HEAD^2 -- <path>` to focus on a single file.
+
+            Review ONLY those changes. Report high-signal findings only.
+
+            Correctness & safety:
+            - logic errors, unhandled edge cases, broken assumptions
+            - security vulnerabilities
+            - data loss, concurrency hazards, resource leaks
+
+            Design & code quality:
+            - the soundness of the overall approach, not just line-level bugs
+            - elegance: is there a simpler, cleaner way to achieve the same result?
+            - abstraction: prefer the most general clean abstraction that fits the problem,
+              without over-engineering for cases that don't exist
+            - redundancy: flag duplicated logic, dead code, and anything that violates DRY
+
+            Skip pure formatting and style nits.
+
+            Report at most the 5 most important findings. Consolidate an issue that
+            recurs in several places into one finding at the most representative location.
+
+            Output JSON matching the provided schema:
+            - `summary`: one or two sentences on the PR overall. If there are no real
+              issues, set summary to "No issues found." and findings to [].
+            - `findings[].path`: repository-relative file path, exactly as git reports it.
+            - `findings[].line`: the line number in the NEW (post-change) version of the
+              file. It MUST be a line the PR adds or modifies.
+            - `findings[].severity`: "blocking" or "consider".
+            - `findings[].comment`: markdown review comment with a short code snippet and a
+              concrete fix.
+
+  post_review:
+    needs: [authorize, review]
+    if: needs.review.outputs.result != ''
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Post inline review
+        uses: actions/github-script@v7
+        env:
+          CODEX_RESULT: ${{ needs.review.outputs.result }}
+          PR_NUMBER: ${{ needs.authorize.outputs.pr }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = Number(process.env.PR_NUMBER);
+            const SUMMARY_MARKER = '<!-- codex-review-summary -->';
+            const INLINE_MARKER = '<!-- codex-review-inline -->';
+            const MAX_COMMENTS = 5;
+
+            // Parse Codex JSON. With --output-schema the result is already pure JSON,
+            // and its findings may contain fenced code blocks, so never grab an inner
+            // fence: parse the whole string first, then a fence wrapping the whole
+            // string, then fall back to the outermost braces.
+            function parseResult(raw) {
+              if (!raw) return null;
+              const tryParse = (s) => { try { return JSON.parse(s); } catch { return null; } };
+              const trimmed = raw.trim();
+              let out = tryParse(trimmed);
+              if (out) return out;
+              const fence = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```$/);
+              if (fence) { out = tryParse(fence[1].trim()); if (out) return out; }
+              const a = trimmed.indexOf('{'), b = trimmed.lastIndexOf('}');
+              if (a !== -1 && b > a) return tryParse(trimmed.slice(a, b + 1));
+              return null;
+            }
+            const result = parseResult(process.env.CODEX_RESULT);
+            if (!result) { core.setFailed('Could not parse Codex output as JSON.'); return; }
+
+            const summary = (result.summary || '').trim();
+            const findings = (Array.isArray(result.findings) ? result.findings : [])
+              .slice(0, MAX_COMMENTS);
+
+            // Build the set of (path -> commentable new-file line numbers) from the diff.
+            const pr = await github.rest.pulls.get({ owner, repo, pull_number });
+            const headSha = pr.data.head.sha;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number, per_page: 100,
+            });
+            const commentable = new Map();
+            for (const f of files) {
+              if (!f.patch) continue;
+              const lines = new Set();
+              let newLine = 0;
+              for (const ln of f.patch.split('\n')) {
+                const h = ln.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+                if (h) { newLine = parseInt(h[1], 10); continue; }
+                if (ln.startsWith('\\')) continue;          // "\ No newline at end of file"
+                if (ln.startsWith('+')) { lines.add(newLine); newLine++; }
+                else if (ln.startsWith('-')) { /* removed line, no new-side number */ }
+                else { newLine++; }                          // context line
+              }
+              commentable.set(f.filename, lines);
+            }
+
+            // Split findings into inline-able vs. orphans (lines not in the diff).
+            const inline = [], orphans = [];
+            for (const fnd of findings) {
+              const sev = (fnd.severity || 'consider').toUpperCase();
+              const set = commentable.get(fnd.path);
+              if (set && set.has(fnd.line)) {
+                inline.push({
+                  path: fnd.path, line: fnd.line, side: 'RIGHT',
+                  body: `${INLINE_MARKER}\n**${sev}** ${fnd.comment}`,
+                });
+              } else {
+                orphans.push({ ...fnd, sev });
+              }
+            }
+
+            // Always clear our prior inline comments first, so findings resolved in a
+            // later push disappear even when this run produces no inline comments.
+            try {
+              const prior = await github.paginate(github.rest.pulls.listReviewComments, {
+                owner, repo, pull_number, per_page: 100,
+              });
+              for (const c of prior) {
+                if (c.body && c.body.includes(INLINE_MARKER)) {
+                  try { await github.rest.pulls.deleteReviewComment({ owner, repo, comment_id: c.id }); }
+                  catch {}
+                }
+              }
+            } catch (e) { core.warning(`Could not clean prior inline comments: ${e.message}`); }
+
+            // Post this run's inline comments. If it fails, fold them into the summary.
+            let inlinePosted = false;
+            if (inline.length) {
+              try {
+                await github.rest.pulls.createReview({
+                  owner, repo, pull_number, commit_id: headSha,
+                  event: 'COMMENT', comments: inline,
+                });
+                inlinePosted = true;
+              } catch (err) {
+                core.warning(`Inline review failed (${err.status || ''}); folding into the summary.`);
+              }
+            }
+
+            // Build the rolling summary comment.
+            const leftover = inlinePosted
+              ? orphans
+              : findings.map(f => ({ ...f, sev: (f.severity || 'consider').toUpperCase() }));
+            let body = `${SUMMARY_MARKER}\n### Codex review\n\n` +
+              (summary || (findings.length ? 'See inline comments.' : 'No issues found.'));
+            if (leftover.length) {
+              body += `\n\n**${inlinePosted ? 'Findings not on changed lines' : 'Findings'}:**\n`;
+              for (const o of leftover) body += `\n- \`${o.path}:${o.line}\` **${o.sev}** ${o.comment}`;
+            }
+
+            // Upsert one rolling summary comment instead of stacking on each push.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: pull_number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(SUMMARY_MARKER));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: pull_number, body });
+            }

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,0 +1,20 @@
+name: python-test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Reports the "python-test" required status check (via the GitHub Actions app).
+# Substantive Python coverage lives in the python-lint and python-sdk-test jobs;
+# this is the gate the branch ruleset still requires by that name. Expand the
+# steps here if a dedicated python-test suite is wanted later.
+jobs:
+  python-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Smoke check
+        run: python -c "print('python-test ok')"

--- a/.github/workflows/vercel-sdk-release.yml
+++ b/.github/workflows/vercel-sdk-release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Get version from package.json
         id: compute
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
           cache-dependency-path: ${{ env.PKG_DIR }}/package-lock.json

--- a/examples/cookbook/vercel-voice-agent/.env.example
+++ b/examples/cookbook/vercel-voice-agent/.env.example
@@ -6,7 +6,5 @@ MOSS_INDEX_NAME=your-index-name
 # Get key: https://vercel.com/dashboard/ai-gateway
 AI_GATEWAY_API_KEY=your-vercel-ai-gateway-key
 
-# Demo auth — set both to the same value; omit to disable the check locally
-DEMO_SECRET=change-me
-NEXT_PUBLIC_DEMO_SECRET=change-me
+# Demo auth — set to "true" to allow unauthenticated access to /api/token (demo only)
 ALLOW_UNAUTHENTICATED_DEMO=true

--- a/examples/cookbook/vercel-voice-agent/README.md
+++ b/examples/cookbook/vercel-voice-agent/README.md
@@ -15,7 +15,7 @@ Browser (useRealtime) ──WebSocket── Vercel AI Gateway ── gpt-realtim
 - `POST /api/token` (empty body) — mints a short-lived WebSocket token via the gateway
 - `POST /api/token` (`{ query }`) — executes MOSS search; uses local in-memory index loaded at startup
 
-> **Security note:** `/api/token` is unauthenticated for demo purposes. Before deploying publicly, add a session/cookie check so arbitrary callers cannot mint Gateway tokens or query your index.
+> **Security note:** `/api/token` is unauthenticated only when `ALLOW_UNAUTHENTICATED_DEMO=true` is set (demo). Before deploying publicly, add a session/cookie check so arbitrary callers cannot mint Gateway tokens or query your index.
 
 ## Setup
 

--- a/examples/cookbook/vercel-voice-agent/app/api/token/route.ts
+++ b/examples/cookbook/vercel-voice-agent/app/api/token/route.ts
@@ -18,10 +18,11 @@ const searchTool = mossSearchTool({
 
 // Load the index into local memory at startup.
 // Cloud query returns 503 — local queries work fine after loadIndex.
-// Storing the promise means search requests block until ready, or fail fast if it rejects.
+// The promise stays fulfilled (true/false) so a startup failure never becomes
+// an unhandled rejection — search requests branch on the result instead.
 const indexReady = client.loadIndex(process.env.MOSS_INDEX_NAME!)
-  .then(() => console.log('[MOSS] index loaded locally'))
-  .catch((err: unknown) => { console.error('[MOSS] loadIndex failed:', err); throw err; });
+  .then(() => { console.log('[MOSS] index loaded locally'); return true; })
+  .catch((err: unknown) => { console.error('[MOSS] loadIndex failed:', err); return false; });
 
 const MOSS_TOOL = {
   type: 'function' as const,
@@ -50,15 +51,13 @@ export async function POST(req: Request) {
   const body = await req.json().catch(() => ({})) as Record<string, unknown>;
 
   if (typeof body.query === 'string') {
-    try {
-      await indexReady;
-    } catch {
+    if (!(await indexReady)) {
       return new Response('Search index unavailable', { status: 503 });
     }
     const topK = Number.isInteger(body.topK) ? Math.min(100, Math.max(1, body.topK as number)) : 5;
     const result = await searchTool.execute!(
       { query: body.query, topK },
-      { toolCallId: 'realtime', messages: [], abortSignal: req.signal },
+      { toolCallId: 'realtime', messages: [], abortSignal: req.signal, context: {} },
     );
     const docs = (result as { docs: Array<{ text: string }> }).docs ?? [];
     return new Response(docs.map((d) => d.text).join('\n\n---\n\n'), {

--- a/examples/cookbook/vercel-voice-agent/app/page.tsx
+++ b/examples/cookbook/vercel-voice-agent/app/page.tsx
@@ -62,6 +62,10 @@ export default function Page() {
           body: JSON.stringify({ query, topK: topK ?? 5 }),
         });
         const text = await res.text();
+        if (!res.ok) {
+          setError(text || `Knowledge base search failed (${res.status})`);
+          throw new Error(text || `Knowledge base search failed (${res.status})`);
+        }
         const hits = text.trim() ? text.split('\n\n---\n\n').length : 0;
         setSearches((s) => [{ query, hits }, ...s.slice(0, 4)]);
         return text;

--- a/examples/cookbook/vercel-voice-agent/package-lock.json
+++ b/examples/cookbook/vercel-voice-agent/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ai-sdk/gateway": "^4.0.6",
         "@ai-sdk/react": "^4.0.9",
-        "@moss-dev/moss": "latest",
+        "@moss-dev/moss": "^1.3.1",
         "@moss-tools/vercel-sdk": "^0.1.1",
         "ai": "^7.0.8",
         "next": "^15.0.0",

--- a/examples/cookbook/vercel-voice-agent/package.json
+++ b/examples/cookbook/vercel-voice-agent/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@ai-sdk/gateway": "^4.0.6",
     "@ai-sdk/react": "^4.0.9",
-    "@moss-dev/moss": "latest",
+    "@moss-dev/moss": "^1.3.1",
     "@moss-tools/vercel-sdk": "^0.1.1",
     "ai": "^7.0.8",
     "next": "^15.0.0",

--- a/examples/cookbook/vercel-voice-agent/tsconfig.json
+++ b/examples/cookbook/vercel-voice-agent/tsconfig.json
@@ -16,6 +16,6 @@
     "plugins": [{ "name": "next" }],
     "paths": { "@/*": ["./*"] }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/vercel-sdk/package-lock.json
+++ b/packages/vercel-sdk/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@moss-tools/vercel-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@moss-tools/vercel-sdk",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "BSD-2-Clause",
       "devDependencies": {
-        "@moss-dev/moss": "1.0.0",
+        "@moss-dev/moss": "1.3.1",
         "@types/node": "22.13.14",
-        "ai": "6.0.97",
+        "ai": "7.0.8",
         "tsup": "8.4.0",
         "typescript": "5.8.2",
         "vitest": "3.2.6",
@@ -19,54 +19,55 @@
       },
       "peerDependencies": {
         "@moss-dev/moss": "^1.0.0",
-        "ai": "^6.0.0",
+        "ai": "^6.0.0 || ^7.0.0",
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.53",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.53.tgz",
-      "integrity": "sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.6.tgz",
+      "integrity": "sha512-8GjssUxXeTd8tst2fYXNOFbtNNZFv3sG7aq7wKnQYrU2eB3JFR7np6o4F3Snp/fy/rJZSeH28LvjSWq5wkdL8Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.15",
-        "@vercel/oidc": "3.1.0"
+        "@ai-sdk/provider": "4.0.1",
+        "@ai-sdk/provider-utils": "5.0.2",
+        "@vercel/oidc": "3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
-      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.1.tgz",
+      "integrity": "sha512-6p3C/vGqVIjcptBu1DnVd/BZJ2wWmV9TUv9192vT6ZvT9KNED8EwRTqyqFpoQZKgSbMDSvBSq3dqR524Nt/Crw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz",
-      "integrity": "sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.2.tgz",
+      "integrity": "sha512-EcmdjJb7yggsZPCbS3MFBpvAUnKaPW+QvanU5GzF00XCq0bqqAmvJ3MN19ejlmOETbW8sJNiq6qam48wTcbUNw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider": "4.0.1",
         "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -554,35 +555,36 @@
       }
     },
     "node_modules/@moss-dev/moss": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss/-/moss-1.0.0.tgz",
-      "integrity": "sha512-vRsRcQQibBCVmJmN4mESiLWqoef/ugrCuE6iU7OAfmtezZyTogOeEZnUGu1s/QbDp2nHXEVgkgFj0VeXZI1CeA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss/-/moss-1.3.1.tgz",
+      "integrity": "sha512-DU6m+1kPBtWJ3iJEHZ5qQCunJBvL2xx/v1NsW6mQfh245QZhQGikS/Zsn8UKxl+M5rPaozKL5aQX4NmrdYvqZQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@moss-dev/moss-core": "0.8.7"
+        "@moss-dev/moss-core": "0.19.1"
       }
     },
     "node_modules/@moss-dev/moss-core": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core/-/moss-core-0.8.7.tgz",
-      "integrity": "sha512-IxmJYNCBHhnjNj8o3H0T7XRCDVhSbwv+WmAc5KLDkAug9Ep74FK4/kpjiR32muZXTbvbktxYgB6iHL7oUMY2xw==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core/-/moss-core-0.19.1.tgz",
+      "integrity": "sha512-YeH+kKuHVyEW0JRF2jP90VQbV8HeGfRtV9U5u5v9MVo0WQ4Lfa8kqM509TE4VMOpHDpO7HMDKn/izRR6Vvw3+w==",
       "dev": true,
       "license": "Proprietary",
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@moss-dev/moss-core-darwin-arm64": "0.8.7",
-        "@moss-dev/moss-core-linux-arm64-gnu": "0.8.7",
-        "@moss-dev/moss-core-linux-x64-gnu": "0.8.7",
-        "@moss-dev/moss-core-win32-x64-msvc": "0.8.7"
+        "@moss-dev/moss-core-darwin-arm64": "0.19.1",
+        "@moss-dev/moss-core-darwin-x64": "0.19.1",
+        "@moss-dev/moss-core-linux-arm64-gnu": "0.19.1",
+        "@moss-dev/moss-core-linux-x64-gnu": "0.19.1",
+        "@moss-dev/moss-core-win32-x64-msvc": "0.19.1"
       }
     },
     "node_modules/@moss-dev/moss-core-darwin-arm64": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-darwin-arm64/-/moss-core-darwin-arm64-0.8.7.tgz",
-      "integrity": "sha512-SxRD5vV5HSezJRr1GcIxQKOyX/nJ6RCgQYSDZTPsYbo49M0bRdAATKUpGIW5xHC7YZsZXZY8OiUVcw5lBQW0Lg==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-darwin-arm64/-/moss-core-darwin-arm64-0.19.1.tgz",
+      "integrity": "sha512-Tu8moQH3hMRfEv/C9fB2HLY7wVoxlVQ2a6vJrBPYdqnEpQRdDNggos3bBevarxEnJhDgp27zvjw5UeWN+H+YRg==",
       "cpu": [
         "arm64"
       ],
@@ -596,10 +598,27 @@
         "node": ">=20"
       }
     },
+    "node_modules/@moss-dev/moss-core-darwin-x64": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-darwin-x64/-/moss-core-darwin-x64-0.19.1.tgz",
+      "integrity": "sha512-DIv/mQrQMR8OYyT/bXXVx6s/XagGzuhbUESvEN9OWQu1eAYD2hqOyJXjAOMsVVYLCB8o0nlolQfbnFiYRUlvbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Proprietary",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@moss-dev/moss-core-linux-arm64-gnu": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-linux-arm64-gnu/-/moss-core-linux-arm64-gnu-0.8.7.tgz",
-      "integrity": "sha512-uRs/V6f0qvbStGSGNd/10cWJQKMPEumpQCAcjdRODiLbh5N+S6TIt2/bUHfc5uMxPFC9Bld7URglNmtfNXCKNA==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-linux-arm64-gnu/-/moss-core-linux-arm64-gnu-0.19.1.tgz",
+      "integrity": "sha512-OrOM6n0z/T5ZryiOwGEBy14zqn/kJXMbTNykBlJIZmCIA0cCvPZqLUt2cMVh+Y51Ofy4HhMnXuyFmsLC8nER0g==",
       "cpu": [
         "arm64"
       ],
@@ -614,9 +633,9 @@
       }
     },
     "node_modules/@moss-dev/moss-core-linux-x64-gnu": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-linux-x64-gnu/-/moss-core-linux-x64-gnu-0.8.7.tgz",
-      "integrity": "sha512-HgQgYN3ivLVNGJbQIBp6N2i+96y7cN/40sqzL0jqh2TzTziygoiSlwIkIqkkDZJ8DnSwJAMMQ9o2l1zPoMskCQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-linux-x64-gnu/-/moss-core-linux-x64-gnu-0.19.1.tgz",
+      "integrity": "sha512-18dZ8pFr0LZvfGCkxGXyCk9zqSmWPKcn5Cmt+JaSfA0vmZiZjQ4EgWAQdTJxGBs+cIa+vc3oMaVGuvJiotMhnw==",
       "cpu": [
         "x64"
       ],
@@ -631,9 +650,9 @@
       }
     },
     "node_modules/@moss-dev/moss-core-win32-x64-msvc": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-win32-x64-msvc/-/moss-core-win32-x64-msvc-0.8.7.tgz",
-      "integrity": "sha512-P49hUAuOXpMP1gVM+SMf0DyvXUU8OHLpppUsz7CRWJ4GkNY6JCnC3tHD1dEJQSnHMx9zOnS0hoAV6qzuhWuIrg==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@moss-dev/moss-core-win32-x64-msvc/-/moss-core-win32-x64-msvc-0.19.1.tgz",
+      "integrity": "sha512-VvOuq/U8IsRdHoGvcJH5jBM1QYuAQsJ7BUcr+OSXqFfht0TB4OpJMHcn9frSzVQ16ULf8x0ewSZYteNxLXKu9w==",
       "cpu": [
         "x64"
       ],
@@ -645,16 +664,6 @@
       ],
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1050,9 +1059,9 @@
       }
     },
     "node_modules/@vercel/oidc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1174,20 +1183,26 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/ai": {
-      "version": "6.0.97",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.97.tgz",
-      "integrity": "sha512-eZIAcBymwGhBwncRH/v9pillZNMeRCDkc4BwcvwXerXd7sxjVxRis3ZNCNCpP02pVH4NLs81ljm4cElC4vbNcQ==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.8.tgz",
+      "integrity": "sha512-vTEKl6fDBZ2IxBXTRaZOajf9W2Ev57Ju8iKtUvqlmDk8Z9BrEP4c22SWJsg1RcWHSFmJMSBa/s5dlUBHUq3YwA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.53",
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.15",
-        "@opentelemetry/api": "1.9.0"
+        "@ai-sdk/gateway": "4.0.6",
+        "@ai-sdk/provider": "4.0.1",
+        "@ai-sdk/provider-utils": "5.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -1387,9 +1402,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1537,9 +1552,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -1613,9 +1628,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -1633,7 +1648,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2029,13 +2044,13 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
-      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",

--- a/packages/vercel-sdk/package.json
+++ b/packages/vercel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moss-tools/vercel-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Vercel AI SDK tools for MOSS semantic search",
   "type": "module",
   "sideEffects": false,
@@ -32,16 +32,16 @@
   "license": "BSD-2-Clause",
   "peerDependencies": {
     "@moss-dev/moss": "^1.0.0",
-    "ai": "^6.0.0",
+    "ai": "^6.0.0 || ^7.0.0",
     "zod": "^3.25.76 || ^4.1.8"
   },
   "devDependencies": {
-    "@moss-dev/moss": "1.0.0",
-    "ai": "6.0.97",
-    "zod": "3.25.76",
+    "@moss-dev/moss": "1.3.1",
     "@types/node": "22.13.14",
+    "ai": "7.0.8",
     "tsup": "8.4.0",
     "typescript": "5.8.2",
-    "vitest": "3.2.6"
+    "vitest": "3.2.6",
+    "zod": "3.25.76"
   }
 }


### PR DESCRIPTION
## Summary

Addresses the outstanding Codex and Copilot review findings on #324. Targets the `vercel-ai` branch so these fixes land inside that PR when merged.

## Blocking findings (Codex)

- **Restored `.github/workflows/` to main's state** — brings back `python-test.yml` (a required status check that would otherwise hang protected-branch merges forever) and `codex-review.yml`, and reverts the unrelated edits to `ci.yml` / `vercel-sdk-release.yml`.
- **Restored `packages/vercel-sdk/` to main's state** — the PR had rolled the package back to `0.1.0` with AI-6-only support (`"ai": "^6.0.0"`) while the new cookbook depends on `ai@^7`. It's back to `0.1.1` with `"ai": "^6.0.0 || ^7.0.0"`.

## Cookbook fixes (`examples/cookbook/vercel-voice-agent/`)

- **`app/api/token/route.ts`** — the `indexReady` startup promise no longer rethrows in `.catch()`; it resolves to `true`/`false` and the handler returns 503 on failure, so a `loadIndex` error can't kill the process as an unhandled rejection (Codex, blocking).
- **`app/page.tsx`** — the tool-call fetch now checks `res.ok`; non-2xx responses surface via `setError` and throw instead of being returned to the model as search results (Copilot/Codex).
- **`.env.example`** — removed the unused `DEMO_SECRET` / `NEXT_PUBLIC_DEMO_SECRET` vars and corrected the comment to describe the actual `ALLOW_UNAUTHENTICATED_DEMO` gate (Copilot).
- **`README.md`** — security note now matches the fail-closed 401 behavior (Copilot).
- **`package.json`** — `@moss-dev/moss` pinned to `^1.3.1` instead of `latest`, with the lockfile mirror entry synced (Copilot).
- **`tsconfig.json`** — added `.next/dev/types/**/*.ts` to `include`, matching `apps/moss-llamaindex/frontend` (Copilot).

## Additional fix required to compile

- **`route.ts`** — `searchTool.execute` now passes `context: {}`: with the installed AI SDK 7, `context` is a required field on `ToolExecutionOptions`, so the example did not typecheck without it. No reviewer flagged this; `next build`'s type check did.

## Verification

`npm install && npm run build` — compiles and the type check passes. (The subsequent page-data collection step fails on my machine only because the `@moss-dev/moss-core` native binding needs GLIBC 2.38 and my Debian host has 2.36 — unrelated to these changes.)

