### PR TITLE
docs: add moss-reflex procedural-memory community demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ moss-live-labs/              # Experimental zone: prototypes and community demos
 │   ├── advanced-voice-agent/ # Persona impersonator built on a PDF knowledge base
 │   └── image-search/        # FastAPI + React image search over COCO
 └── community-demos/         # Community-contributed projects
-    ├── coding-agents/       # moss-reflex procedural memory
+    ├── coding-agents/       # moss-reflex
     └── voice-agents/        # bharat-benefits, shoplabs-voice-agent
 ```
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ moss-live-labs/              # Experimental zone: prototypes and community demos
 │   ├── advanced-voice-agent/ # Persona impersonator built on a PDF knowledge base
 │   └── image-search/        # FastAPI + React image search over COCO
 └── community-demos/         # Community-contributed projects
+    ├── coding-agents/       # moss-reflex procedural memory
     └── voice-agents/        # bharat-benefits, shoplabs-voice-agent
 ```
 
@@ -229,6 +230,7 @@ Full API reference: [docs.moss.dev](https://docs.moss.dev).
 | [LlamaIndex](https://github.com/run-llama/llama_index) | Available | [`apps/moss-llamaindex/`](apps/moss-llamaindex/) |
 | [CrewAI](https://github.com/crewAIInc/crewAI) | Available | [`examples/cookbook/crewai/`](examples/cookbook/crewai/) |
 | [AutoGen](https://github.com/microsoft/autogen) | Available | [`examples/cookbook/autogen/`](examples/cookbook/autogen/) |
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) | Available | [`moss-live-labs/community-demos/coding-agents/moss-reflex/`](moss-live-labs/community-demos/coding-agents/moss-reflex/) |
 | [Haystack](https://github.com/deepset-ai/haystack) | Available | [`examples/cookbook/haystack/`](examples/cookbook/haystack/) |
 | [Mastra](https://mastra.ai) | Available | [`examples/cookbook/mastra/`](examples/cookbook/mastra/) |
 | [Pydantic AI](https://ai.pydantic.dev) | Available | [`examples/cookbook/pydantic-ai/`](examples/cookbook/pydantic-ai/) |

--- a/moss-live-labs/community-demos/coding-agents/moss-reflex/README.md
+++ b/moss-live-labs/community-demos/coding-agents/moss-reflex/README.md
@@ -1,0 +1,48 @@
+# moss-reflex: procedural memory for coding agents
+
+[moss-reflex](https://github.com/Naut1cal5/moss-reflex) records what a coding agent tried,
+what happened, and whether that action fixed, worsened, or reverted a recurring failure. It turns
+Claude Code's tool execution trail into a local Moss session and exposes procedural recall over
+MCP.
+
+## What this demo shows
+
+- `PostToolUse`, `PostToolUseFailure`, and `Stop` hooks capture execution context automatically.
+- Exit codes, test-count deltas, and Git diff fingerprints label outcomes without an LLM.
+- Trace normalization strips volatile addresses, line numbers, timestamps, and absolute path
+  prefixes while retaining exception types, frame functions, and relative module paths.
+- Moss structured payloads preserve the original raw trace for verbatim retrieval.
+- Metadata filters scope recall by repository, language, error class, tool, outcome, and time.
+- Exponential recency reranking keeps fixes from the current dependency era above stale ones.
+- Native local disk snapshots make restarts fast; append-only JSONL rebuilds a missing or damaged
+  snapshot without uploading the corpus.
+
+## Try it
+
+```bash
+git clone https://github.com/Naut1cal5/moss-reflex.git
+cd moss-reflex
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install .
+
+export MOSS_PROJECT_ID="your-project-id"
+export MOSS_PROJECT_KEY="your-project-key"
+
+# Run this from the repository Claude Code should remember.
+moss-reflex init
+```
+
+Restart Claude Code, then call `recall_similar_situations` before retrying a familiar failure.
+`reflex_stats` summarizes the local episode store.
+
+## Why Moss sessions fit
+
+Agent procedures arrive continuously during a coding session. A Moss `SessionIndex` supports
+local embedding, immediate mutation, metadata-filtered semantic search, and single-digit
+millisecond queries in the agent process. `moss-reflex` keeps both the source JSONL and native
+snapshot on the developer's machine and uses the built-in local embedding model, so there is no
+embedding provider or LLM-labeling cost. Local Moss queries are unmetered on the Developer plan.
+
+The complete implementation, tests, benchmark harness, MIT license, and issue tracker live in the
+[standalone repository](https://github.com/Naut1cal5/moss-reflex).


### PR DESCRIPTION
## Summary

- add `moss-reflex` to the coding-agent community demos
- document deterministic outcome labeling, trace normalization, structured payloads, metadata filters, recency reranking, and local snapshot recovery
- add Claude Code to the integration catalog and update the community-demo tree

## Why

Coding agents repeatedly rediscover repository-specific fixes. `moss-reflex` uses a local Moss session as procedural memory: Claude Code hooks capture context/action/outcome episodes, mechanical signals label the result without an LLM, and a stdio MCP server recalls similar past situations before the next attempt.

The complete MIT-licensed implementation is maintained at https://github.com/Naut1cal5/moss-reflex so its CLI, tests, benchmark harness, and releases do not drift inside this monorepo.

## Validation

- `git diff --check`
- standalone project: 15 tests passing on Python 3.13
- Ruff and strict mypy passing
- package wheel and source distribution build successfully
- repository, commit diff, and built artifacts scanned with no secret findings

## Data and cost boundary

Episodes, local embeddings, queries, JSONL, and native snapshots remain on the developer machine. The project does not invoke an LLM for capture or labeling and local Moss queries are unmetered on the Developer plan. Credentials are environment-only; no project IDs or keys are included here.
