### PR TITLE
feat(moss-cli): add mapped CSV/JSON bulk import

### DIFF
--- a/packages/moss-cli/CHANGELOG.md
+++ b/packages/moss-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Bulk document import: `moss documents import` / `moss doc import` can map
+  custom ID, text, and metadata columns from CSV, JSON, and JSONL files
 - Shell completions: `moss completions bash` and `moss completions zsh` output
   completion scripts covering commands, subcommands, and global flags, with
   dynamic completion of index names

--- a/packages/moss-cli/README.md
+++ b/packages/moss-cli/README.md
@@ -99,6 +99,13 @@ moss doc add my-index -f new-docs.json
 # Add with upsert (update existing, insert new)
 moss doc add my-index -f docs.json --upsert --wait
 
+# Import a file whose columns use different names
+moss documents import my-index -f products.csv \
+  --id-column sku \
+  --text-column description \
+  --metadata-columns category,price \
+  --upsert --wait
+
 # Get all documents
 moss doc get my-index
 
@@ -220,11 +227,36 @@ doc2,Deep learning with neural networks,
 doc3,Natural language processing,"{""topic"": ""nlp""}"
 ```
 
+For CSV or JSON data that does not use the standard `id` and `text` field
+names, use `moss documents import` (or the shorter `moss doc import`) to map
+source columns. Repeat `--metadata-column` or pass a comma-separated list to
+`--metadata-columns`; non-empty values from those columns are stored as string
+metadata.
+
+```csv
+sku,description,category,price
+A-100,Lightweight trail running shoe,footwear,89.99
+A-200,Waterproof hiking boot,footwear,129.99
+```
+
+```bash
+moss documents import products -f products.csv \
+  --id-column sku \
+  --text-column description \
+  --metadata-column category \
+  --metadata-column price
+```
+
+Column mapping also works with top-level fields in JSON and JSONL documents.
+IDs are never generated automatically: every record must have a non-empty
+value in the mapped ID and text columns.
+
 ### stdin
 
 ```bash
 cat docs.json | moss index create my-index -f -
 cat docs.json | moss doc add my-index -f -
+cat docs.json | moss documents import my-index -f - --id-column doc_id --text-column body
 ```
 
 ## Global Options

--- a/packages/moss-cli/src/moss_cli/commands/doc.py
+++ b/packages/moss-cli/src/moss_cli/commands/doc.py
@@ -1,14 +1,13 @@
-"""moss doc {add, delete, get} commands."""
+"""moss doc {add, import, delete, get} commands."""
 
 from __future__ import annotations
 
 import asyncio
-from typing import Optional
+from typing import List, Optional, Sequence
 
 import typer
+from moss import GetDocumentsOptions, MossClient, MutationOptions
 from rich.console import Console
-
-from moss import MossClient, GetDocumentsOptions, MutationOptions
 
 from .. import output
 from ..completion import complete_index_name
@@ -30,28 +29,134 @@ def _client(ctx: typer.Context) -> MossClient:
 @doc_app.command(name="add")
 def add(
     ctx: typer.Context,
-    index_name: str = typer.Argument(..., help="Index name", autocompletion=complete_index_name),
-    file: str = typer.Option(..., "--file", "-f", help="Path to JSON/CSV document file, or '-' for stdin"),
+    index_name: str = typer.Argument(
+        ..., help="Index name", autocompletion=complete_index_name
+    ),
+    file: str = typer.Option(
+        ..., "--file", "-f", help="Path to JSON/CSV document file, or '-' for stdin"
+    ),
     profile: Optional[str] = typer.Option(
         None, "--profile", help="Credential profile name"
     ),
-    upsert: bool = typer.Option(False, "--upsert", "-u", help="Update existing documents"),
+    upsert: bool = typer.Option(
+        False, "--upsert", "-u", help="Update existing documents"
+    ),
     wait: bool = typer.Option(False, "--wait", "-w", help="Wait for job to complete"),
-    poll_interval: float = typer.Option(2.0, "--poll-interval", help="Seconds between status checks"),
-    timeout: Optional[float] = typer.Option(None, "--timeout", help="Max seconds to wait (requires --wait)"),
+    poll_interval: float = typer.Option(
+        2.0, "--poll-interval", help="Seconds between status checks"
+    ),
+    timeout: Optional[float] = typer.Option(
+        None, "--timeout", help="Max seconds to wait (requires --wait)"
+    ),
 ) -> None:
     """Add documents to an index."""
+    _submit_documents(
+        ctx,
+        index_name=index_name,
+        file=file,
+        profile=profile,
+        upsert=upsert,
+        wait=wait,
+        poll_interval=poll_interval,
+        timeout=timeout,
+        action="Adding",
+    )
+
+
+@doc_app.command(name="import")
+def import_documents(
+    ctx: typer.Context,
+    index_name: str = typer.Argument(
+        ..., help="Index name", autocompletion=complete_index_name
+    ),
+    file: str = typer.Option(
+        ...,
+        "--file",
+        "-f",
+        help="Path to a JSON/JSONL/CSV document file, or '-' for JSON stdin",
+    ),
+    id_column: str = typer.Option(
+        "id", "--id-column", help="Source column to use as the document ID"
+    ),
+    text_column: str = typer.Option(
+        "text", "--text-column", help="Source column to use as the document text"
+    ),
+    metadata_column: Optional[List[str]] = typer.Option(
+        None,
+        "--metadata-column",
+        "--metadata-columns",
+        help=(
+            "Source column to copy into metadata. Repeat this option or pass "
+            "comma-separated names."
+        ),
+    ),
+    profile: Optional[str] = typer.Option(
+        None, "--profile", help="Credential profile name"
+    ),
+    upsert: bool = typer.Option(
+        False, "--upsert", "-u", help="Update existing documents"
+    ),
+    wait: bool = typer.Option(False, "--wait", "-w", help="Wait for job to complete"),
+    poll_interval: float = typer.Option(
+        2.0, "--poll-interval", help="Seconds between status checks"
+    ),
+    timeout: Optional[float] = typer.Option(
+        None, "--timeout", help="Max seconds to wait (requires --wait)"
+    ),
+) -> None:
+    """Bulk-import documents with optional source-column mapping."""
+    _submit_documents(
+        ctx,
+        index_name=index_name,
+        file=file,
+        profile=profile,
+        upsert=upsert,
+        wait=wait,
+        poll_interval=poll_interval,
+        timeout=timeout,
+        action="Importing",
+        id_column=id_column,
+        text_column=text_column,
+        metadata_columns=_split_metadata_columns(metadata_column),
+        require_documents=True,
+    )
+
+
+def _submit_documents(
+    ctx: typer.Context,
+    *,
+    index_name: str,
+    file: str,
+    profile: Optional[str],
+    upsert: bool,
+    wait: bool,
+    poll_interval: float,
+    timeout: Optional[float],
+    action: str,
+    id_column: str = "id",
+    text_column: str = "text",
+    metadata_columns: Optional[Sequence[str]] = None,
+    require_documents: bool = False,
+) -> None:
     json_mode = ctx.obj.get("json_output", False)
     if profile:
         ctx.obj["profile"] = profile
+    docs = load_documents(
+        file,
+        id_column=id_column,
+        text_column=text_column,
+        metadata_columns=metadata_columns,
+        require_non_empty=require_documents,
+    )
+    if require_documents and not docs:
+        raise typer.BadParameter(f"No documents found in {file}")
     client = _client(ctx)
-    docs = load_documents(file)
 
     options = MutationOptions(upsert=True) if upsert else None
 
     if not json_mode:
         console.print(
-            f"Adding {len(docs)} document(s) to [cyan]{index_name}[/cyan]"
+            f"{action} {len(docs)} document(s) to [cyan]{index_name}[/cyan]"
             f"{' (upsert)' if upsert else ''}..."
         )
 
@@ -59,20 +164,38 @@ def add(
     output.print_mutation_result(result, json_mode=json_mode)
 
     if wait:
-        asyncio.run(wait_for_job(client, result.job_id, poll_interval, json_mode, timeout))
+        asyncio.run(
+            wait_for_job(client, result.job_id, poll_interval, json_mode, timeout)
+        )
+
+
+def _split_metadata_columns(values: Optional[Sequence[str]]) -> Optional[List[str]]:
+    if not values:
+        return None
+
+    columns: List[str] = []
+    for value in values:
+        columns.extend(name.strip() for name in value.split(","))
+    return columns or None
 
 
 @doc_app.command(name="delete")
 def delete(
     ctx: typer.Context,
-    index_name: str = typer.Argument(..., help="Index name", autocompletion=complete_index_name),
+    index_name: str = typer.Argument(
+        ..., help="Index name", autocompletion=complete_index_name
+    ),
     ids: str = typer.Option(..., "--ids", "-i", help="Comma-separated document IDs"),
     profile: Optional[str] = typer.Option(
         None, "--profile", help="Credential profile name"
     ),
     wait: bool = typer.Option(False, "--wait", "-w", help="Wait for job to complete"),
-    poll_interval: float = typer.Option(2.0, "--poll-interval", help="Seconds between status checks"),
-    timeout: Optional[float] = typer.Option(None, "--timeout", help="Max seconds to wait (requires --wait)"),
+    poll_interval: float = typer.Option(
+        2.0, "--poll-interval", help="Seconds between status checks"
+    ),
+    timeout: Optional[float] = typer.Option(
+        None, "--timeout", help="Max seconds to wait (requires --wait)"
+    ),
 ) -> None:
     """Delete documents from an index by ID."""
     json_mode = ctx.obj.get("json_output", False)
@@ -86,20 +209,28 @@ def delete(
         raise typer.Exit(1)
 
     if not json_mode:
-        console.print(f"Deleting {len(doc_ids)} document(s) from [cyan]{index_name}[/cyan]...")
+        console.print(
+            f"Deleting {len(doc_ids)} document(s) from [cyan]{index_name}[/cyan]..."
+        )
 
     result = asyncio.run(client.delete_docs(index_name, doc_ids))
     output.print_mutation_result(result, json_mode=json_mode)
 
     if wait:
-        asyncio.run(wait_for_job(client, result.job_id, poll_interval, json_mode, timeout))
+        asyncio.run(
+            wait_for_job(client, result.job_id, poll_interval, json_mode, timeout)
+        )
 
 
 @doc_app.command(name="get")
 def get(
     ctx: typer.Context,
-    index_name: str = typer.Argument(..., help="Index name", autocompletion=complete_index_name),
-    ids: Optional[str] = typer.Option(None, "--ids", "-i", help="Comma-separated document IDs (omit for all)"),
+    index_name: str = typer.Argument(
+        ..., help="Index name", autocompletion=complete_index_name
+    ),
+    ids: Optional[str] = typer.Option(
+        None, "--ids", "-i", help="Comma-separated document IDs (omit for all)"
+    ),
     profile: Optional[str] = typer.Option(
         None, "--profile", help="Credential profile name"
     ),

--- a/packages/moss-cli/src/moss_cli/documents.py
+++ b/packages/moss-cli/src/moss_cli/documents.py
@@ -1,116 +1,340 @@
-"""Load documents from JSON/CSV files or stdin."""
+"""Load and map documents from JSON/JSONL/CSV files or stdin."""
 
 from __future__ import annotations
 
 import csv
+import io
 import json
 import sys
 from pathlib import Path
-from typing import Any, List
+from typing import (
+    Any,
+    Collection,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypedDict,
+    cast,
+)
 
 import typer
 from moss import DocumentInfo
 
 
-def load_documents(file_path: str) -> List[DocumentInfo]:
-    """Load documents from a JSON/CSV file or stdin ('-')."""
+class _MappingOptions(TypedDict):
+    id_column: str
+    text_column: str
+    metadata_columns: Optional[List[str]]
+    require_non_empty: bool
+
+
+_Record = Tuple[Dict[str, Any], str]
+
+
+def load_documents(
+    file_path: str,
+    *,
+    id_column: str = "id",
+    text_column: str = "text",
+    metadata_columns: Optional[Sequence[str]] = None,
+    require_non_empty: bool = False,
+) -> List[DocumentInfo]:
+    """Load documents and optionally map custom source columns.
+
+    When ``metadata_columns`` is provided, those source fields are copied into
+    metadata as strings. Otherwise, the existing ``metadata`` object is used.
+    ``require_non_empty`` lets the import command reject blank IDs and text
+    without changing legacy callers that use this loader for validation.
+    """
+    mapping = _mapping_options(
+        id_column, text_column, metadata_columns, require_non_empty
+    )
+
     if file_path == "-":
-        raw = sys.stdin.read()
-        return _parse_json_docs(raw, source="stdin")
+        return _parse_json(sys.stdin.read(), "stdin", mapping)
 
     path = Path(file_path)
     if not path.exists():
         raise typer.BadParameter(f"File not found: {file_path}")
+    if not path.is_file():
+        raise typer.BadParameter(f"Not a file: {file_path}")
 
-    suffix = path.suffix.lower()
-    content = path.read_text()
+    try:
+        content = path.read_text(encoding="utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise typer.BadParameter(f"{file_path} is not valid UTF-8: {exc}") from exc
 
-    if suffix == ".csv":
-        return _parse_csv_docs(content)
-    elif suffix == ".jsonl":
-        return _parse_jsonl_docs(content, source=file_path)
-    elif suffix == ".json":
-        return _parse_json_docs(content, source=file_path)
-    else:
-        return _parse_json_docs(content, source=file_path)
+    if path.suffix.lower() == ".csv":
+        return _parse_csv(content, file_path, mapping)
+    if path.suffix.lower() == ".jsonl":
+        return _parse_jsonl(content, file_path, mapping)
+    return _parse_json(content, file_path, mapping)
 
 
-def _parse_json_docs(raw: str, source: str = "input") -> List[DocumentInfo]:
+def _mapping_options(
+    id_column: str,
+    text_column: str,
+    metadata_columns: Optional[Sequence[str]],
+    require_non_empty: bool,
+) -> _MappingOptions:
+    id_column = id_column.strip()
+    text_column = text_column.strip()
+    if not id_column:
+        raise typer.BadParameter("ID column name cannot be empty")
+    if not text_column:
+        raise typer.BadParameter("Text column name cannot be empty")
+
+    normalized_metadata: Optional[List[str]] = None
+    if metadata_columns is not None:
+        normalized_metadata = []
+        for column in metadata_columns:
+            name = column.strip()
+            if not name:
+                raise typer.BadParameter("Metadata column name cannot be empty")
+            if name not in normalized_metadata:
+                normalized_metadata.append(name)
+
+    return {
+        "id_column": id_column,
+        "text_column": text_column,
+        "metadata_columns": normalized_metadata,
+        "require_non_empty": require_non_empty,
+    }
+
+
+def _parse_json(raw: str, source: str, mapping: _MappingOptions) -> List[DocumentInfo]:
     try:
         data = json.loads(raw)
-    except json.JSONDecodeError as e:
-        raise typer.BadParameter(f"Invalid JSON in {source}: {e}")
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"Invalid JSON in {source}: {exc}") from exc
 
     if isinstance(data, dict):
-        data = data.get("documents", data.get("docs", []))
-
+        if "documents" in data:
+            data = data["documents"]
+        elif "docs" in data:
+            data = data["docs"]
+        else:
+            raise typer.BadParameter(
+                "Expected a JSON array or an object with a 'documents' or "
+                f"'docs' array in {source}"
+            )
     if not isinstance(data, list):
         raise typer.BadParameter(
             f"Expected a JSON array of documents, got {type(data).__name__}"
         )
 
-    return [_dict_to_doc(d, i) for i, d in enumerate(data)]
+    records = []
+    for index, item in enumerate(data):
+        label = f"Document at index {index}"
+        records.append((_require_record(item, label), label))
+    return _records_to_docs(records, source, mapping)
 
 
-def _parse_jsonl_docs(raw: str, source: str = "input") -> List[DocumentInfo]:
-    docs = []
+def _parse_jsonl(raw: str, source: str, mapping: _MappingOptions) -> List[DocumentInfo]:
+    records: List[_Record] = []
     for line_no, line in enumerate(raw.splitlines(), start=1):
-        line = line.strip()
-        if not line:
+        if not line.strip():
             continue
         try:
-            obj = json.loads(line)
-        except json.JSONDecodeError as e:
-            raise typer.BadParameter(f"Invalid JSON on line {line_no} in {source}: {e}")
-        docs.append(_dict_to_doc(obj, line_no - 1))
-    return docs
-
-
-def _parse_csv_docs(content: str) -> List[DocumentInfo]:
-    reader = csv.DictReader(content.splitlines())
-    docs = []
-    for i, row in enumerate(reader):
-        if "id" not in row or "text" not in row:
+            item = json.loads(line)
+        except json.JSONDecodeError as exc:
             raise typer.BadParameter(
-                f"CSV row {i + 1}: missing required 'id' or 'text' column"
-            )
-        metadata = None
-        if "metadata" in row and row["metadata"]:
-            try:
-                metadata = json.loads(row["metadata"])
-            except json.JSONDecodeError:
-                raise typer.BadParameter(
-                    f"CSV row {i + 1}: invalid JSON in 'metadata' column"
-                )
+                f"Invalid JSON on line {line_no} in {source}: {exc}"
+            ) from exc
+        label = f"JSONL line {line_no}"
+        records.append((_require_record(item, label), label))
+    return _records_to_docs(records, source, mapping)
 
-        embedding = None
-        if "embedding" in row and row["embedding"]:
-            try:
-                embedding = json.loads(row["embedding"])
-            except json.JSONDecodeError:
-                raise typer.BadParameter(
-                    f"CSV row {i + 1}: invalid JSON in 'embedding' column"
-                )
 
-        docs.append(
-            DocumentInfo(
-                id=row["id"],
-                text=row["text"],
-                metadata=metadata,
-                embedding=embedding,
+def _parse_csv(
+    content: str, source: str, mapping: _MappingOptions
+) -> List[DocumentInfo]:
+    # StringIO preserves newlines inside quoted fields; splitlines() does not.
+    reader = csv.DictReader(io.StringIO(content, newline=""))
+    fieldnames = reader.fieldnames
+    if not fieldnames:
+        raise typer.BadParameter(f"CSV in {source} is missing a header row")
+
+    duplicate_headers = _duplicates(fieldnames)
+    if duplicate_headers:
+        names = ", ".join(repr(name) for name in duplicate_headers)
+        raise typer.BadParameter(f"CSV in {source} has duplicate column(s): {names}")
+
+    _validate_required_columns(fieldnames, mapping, source)
+    _validate_metadata_column_names(fieldnames, mapping["metadata_columns"], source)
+
+    docs = []
+    for row in reader:
+        label = f"CSV row {reader.line_num}"
+        if None in row:
+            raise typer.BadParameter(
+                f"{label} in {source} has more values than the header row"
             )
-        )
+        docs.append(_record_to_doc(row, label, mapping))
     return docs
 
 
-def _dict_to_doc(d: Any, index: int) -> DocumentInfo:
-    if not isinstance(d, dict):
-        raise typer.BadParameter(f"Document at index {index}: expected object, got {type(d).__name__}")
-    if "id" not in d or "text" not in d:
-        raise typer.BadParameter(f"Document at index {index}: missing required 'id' or 'text' field")
-    return DocumentInfo(
-        id=str(d["id"]),
-        text=str(d["text"]),
-        metadata=d.get("metadata"),
-        embedding=d.get("embedding"),
+def _records_to_docs(
+    records: Sequence[_Record], source: str, mapping: _MappingOptions
+) -> List[DocumentInfo]:
+    if records:
+        available_names = {name for record, _ in records for name in record}
+        _validate_metadata_column_names(
+            available_names, mapping["metadata_columns"], source
+        )
+    return [_record_to_doc(record, label, mapping) for record, label in records]
+
+
+def _require_record(item: Any, label: str) -> Dict[str, Any]:
+    if not isinstance(item, dict):
+        raise typer.BadParameter(f"{label}: expected object, got {type(item).__name__}")
+    return item
+
+
+def _record_to_doc(
+    record: Dict[str, Any], label: str, mapping: _MappingOptions
+) -> DocumentInfo:
+    id_column = mapping["id_column"]
+    text_column = mapping["text_column"]
+    metadata_columns = mapping["metadata_columns"]
+    doc_id = _required_value(record, id_column, "ID", label, mapping)
+    text = _required_value(record, text_column, "text", label, mapping)
+
+    consumed_columns = {id_column, text_column}
+    if metadata_columns is not None:
+        consumed_columns.update(metadata_columns)
+        metadata = _mapped_metadata(record, metadata_columns)
+    else:
+        metadata = (
+            None
+            if "metadata" in consumed_columns
+            else _parse_metadata(record.get("metadata"), label)
+        )
+
+    embedding = (
+        None
+        if "embedding" in consumed_columns
+        else _parse_embedding(record.get("embedding"), label)
     )
+    return DocumentInfo(
+        id=str(doc_id), text=str(text), metadata=metadata, embedding=embedding
+    )
+
+
+def _required_value(
+    record: Dict[str, Any],
+    column: str,
+    role: str,
+    label: str,
+    mapping: _MappingOptions,
+) -> Any:
+    if column not in record:
+        raise typer.BadParameter(f"{label}: missing mapped {role} column '{column}'")
+    value = record[column]
+    if value is None:
+        raise typer.BadParameter(
+            f"{label}: mapped {role} column '{column}' has no value"
+        )
+    if mapping["require_non_empty"] and isinstance(value, str) and not value.strip():
+        raise typer.BadParameter(f"{label}: mapped {role} column '{column}' is blank")
+    return value
+
+
+def _parse_metadata(value: Any, label: str) -> Optional[Dict[str, str]]:
+    if value in (None, ""):
+        return None
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise typer.BadParameter(
+                f"{label}: invalid JSON in 'metadata' column"
+            ) from exc
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise typer.BadParameter(f"{label}: 'metadata' must be a JSON object")
+    metadata = {
+        str(key): _metadata_value(item)
+        for key, item in value.items()
+        if item is not None
+    }
+    return metadata
+
+
+def _mapped_metadata(
+    record: Dict[str, Any], metadata_columns: Sequence[str]
+) -> Optional[Dict[str, str]]:
+    metadata = {}
+    for column in metadata_columns:
+        value = record.get(column)
+        if value is None or (isinstance(value, str) and not value.strip()):
+            continue
+        metadata[column] = _metadata_value(value)
+    return metadata or None
+
+
+def _metadata_value(value: Any) -> str:
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return str(value)
+
+
+def _parse_embedding(value: Any, label: str) -> Optional[List[float]]:
+    if value in (None, ""):
+        return None
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise typer.BadParameter(
+                f"{label}: invalid JSON in 'embedding' column"
+            ) from exc
+    if value is None:
+        return None
+    if not isinstance(value, list) or not all(
+        isinstance(item, (int, float)) and not isinstance(item, bool) for item in value
+    ):
+        raise typer.BadParameter(
+            f"{label}: 'embedding' must be a JSON array of numbers"
+        )
+    return cast(List[float], value)
+
+
+def _validate_required_columns(
+    columns: Collection[str], mapping: _MappingOptions, source: str
+) -> None:
+    expected = (mapping["id_column"], mapping["text_column"])
+    missing = [name for name in expected if name not in columns]
+    if missing:
+        formatted = ", ".join(repr(name) for name in missing)
+        raise typer.BadParameter(
+            f"{source}: mapped required column(s) not found: {formatted}"
+        )
+
+
+def _validate_metadata_column_names(
+    names: Collection[str],
+    metadata_columns: Optional[Sequence[str]],
+    source: str,
+) -> None:
+    if metadata_columns is None:
+        return
+    missing = [name for name in metadata_columns if name not in names]
+    if missing:
+        formatted = ", ".join(repr(name) for name in missing)
+        raise typer.BadParameter(
+            f"{source}: mapped metadata column(s) not found: {formatted}"
+        )
+
+
+def _duplicates(names: Sequence[str]) -> List[str]:
+    seen = set()
+    duplicates = []
+    for name in names:
+        if name in seen and name not in duplicates:
+            duplicates.append(name)
+        seen.add(name)
+    return duplicates

--- a/packages/moss-cli/src/moss_cli/main.py
+++ b/packages/moss-cli/src/moss_cli/main.py
@@ -29,6 +29,11 @@ app = typer.Typer(
 # Register subgroups
 app.add_typer(index_app, name="index", help="Manage indexes")
 app.add_typer(doc_app, name="doc", help="Manage documents")
+app.add_typer(
+    doc_app,
+    name="documents",
+    help="Manage documents (alias for 'doc')",
+)
 app.add_typer(job_app, name="job", help="Track background jobs")
 app.add_typer(profile_app, name="profile", help="Manage auth profiles")
 

--- a/packages/moss-cli/tests/test_documents_import.py
+++ b/packages/moss-cli/tests/test_documents_import.py
@@ -1,0 +1,460 @@
+import io
+import json
+from types import SimpleNamespace
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from moss_cli.commands import doc as doc_cmd
+from moss_cli.documents import load_documents
+from moss_cli.main import app
+
+runner = CliRunner()
+AUTH_OPTIONS = [
+    "--project-id",
+    "project-id",
+    "--project-key",
+    "project-key",
+]
+
+
+def _install_recording_client(monkeypatch, seen):
+    class FakeClient:
+        def __init__(self, project_id, project_key):
+            seen["credentials"] = (project_id, project_key)
+
+        async def add_docs(self, index_name, docs, options):
+            seen.update(
+                index_name=index_name,
+                docs=docs,
+                upsert=options.upsert if options else False,
+            )
+            return SimpleNamespace(
+                job_id="job-123", index_name=index_name, doc_count=len(docs)
+            )
+
+    monkeypatch.setattr(doc_cmd, "MossClient", FakeClient)
+
+
+def _invoke_import(path, *options, group="doc", json_output=False):
+    args = [*AUTH_OPTIONS]
+    if json_output:
+        args.append("--json")
+    args.extend([group, "import", "products", "--file", str(path), *options])
+    return runner.invoke(app, args)
+
+
+def test_load_mapped_csv_with_metadata_and_multiline_text(tmp_path):
+    path = tmp_path / "products.csv"
+    path.write_text(
+        "sku,description,category,price\n"
+        'A-100,"Lightweight trail\nrunning shoe",footwear,89.99\n'
+        "A-200,Waterproof hiking boot,,129.99\n",
+        encoding="utf-8",
+    )
+
+    docs = load_documents(
+        str(path),
+        id_column="sku",
+        text_column="description",
+        metadata_columns=["category", "price"],
+    )
+
+    assert [(doc.id, doc.text) for doc in docs] == [
+        ("A-100", "Lightweight trail\nrunning shoe"),
+        ("A-200", "Waterproof hiking boot"),
+    ]
+    assert docs[0].metadata == {"category": "footwear", "price": "89.99"}
+    assert docs[1].metadata == {"price": "129.99"}
+
+
+def test_load_mapped_wrapper_json_stringifies_metadata_values(tmp_path):
+    path = tmp_path / "products.json"
+    path.write_text(
+        json.dumps(
+            {
+                "documents": [
+                    {
+                        "sku": 100,
+                        "body": "Trail shoe",
+                        "price": 89.99,
+                        "tags": ["trail", "lightweight"],
+                        "details": {"color": "blue"},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    docs = load_documents(
+        str(path),
+        id_column="sku",
+        text_column="body",
+        metadata_columns=["price", "tags", "details"],
+    )
+
+    assert docs[0].id == "100"
+    assert docs[0].text == "Trail shoe"
+    assert docs[0].metadata == {
+        "price": "89.99",
+        "tags": '["trail", "lightweight"]',
+        "details": '{"color": "blue"}',
+    }
+
+
+def test_load_mapped_jsonl_allows_optional_metadata_fields(tmp_path):
+    path = tmp_path / "products.jsonl"
+    path.write_text(
+        '{"sku":"A-1","body":"One","category":"shoes"}\n'
+        '{"sku":"A-2","body":"Two"}\n',
+        encoding="utf-8",
+    )
+
+    docs = load_documents(
+        str(path),
+        id_column="sku",
+        text_column="body",
+        metadata_columns=["category"],
+    )
+
+    assert docs[0].metadata == {"category": "shoes"}
+    assert docs[1].metadata is None
+
+
+def test_load_mapped_json_from_stdin(monkeypatch):
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO('[{"doc_id":"one","body":"From stdin"}]'),
+    )
+
+    docs = load_documents("-", id_column="doc_id", text_column="body")
+
+    assert [(doc.id, doc.text) for doc in docs] == [("one", "From stdin")]
+
+
+def test_single_json_object_reports_expected_container(tmp_path):
+    path = tmp_path / "document.json"
+    path.write_text('{"id":"one","text":"Hello"}', encoding="utf-8")
+
+    with pytest.raises(
+        typer.BadParameter,
+        match="Expected a JSON array or an object with a 'documents' or 'docs' array",
+    ):
+        load_documents(str(path))
+
+
+def test_default_mapping_preserves_metadata_and_embedding(tmp_path):
+    path = tmp_path / "documents.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "id": "one",
+                    "text": "Default format",
+                    "metadata": {"rank": 1, "active": True, "skip": None},
+                    "embedding": [0.1, 0.2],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    docs = load_documents(str(path))
+
+    assert docs[0].metadata == {"rank": "1", "active": "True"}
+    assert list(docs[0].embedding) == pytest.approx([0.1, 0.2])
+
+
+def test_default_csv_accepts_json_null_metadata_and_embedding(tmp_path):
+    path = tmp_path / "documents.csv"
+    path.write_text(
+        "id,text,metadata,embedding\none,Hello,null,null\n", encoding="utf-8"
+    )
+
+    docs = load_documents(str(path))
+
+    assert docs[0].metadata is None
+    assert docs[0].embedding is None
+
+
+def test_default_mapping_preserves_empty_metadata_object(tmp_path):
+    path = tmp_path / "documents.json"
+    path.write_text('[{"id":"one","text":"Hello","metadata":{}}]', encoding="utf-8")
+
+    docs = load_documents(str(path))
+
+    assert docs[0].metadata == {}
+
+
+@pytest.mark.parametrize("text_column", ["metadata", "embedding"])
+def test_mapped_required_column_can_use_legacy_special_name(tmp_path, text_column):
+    path = tmp_path / "documents.csv"
+    path.write_text(f"id,{text_column}\none,Ordinary text\n", encoding="utf-8")
+
+    docs = load_documents(str(path), text_column=text_column)
+
+    assert docs[0].text == "Ordinary text"
+    assert docs[0].metadata is None
+    assert docs[0].embedding is None
+
+
+def test_mapped_metadata_can_use_embedding_column_name(tmp_path):
+    path = tmp_path / "documents.csv"
+    path.write_text("id,text,embedding\none,Hello,source-value\n", encoding="utf-8")
+
+    docs = load_documents(str(path), metadata_columns=["embedding"])
+
+    assert docs[0].metadata == {"embedding": "source-value"}
+    assert docs[0].embedding is None
+
+
+def test_csv_with_utf8_bom_is_supported(tmp_path):
+    path = tmp_path / "bom.csv"
+    path.write_text("\ufeffid,text\none,Hello\n", encoding="utf-8")
+
+    docs = load_documents(str(path))
+
+    assert docs[0].id == "one"
+
+
+@pytest.mark.parametrize(
+    ("content", "message"),
+    [
+        (
+            "sku,description\nA-1,Hello\n",
+            "mapped required column(s) not found: 'id', 'text'",
+        ),
+        ("id,text\n,Hello\n", "mapped ID column 'id' is blank"),
+        ("id,text\nA-1,   \n", "mapped text column 'text' is blank"),
+    ],
+)
+def test_csv_reports_actionable_required_column_errors(tmp_path, content, message):
+    path = tmp_path / "bad.csv"
+    path.write_text(content, encoding="utf-8")
+
+    with pytest.raises(typer.BadParameter) as exc_info:
+        load_documents(str(path), require_non_empty=True)
+    assert message in str(exc_info.value)
+
+
+def test_json_reports_missing_mapped_required_column(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text('[{"sku":"A-1"}]', encoding="utf-8")
+
+    with pytest.raises(
+        typer.BadParameter,
+        match="Document at index 0: missing mapped text column 'body'",
+    ):
+        load_documents(str(path), id_column="sku", text_column="body")
+
+
+def test_validate_keeps_aggregating_blank_text_and_duplicate_ids(tmp_path):
+    path = tmp_path / "documents.csv"
+    path.write_text(
+        "id,text\nsame,\nsame,Hello\nother,   \n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["--json", "validate", "--file", str(path)])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["doc_count"] == 3
+    assert "Duplicate ID 'same' appears 2 times" in payload["issues"]
+    assert "Document 0 (id='same'): empty text" in payload["issues"]
+    assert "Document 2 (id='other'): empty text" in payload["issues"]
+
+
+def test_missing_trailing_csv_value_is_not_stringified_as_none(tmp_path):
+    path = tmp_path / "documents.csv"
+    path.write_text("id,text\none\n", encoding="utf-8")
+
+    with pytest.raises(
+        typer.BadParameter, match="mapped text column 'text' has no value"
+    ):
+        load_documents(str(path))
+
+    result = runner.invoke(app, ["--json", "validate", "--file", str(path)])
+    assert result.exit_code == 1
+    assert json.loads(result.output)["valid"] is False
+
+
+@pytest.mark.parametrize(
+    "suffix,content",
+    [("csv", "id,text\none,Hello\n"), ("json", '[{"id":"one","text":"Hello"}]')],
+)
+def test_unknown_metadata_column_is_rejected(tmp_path, suffix, content):
+    path = tmp_path / f"documents.{suffix}"
+    path.write_text(content, encoding="utf-8")
+
+    with pytest.raises(
+        typer.BadParameter, match=r"mapped metadata column\(s\) not found: 'missing'"
+    ):
+        load_documents(str(path), metadata_columns=["missing"])
+
+
+def test_invalid_metadata_and_embedding_are_rejected(tmp_path):
+    metadata_path = tmp_path / "metadata.csv"
+    metadata_path.write_text("id,text,metadata\none,Hello,not-json\n", encoding="utf-8")
+    embedding_path = tmp_path / "embedding.json"
+    embedding_path.write_text(
+        '[{"id":"one","text":"Hello","embedding":[0.1,true]}]',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(typer.BadParameter, match="invalid JSON in 'metadata' column"):
+        load_documents(str(metadata_path))
+    with pytest.raises(
+        typer.BadParameter, match="'embedding' must be a JSON array of numbers"
+    ):
+        load_documents(str(embedding_path))
+
+
+def test_duplicate_csv_headers_are_rejected(tmp_path):
+    path = tmp_path / "duplicate.csv"
+    path.write_text("id,text,text\none,Hello,Again\n", encoding="utf-8")
+
+    with pytest.raises(typer.BadParameter, match=r"duplicate column\(s\): 'text'"):
+        load_documents(str(path))
+
+
+@pytest.mark.parametrize("command_group", ["doc", "documents"])
+def test_import_command_maps_columns_for_both_command_names(
+    monkeypatch, tmp_path, command_group
+):
+    path = tmp_path / "products.csv"
+    path.write_text(
+        "sku,description,category,price\n" "A-100,Trail shoe,footwear,89.99\n",
+        encoding="utf-8",
+    )
+    seen = {}
+    _install_recording_client(monkeypatch, seen)
+
+    result = _invoke_import(
+        path,
+        "--id-column",
+        "sku",
+        "--text-column",
+        "description",
+        "--metadata-columns",
+        "category,price",
+        "--upsert",
+        group=command_group,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen["credentials"] == ("project-id", "project-key")
+    assert seen["index_name"] == "products"
+    assert seen["upsert"] is True
+    assert seen["docs"][0].id == "A-100"
+    assert seen["docs"][0].text == "Trail shoe"
+    assert seen["docs"][0].metadata == {
+        "category": "footwear",
+        "price": "89.99",
+    }
+    assert "Importing 1 document(s)" in result.output
+    assert "job-123" in result.output
+
+
+def test_import_command_supports_repeated_metadata_flags_and_wait(
+    monkeypatch, tmp_path
+):
+    path = tmp_path / "products.csv"
+    path.write_text(
+        "sku,description,category,price\nA-100,Trail shoe,footwear,89.99\n",
+        encoding="utf-8",
+    )
+    seen = {}
+    _install_recording_client(monkeypatch, seen)
+
+    async def fake_wait_for_job(client, job_id, poll_interval, json_mode, timeout):
+        seen["wait"] = (job_id, poll_interval, json_mode, timeout)
+
+    monkeypatch.setattr(doc_cmd, "wait_for_job", fake_wait_for_job)
+
+    result = _invoke_import(
+        path,
+        "--id-column",
+        "sku",
+        "--text-column",
+        "description",
+        "--metadata-column",
+        "category",
+        "--metadata-column",
+        "price",
+        "--wait",
+        "--poll-interval",
+        "0.25",
+        "--timeout",
+        "3",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen["docs"][0].metadata == {
+        "category": "footwear",
+        "price": "89.99",
+    }
+    assert seen["wait"] == ("job-123", 0.25, False, 3.0)
+
+
+def test_import_without_mapping_preserves_standard_metadata(monkeypatch, tmp_path):
+    path = tmp_path / "documents.json"
+    path.write_text(
+        '[{"id":"one","text":"Hello","metadata":{"topic":"intro"}}]',
+        encoding="utf-8",
+    )
+    seen = {}
+    _install_recording_client(monkeypatch, seen)
+
+    result = _invoke_import(path)
+
+    assert result.exit_code == 0, result.output
+    assert seen["docs"][0].metadata == {"topic": "intro"}
+
+
+def test_import_json_output_is_machine_readable(monkeypatch, tmp_path):
+    path = tmp_path / "documents.json"
+    path.write_text('[{"id":"one","text":"Hello"}]', encoding="utf-8")
+    seen = {}
+    _install_recording_client(monkeypatch, seen)
+
+    result = _invoke_import(path, group="documents", json_output=True)
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {
+        "job_id": "job-123",
+        "index_name": "products",
+        "doc_count": 1,
+    }
+
+
+def test_import_rejects_empty_input_before_creating_client(monkeypatch, tmp_path):
+    path = tmp_path / "documents.json"
+    path.write_text("[]", encoding="utf-8")
+
+    class UnexpectedClient:
+        def __init__(self, project_id, project_key):
+            raise AssertionError("client should not be created for invalid input")
+
+    monkeypatch.setattr(doc_cmd, "MossClient", UnexpectedClient)
+
+    result = _invoke_import(path, "--metadata-column", "category", group="documents")
+
+    assert result.exit_code != 0
+    assert "No documents found in" in result.output
+
+
+def test_doc_add_remains_backward_compatible(monkeypatch, tmp_path):
+    path = tmp_path / "documents.json"
+    path.write_text('[{"id":"one","text":"Hello"}]', encoding="utf-8")
+    seen = {}
+    _install_recording_client(monkeypatch, seen)
+
+    result = runner.invoke(
+        app, [*AUTH_OPTIONS, "doc", "add", "products", "-f", str(path)]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert [(doc.id, doc.text) for doc in seen["docs"]] == [("one", "Hello")]


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [x] I have updated the documentation.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove the feature works.
- [x] New and existing tests pass locally, except for two pre-existing shell-completion failures described below.

## Description

Adds a discoverable bulk-import workflow for CSV, JSON, and JSONL files whose source columns do not already use Moss's `id` and `text` names.

- Adds the requested `moss documents import` command and the shorter `moss doc import` form.
- Supports `--id-column`, `--text-column`, repeatable `--metadata-column`, and comma-separated `--metadata-columns` mappings.
- Reuses the existing authentication, profile, upsert, wait, timeout, JSON-output, and index-completion behavior.
- Validates mapped files before creating the client, with row-specific errors for missing or blank required values.
- Preserves the existing standard document format, including metadata objects, custom embeddings, JSON wrappers, JSONL, and stdin input.
- Handles quoted multiline CSV fields without retaining an additional copy of every parsed row.
- Documents the new workflow and adds focused parser and no-network CLI coverage.

```bash
moss documents import products -f products.csv \
  --id-column sku \
  --text-column description \
  --metadata-column category \
  --metadata-column price \
  --upsert --wait
```

Fixes #379

## Testing

- `pytest packages/moss-cli/tests/test_documents_import.py -q` — 29 passed on Python 3.13 and 3.14
- Repeated the focused suite with Typer 0.9.0 (declared minimum) and Typer 0.26.8 — 29 passed on each
- `ruff check . --extend-exclude '**/*.ipynb'`
- `mypy packages/moss-cli/src/moss_cli/documents.py packages/moss-cli/src/moss_cli/commands/doc.py --ignore-missing-imports`
- `black --check` and `isort --check-only` on changed Python files
- Python 3.10 grammar check on changed Python files
- Built both sdist and wheel; `twine check` passed for both
- Clean-wheel smoke test: package import and `moss documents import --help` passed

The full Moss CLI suite reports 57 passed and 2 failed under the latest Typer. The same two untouched shell-completion tests (`test_completions_bash_outputs_script` and `test_completions_zsh_outputs_script`) also fail on `origin/main` in the same environment because Typer's completion API changed; this PR does not alter that code.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature which changes existing behavior)
- [x] Documentation update
