### PR TITLE
feat: add Moss-backed archival memory package for Letta

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ apps/
 packages/
   agora-moss/            — Agora Conversational AI MCP server package
   elevenlabs-moss/       — ElevenLabs integration package
+  letta-moss/            — Letta (MemGPT) archival memory integration package
   moss-cli/              — CLI for index/document management (no-code workflows)
   moss-data-connector/   — Database source connectors
     moss-connector-mongodb/  — MongoDB connector
@@ -134,6 +135,7 @@ asks for an experimental landing spot.
 | ------- | ---------- | ---------------- |
 | `agora-moss/` | (internal) | MCP server exposing Moss search to Agora Conversational AI |
 | `elevenlabs-moss/` | `elevenlabs-moss` | `MossElevenLabsTool` — drop-in knowledge-base tool for ElevenLabs agents |
+| `letta-moss/` | `letta-moss` | `MossLettaMemory` + MCP/custom-tool surfaces — Moss-backed archival memory for Letta (MemGPT) agents |
 | `moss-cli/` | `moss-cli` | CLI: `moss index`, `moss query`, `moss documents` — no-code index management |
 | `moss-connector-mongodb/` | `moss-connector-mongodb` | Sync MongoDB collections → Moss index |
 | `moss-connector-mysql/` | `moss-connector-mysql` | Sync MySQL / MariaDB tables → Moss index |

--- a/packages/letta-moss/LICENSE
+++ b/packages/letta-moss/LICENSE
@@ -1,0 +1,24 @@
+BSD 2-Clause License
+
+Copyright (c) 2025, InferEdge Inc.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/letta-moss/README.md
+++ b/packages/letta-moss/README.md
@@ -68,7 +68,7 @@ Then register the server as an MCP tool source on your Letta agent, pointing at 
 |---|---|---|
 | `MossLettaMemory(*, project_id=None, project_key=None, index_name, top_k=5, alpha=0.8)` | class | Core adapter; `async load_index()`, `async insert_memory(content, tags=, metadata=) -> str`, `async search_memory(query, top_k=, tags=) -> list[ArchivalMemoryItem]`, `async delete_memory(memory_id)`, `async get_memory(memory_id) -> ArchivalMemoryItem \| None`, `async list_memories(limit=) -> list[ArchivalMemoryItem]`. Falls back to `MOSS_PROJECT_ID`/`MOSS_PROJECT_KEY` env vars when credentials are omitted. |
 | `moss_memory_insert(content, tags=None) -> str` | async function | Custom-tool wrapper; insert a memory, return its id. |
-| `moss_memory_search(query, top_k=5) -> list[dict]` | async function | Custom-tool wrapper; search memories, return dicts. |
+| `moss_memory_search(query, top_k=5, tags=None) -> list[dict]` | async function | Custom-tool wrapper; search memories, return dicts. |
 | `moss_memory_delete(memory_id) -> None` | async function | Custom-tool wrapper; delete a memory by id. |
 | `create_mcp_app(memory) -> FastMCP` | function | Returns a FastMCP server exposing `moss_memory_insert`/`moss_memory_search`/`moss_memory_delete`; runs `memory.load_index()` in its lifespan. |
 | `ArchivalMemoryItem` | dataclass | `id: str`, `content: str`, `tags: list[str]`, `metadata: dict`, `score: float \| None` (only populated on search results). |
@@ -86,7 +86,7 @@ Then register the server as an MCP tool source on your Letta agent, pointing at 
 ## Dependencies
 
 - `moss>=1.1.1`
-- `mcp>=1.2` (Model Context Protocol Python SDK, FastMCP) — only needed for the MCP server path
+- `mcp>=1.2` (Model Context Protocol Python SDK, FastMCP)
 - Python `>=3.10,<3.15`
 
 This package does not depend on `letta`/`letta-client` — it installs and runs standalone; you bring your own Letta client to register the tools.

--- a/packages/letta-moss/README.md
+++ b/packages/letta-moss/README.md
@@ -1,0 +1,96 @@
+# letta-moss
+
+Moss-backed archival memory for [Letta](https://docs.letta.com) (MemGPT) agents.
+
+Letta's archival memory storage layer no longer has a pluggable backend interface — it's hardcoded to Postgres/pgvector, Turbopuffer, or Pinecone, with no public extension point to register a fourth. Letta's own docs recommend "External RAG through custom tools or MCP" as the sanctioned path once you need something beyond built-in archival memory. This package follows that path: it wraps a Moss index as agent-callable memory tools, in both forms Letta documents.
+
+**No code in the `letta` package is modified.** You register these tools against your Letta agent explicitly, and set `include_base_tools=False` so Moss fully replaces Letta's built-in `archival_memory_insert`/`archival_memory_search` tools.
+
+## Install
+
+```bash
+pip install letta-moss
+# or
+uv add letta-moss
+```
+
+## Quickstart — Option A: custom tools (recommended, no extra process)
+
+Registers plain async functions with `client.tools.upsert_from_function`; they run inside Letta's own sandboxed tool-execution environment.
+
+```python
+from letta_client import Letta
+from letta_moss import moss_memory_delete, moss_memory_insert, moss_memory_search
+
+client = Letta(token="...")
+
+tool_ids = [
+    client.tools.upsert_from_function(func=fn).id
+    for fn in (moss_memory_insert, moss_memory_search, moss_memory_delete)
+]
+
+agent = client.agents.create(
+    model="...",
+    embedding="...",
+    include_base_tools=False,  # drop Letta's built-in archival_memory_* tools
+    tool_ids=tool_ids,
+    tool_exec_environment_variables={
+        "MOSS_PROJECT_ID": "moss-project-id",
+        "MOSS_PROJECT_KEY": "moss-project-key",
+        "MOSS_INDEX_NAME": "my-agent-memory",
+    },
+)
+```
+
+## Quickstart — Option B: MCP server
+
+Runs Moss as an out-of-process MCP server; Letta connects to it as an MCP host, so no Moss code runs inside Letta's own infrastructure.
+
+```python
+import uvicorn
+from letta_moss import MossLettaMemory, create_mcp_app
+
+memory = MossLettaMemory(
+    project_id="moss-project-id",
+    project_key="moss-project-key",
+    index_name="my-agent-memory",
+)
+
+app = create_mcp_app(memory)
+uvicorn.run(app.streamable_http_app(), host="0.0.0.0", port=8080)
+```
+
+Then register the server as an MCP tool source on your Letta agent, pointing at `https://<public-host>/mcp`, and — as in Option A — create the agent with `include_base_tools=False`.
+
+## Public API
+
+| Symbol | Kind | Purpose |
+|---|---|---|
+| `MossLettaMemory(*, project_id=None, project_key=None, index_name, top_k=5, alpha=0.8)` | class | Core adapter; `async load_index()`, `async insert_memory(content, tags=, metadata=) -> str`, `async search_memory(query, top_k=, tags=) -> list[ArchivalMemoryItem]`, `async delete_memory(memory_id)`, `async get_memory(memory_id) -> ArchivalMemoryItem \| None`, `async list_memories(limit=) -> list[ArchivalMemoryItem]`. Falls back to `MOSS_PROJECT_ID`/`MOSS_PROJECT_KEY` env vars when credentials are omitted. |
+| `moss_memory_insert(content, tags=None) -> str` | async function | Custom-tool wrapper; insert a memory, return its id. |
+| `moss_memory_search(query, top_k=5) -> list[dict]` | async function | Custom-tool wrapper; search memories, return dicts. |
+| `moss_memory_delete(memory_id) -> None` | async function | Custom-tool wrapper; delete a memory by id. |
+| `create_mcp_app(memory) -> FastMCP` | function | Returns a FastMCP server exposing `moss_memory_insert`/`moss_memory_search`/`moss_memory_delete`; runs `memory.load_index()` in its lifespan. |
+| `ArchivalMemoryItem` | dataclass | `id: str`, `content: str`, `tags: list[str]`, `metadata: dict`, `score: float \| None` (only populated on search results). |
+
+**Note:** `include_base_tools=False` is required when attaching these tools, or the agent ends up with two competing memory tool sets — Letta's built-in `archival_memory_*` tools and these Moss-backed ones.
+
+**Index creation:** `insert_memory` creates the backing Moss index automatically on the first call if `index_name` doesn't exist yet — you don't need to pre-create it. `search_memory`/`load_index` treat a not-yet-created index as "no memories yet" (returning an empty list) rather than raising.
+
+**Tag filtering:** `search_memory(..., tags=...)` filters client-side on the already-returned results, not via a Moss-side query filter — tags are stored as a single JSON-encoded metadata blob, and Moss's `QueryOptions.filter` grammar only supports `$eq`-style matching against scalar string fields, which can't express "contains tag X" against that blob. To reduce (not eliminate) the chance of under-returning, the underlying query is oversampled when `tags` is set and truncated back to the requested `top_k` after filtering.
+
+**Reserved metadata key:** `insert_memory`'s `metadata` argument must not contain a `"tags"` key — `tags` is a first-class parameter, and passing it inside `metadata` too raises `ValueError` rather than silently overwriting one or the other.
+
+**Env var fallback:** `MossLettaMemory` falls back to `MOSS_PROJECT_ID`/`MOSS_PROJECT_KEY` when constructor args are omitted, unlike some other Moss integrations in this repo (e.g. `agora-moss`) that require explicit args. This is deliberate: these tools typically run inside Letta's sandboxed tool-execution environment, where env vars passed via `tool_exec_environment_variables` are the natural way to configure credentials without hardcoding them in tool source.
+
+## Dependencies
+
+- `moss>=1.1.1`
+- `mcp>=1.2` (Model Context Protocol Python SDK, FastMCP) — only needed for the MCP server path
+- Python `>=3.10,<3.15`
+
+This package does not depend on `letta`/`letta-client` — it installs and runs standalone; you bring your own Letta client to register the tools.
+
+## License
+
+BSD-2-Clause. See repository root.

--- a/packages/letta-moss/README.md
+++ b/packages/letta-moss/README.md
@@ -25,7 +25,7 @@ from letta_moss import moss_memory_delete, moss_memory_insert, moss_memory_searc
 client = Letta(token="...")
 
 tool_ids = [
-    client.tools.upsert_from_function(func=fn).id
+    client.tools.upsert_from_function(func=fn, pip_requirements=["letta-moss"]).id
     for fn in (moss_memory_insert, moss_memory_search, moss_memory_delete)
 ]
 
@@ -41,6 +41,8 @@ agent = client.agents.create(
     },
 )
 ```
+
+**Why `pip_requirements`:** Letta's `upsert_from_function` uploads only the extracted source of each function, not the rest of `letta_moss/tools.py` — so `moss_memory_insert`/`_search`/`_delete` each import `_get_memory` (and, for search, `dataclasses`) *inside* their own body rather than relying on this module's top-level imports. Passing `pip_requirements=["letta-moss"]` ensures the sandbox has the package installed so those in-body imports resolve.
 
 ## Quickstart — Option B: MCP server
 
@@ -61,10 +63,12 @@ memory = MossLettaMemory(
 )
 
 app = create_mcp_app(memory)
-uvicorn.run(app.streamable_http_app(), host="0.0.0.0", port=8080)
+uvicorn.run(app.streamable_http_app(), host="127.0.0.1", port=8080)
 ```
 
-Then register the server as an MCP tool source on your Letta agent, pointing at `https://<public-host>/mcp`, and — as in Option A — create the agent with `include_base_tools=False`.
+**Security:** `create_mcp_app` adds no authentication of its own — the `moss_memory_insert`/`_search`/`_delete` tools are wide open to anyone who can reach the listening port. The snippet above binds to `127.0.0.1` deliberately; if Letta runs on a different host and you need to expose this beyond localhost, put it behind a reverse proxy or gateway that authenticates the caller (e.g. FastMCP's `auth`/`token_verifier` options, mTLS, or a private network) rather than binding `host="0.0.0.0"` directly to a public interface.
+
+Then register the server as an MCP tool source on your Letta agent, pointing at `https://<public-host>/mcp` (behind whatever auth layer you put in front of it), and — as in Option A — create the agent with `include_base_tools=False`.
 
 ## Public API
 
@@ -90,7 +94,7 @@ Then register the server as an MCP tool source on your Letta agent, pointing at 
 ## Dependencies
 
 - `moss>=1.1.1`
-- `mcp>=1.2` (Model Context Protocol Python SDK, FastMCP)
+- `mcp>=1.28,<2` (Model Context Protocol Python SDK, FastMCP; pinned to the v1 line — `create_mcp_app`'s `lifespan=` support and `streamable_http_app()` aren't in the v2 `MCPServer` API)
 - Python `>=3.10,<3.15`
 
 This package does not depend on `letta`/`letta-client` — it installs and runs standalone; you bring your own Letta client to register the tools.

--- a/packages/letta-moss/README.md
+++ b/packages/letta-moss/README.md
@@ -20,13 +20,14 @@ Registers plain async functions with `client.tools.upsert_from_function`; they r
 
 ```python
 from letta_client import Letta
-from letta_moss import moss_memory_delete, moss_memory_insert, moss_memory_search
+from letta_moss import moss_memory_insert, moss_memory_search
 
 client = Letta(token="...")
 
+# Deliberately excludes moss_memory_delete — see "Deletion is opt-in" below.
 tool_ids = [
     client.tools.upsert_from_function(func=fn, pip_requirements=["letta-moss"]).id
-    for fn in (moss_memory_insert, moss_memory_search, moss_memory_delete)
+    for fn in (moss_memory_insert, moss_memory_search)
 ]
 
 agent = client.agents.create(
@@ -43,6 +44,16 @@ agent = client.agents.create(
 ```
 
 **Why `pip_requirements`:** Letta's `upsert_from_function` uploads only the extracted source of each function, not the rest of `letta_moss/tools.py` — so `moss_memory_insert`/`_search`/`_delete` each import `_get_memory` (and, for search, `dataclasses`) *inside* their own body rather than relying on this module's top-level imports. Passing `pip_requirements=["letta-moss"]` ensures the sandbox has the package installed so those in-body imports resolve.
+
+**Deletion is opt-in:** `moss_memory_delete` is left out of the default registration above on purpose. Letta's own built-in archival memory has no delete tool either, and giving every conversational agent standing access to erase entries from a shared index is a larger blast radius than most agents need — a prompt-injected or simply mistaken agent could wipe archival memory after a search returns ids. Register it explicitly, and only for agents that are meant to curate memory (e.g. a separate admin/maintenance agent), the same way as the other tools:
+
+```python
+from letta_moss import moss_memory_delete
+
+delete_tool_id = client.tools.upsert_from_function(
+    func=moss_memory_delete, pip_requirements=["letta-moss"]
+).id
+```
 
 ## Quickstart — Option B: MCP server
 

--- a/packages/letta-moss/README.md
+++ b/packages/letta-moss/README.md
@@ -44,7 +44,11 @@ agent = client.agents.create(
 
 ## Quickstart — Option B: MCP server
 
-Runs Moss as an out-of-process MCP server; Letta connects to it as an MCP host, so no Moss code runs inside Letta's own infrastructure.
+Runs Moss as an out-of-process MCP server; Letta connects to it as an MCP host, so no Moss code runs inside Letta's own infrastructure. This option needs an ASGI server, so install the `server` extra:
+
+```bash
+pip install "letta-moss[server]"
+```
 
 ```python
 import uvicorn

--- a/packages/letta-moss/README.md
+++ b/packages/letta-moss/README.md
@@ -74,7 +74,7 @@ Then register the server as an MCP tool source on your Letta agent, pointing at 
 
 | Symbol | Kind | Purpose |
 |---|---|---|
-| `MossLettaMemory(*, project_id=None, project_key=None, index_name, top_k=5, alpha=0.8)` | class | Core adapter; `async load_index()`, `async insert_memory(content, tags=, metadata=) -> str`, `async search_memory(query, top_k=, tags=) -> list[ArchivalMemoryItem]`, `async delete_memory(memory_id)`, `async get_memory(memory_id) -> ArchivalMemoryItem \| None`, `async list_memories(limit=) -> list[ArchivalMemoryItem]`. Falls back to `MOSS_PROJECT_ID`/`MOSS_PROJECT_KEY` env vars when credentials are omitted. |
+| `MossLettaMemory(*, project_id=None, project_key=None, index_name, top_k=5, alpha=0.8, auto_refresh=True, refresh_interval_seconds=60)` | class | Core adapter; `async load_index()`, `async insert_memory(content, tags=, metadata=) -> str`, `async search_memory(query, top_k=, tags=) -> list[ArchivalMemoryItem]`, `async delete_memory(memory_id)`, `async get_memory(memory_id) -> ArchivalMemoryItem \| None`, `async list_memories(limit=) -> list[ArchivalMemoryItem]`. Falls back to `MOSS_PROJECT_ID`/`MOSS_PROJECT_KEY` env vars when credentials are omitted. `auto_refresh`/`refresh_interval_seconds` are forwarded to Moss's `load_index()` so this process's in-memory snapshot picks up writes made by *other* processes against the same index, not just its own. |
 | `moss_memory_insert(content, tags=None) -> str` | async function | Custom-tool wrapper; insert a memory, return its id. |
 | `moss_memory_search(query, top_k=5, tags=None) -> list[dict]` | async function | Custom-tool wrapper; search memories, return dicts. |
 | `moss_memory_delete(memory_id) -> None` | async function | Custom-tool wrapper; delete a memory by id. |
@@ -90,6 +90,8 @@ Then register the server as an MCP tool source on your Letta agent, pointing at 
 **Reserved metadata key:** `insert_memory`'s `metadata` argument must not contain a `"tags"` key — `tags` is a first-class parameter, and passing it inside `metadata` too raises `ValueError` rather than silently overwriting one or the other.
 
 **Env var fallback:** `MossLettaMemory` falls back to `MOSS_PROJECT_ID`/`MOSS_PROJECT_KEY` when constructor args are omitted, unlike some other Moss integrations in this repo (e.g. `agora-moss`) that require explicit args. This is deliberate: these tools typically run inside Letta's sandboxed tool-execution environment, where env vars passed via `tool_exec_environment_variables` are the natural way to configure credentials without hardcoding them in tool source.
+
+**Sandbox process reuse:** the Option A custom tools cache a single `MossLettaMemory` instance at module scope per worker process (so `load_index()` only runs once). That cache is keyed on `MOSS_PROJECT_ID`/`MOSS_PROJECT_KEY`/`MOSS_INDEX_NAME` — if Letta reuses the same worker process for a different agent whose `tool_exec_environment_variables` set different values, the cached instance is discarded and rebuilt against the new values rather than leaking reads/writes across agents.
 
 ## Dependencies
 

--- a/packages/letta-moss/pyproject.toml
+++ b/packages/letta-moss/pyproject.toml
@@ -1,0 +1,51 @@
+[project]
+name = "letta-moss"
+version = "0.0.1"
+description = "Moss-backed archival memory for Letta (MemGPT) agents"
+readme = "README.md"
+license = { text = "BSD-2-Clause" }
+requires-python = ">=3.10,<3.15"
+dependencies = [
+    "moss>=1.1.1",
+    "mcp>=1.2",
+]
+
+[dependency-groups]
+dev = [
+    "ruff>=0.1.0",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23.0",
+    "httpx>=0.27.0",
+    "uvicorn>=0.30.0",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "B", "UP", "D"]
+ignore = ["D100", "D104"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["D101", "D102", "D103", "D107"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+namespaces = false

--- a/packages/letta-moss/pyproject.toml
+++ b/packages/letta-moss/pyproject.toml
@@ -7,7 +7,7 @@ license = { text = "BSD-2-Clause" }
 requires-python = ">=3.10,<3.15"
 dependencies = [
     "moss>=1.1.1",
-    "mcp>=1.2",
+    "mcp>=1.28,<2",
 ]
 
 [project.optional-dependencies]

--- a/packages/letta-moss/pyproject.toml
+++ b/packages/letta-moss/pyproject.toml
@@ -10,6 +10,9 @@ dependencies = [
     "mcp>=1.2",
 ]
 
+[project.optional-dependencies]
+server = ["uvicorn>=0.30.0"]
+
 [dependency-groups]
 dev = [
     "ruff>=0.1.0",

--- a/packages/letta-moss/src/letta_moss/__init__.py
+++ b/packages/letta-moss/src/letta_moss/__init__.py
@@ -1,0 +1,14 @@
+"""Public interface for letta-moss."""
+
+from .mcp_app import create_mcp_app
+from .memory import ArchivalMemoryItem, MossLettaMemory
+from .tools import moss_memory_delete, moss_memory_insert, moss_memory_search
+
+__all__ = [
+    "ArchivalMemoryItem",
+    "MossLettaMemory",
+    "create_mcp_app",
+    "moss_memory_delete",
+    "moss_memory_insert",
+    "moss_memory_search",
+]

--- a/packages/letta-moss/src/letta_moss/mcp_app.py
+++ b/packages/letta-moss/src/letta_moss/mcp_app.py
@@ -45,15 +45,15 @@ def create_mcp_app(memory: MossLettaMemory) -> FastMCP:
         try:
             return await memory.insert_memory(content, tags=tags)
         except Exception as e:
-            raise RuntimeError(f"Moss memory insert failed: {e}") from e
+            raise RuntimeError("Moss memory insert failed") from e
 
     @app.tool(name=tools.moss_memory_search.__name__)
-    async def _search(query: str, top_k: int = 5) -> list[dict]:
+    async def _search(query: str, top_k: int = 5, tags: list[str] | None = None) -> list[dict]:
         """Search Moss-backed archival storage for memories relevant to a query."""
         try:
-            items = await memory.search_memory(query, top_k=top_k)
+            items = await memory.search_memory(query, top_k=top_k, tags=tags)
         except Exception as e:
-            raise RuntimeError(f"Moss memory search failed: {e}") from e
+            raise RuntimeError("Moss memory search failed") from e
         return [dataclasses.asdict(item) for item in items]
 
     @app.tool(name=tools.moss_memory_delete.__name__)
@@ -62,6 +62,6 @@ def create_mcp_app(memory: MossLettaMemory) -> FastMCP:
         try:
             await memory.delete_memory(memory_id)
         except Exception as e:
-            raise RuntimeError(f"Moss memory delete failed: {e}") from e
+            raise RuntimeError("Moss memory delete failed") from e
 
     return app

--- a/packages/letta-moss/src/letta_moss/mcp_app.py
+++ b/packages/letta-moss/src/letta_moss/mcp_app.py
@@ -1,0 +1,67 @@
+"""Moss archival memory exposed as an MCP server for Letta.
+
+Letta can act as an MCP host, connecting to an external MCP server without
+any Moss code running inside Letta's own process. Run this module's app
+behind a reachable URL and register it as an MCP server on the agent, as an
+alternative to the in-sandbox custom tools in ``letta_moss.tools``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from contextlib import asynccontextmanager
+
+from mcp.server.fastmcp import FastMCP
+
+from . import tools
+from .memory import MossLettaMemory
+
+
+def create_mcp_app(memory: MossLettaMemory) -> FastMCP:
+    """Build a FastMCP server exposing Moss archival memory tools.
+
+    The server awaits ``memory.load_index()`` in its lifespan before
+    accepting tool calls. This is the single exception-to-tool-error
+    boundary: adapter methods raise ordinary exceptions, and each tool
+    wrapper here re-raises them as ``RuntimeError`` so FastMCP serializes
+    them as MCP tool-errors.
+
+    Tool names are taken from ``letta_moss.tools``'s function names (via
+    ``@app.tool(name=...)``) rather than hardcoded again here, so this
+    surface and the custom-tool surface in ``letta_moss.tools`` can't
+    silently drift apart if one of them is renamed.
+    """
+
+    @asynccontextmanager
+    async def lifespan(_app: FastMCP):
+        await memory.load_index()
+        yield
+
+    app = FastMCP("letta-moss", lifespan=lifespan)
+
+    @app.tool(name=tools.moss_memory_insert.__name__)
+    async def _insert(content: str, tags: list[str] | None = None) -> str:
+        """Insert a new memory into Moss-backed archival storage."""
+        try:
+            return await memory.insert_memory(content, tags=tags)
+        except Exception as e:
+            raise RuntimeError(f"Moss memory insert failed: {e}") from e
+
+    @app.tool(name=tools.moss_memory_search.__name__)
+    async def _search(query: str, top_k: int = 5) -> list[dict]:
+        """Search Moss-backed archival storage for memories relevant to a query."""
+        try:
+            items = await memory.search_memory(query, top_k=top_k)
+        except Exception as e:
+            raise RuntimeError(f"Moss memory search failed: {e}") from e
+        return [dataclasses.asdict(item) for item in items]
+
+    @app.tool(name=tools.moss_memory_delete.__name__)
+    async def _delete(memory_id: str) -> None:
+        """Delete a memory from Moss-backed archival storage by id."""
+        try:
+            await memory.delete_memory(memory_id)
+        except Exception as e:
+            raise RuntimeError(f"Moss memory delete failed: {e}") from e
+
+    return app

--- a/packages/letta-moss/src/letta_moss/memory.py
+++ b/packages/letta-moss/src/letta_moss/memory.py
@@ -1,0 +1,254 @@
+"""Moss-backed archival memory adapter for Letta (MemGPT) agents.
+
+Letta removed its pluggable storage-backend abstraction for archival memory;
+today's archival memory is hardcoded to Postgres/pgvector, Turbopuffer, or
+Pinecone with no public extension point. This module instead wraps Moss as a
+standalone memory store that Letta agents call through tools (see
+``letta_moss.tools`` and ``letta_moss.mcp_app``), following the pattern
+Letta's own docs recommend for external memory providers.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from moss import (
+    DocumentInfo,
+    GetDocumentsOptions,
+    MossClient,
+    MutationOptions,
+    QueryOptions,
+)
+
+_MOSS_TYPED_PREFIX = "__moss_typed__:"
+
+# When `tags` is set, oversample the Moss-side query by this factor before
+# applying the client-side tag filter, so truncating to `top_k` afterward is
+# less likely to silently drop tag-matching memories that ranked just outside
+# the raw top_k window. Bounded, not a guarantee: Moss has no native way to
+# filter on the tags blob, so a true exhaustive match still isn't possible.
+_TAGS_OVERSAMPLE_FACTOR = 4
+
+
+def _serialize_metadata(meta: dict[str, Any] | None) -> dict[str, str] | None:
+    """Convert arbitrary-typed metadata to Moss string-only metadata.
+
+    Moss only accepts string values in metadata. Non-string values are
+    JSON-encoded and prefixed with ``__moss_typed__:`` so the deserializer
+    can recover the original type. Plain strings are stored as-is, *unless*
+    they already start with the ``__moss_typed__:`` sentinel themselves, in
+    which case they're JSON-encoded too so the deserializer can't mistake a
+    literal string for an encoded value.
+    """
+    if meta is None:
+        return None
+
+    result: dict[str, str] = {}
+    for k, v in meta.items():
+        if isinstance(v, str) and not v.startswith(_MOSS_TYPED_PREFIX):
+            result[k] = v
+        else:
+            result[k] = f"{_MOSS_TYPED_PREFIX}{json.dumps(v)}"
+    return result
+
+
+def _deserialize_metadata(meta: dict[str, str] | None) -> dict[str, Any]:
+    """Convert Moss string metadata back to original types.
+
+    Values prefixed with ``__moss_typed__:`` are JSON-decoded to restore
+    their original type. All other values are returned as plain strings.
+    """
+    if meta is None:
+        return {}
+
+    result: dict[str, Any] = {}
+    for k, v in meta.items():
+        if isinstance(v, str) and v.startswith(_MOSS_TYPED_PREFIX):
+            json_str = v[len(_MOSS_TYPED_PREFIX) :]
+            try:
+                result[k] = json.loads(json_str)
+            except (json.JSONDecodeError, TypeError):
+                result[k] = v
+        else:
+            result[k] = v
+    return result
+
+
+@dataclass
+class ArchivalMemoryItem:
+    """A single archival memory entry.
+
+    ``score`` is only populated on ``search_memory`` results; inserted or
+    fetched-by-id items leave it as ``None``.
+    """
+
+    id: str
+    content: str
+    tags: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    score: float | None = None
+
+
+def _doc_to_item(doc: Any, *, score: float | None = None) -> ArchivalMemoryItem:
+    """Convert a Moss ``DocumentInfo``/``QueryResultDocumentInfo`` to an ``ArchivalMemoryItem``."""
+    full_meta = _deserialize_metadata(getattr(doc, "metadata", None))
+    tags = full_meta.pop("tags", [])
+    return ArchivalMemoryItem(
+        id=doc.id,
+        content=doc.text,
+        tags=tags if isinstance(tags, list) else [],
+        metadata=full_meta,
+        score=score if score is not None else getattr(doc, "score", None),
+    )
+
+
+class MossLettaMemory:
+    """Moss-backed archival memory store for a single Letta agent's index.
+
+    Unlike ``agora_moss.MossAgoraSearch`` (explicit constructor args only),
+    this adapter falls back to ``MOSS_PROJECT_ID``/``MOSS_PROJECT_KEY`` env
+    vars when arguments are omitted. That divergence is deliberate: this
+    package is meant to run as a Letta custom tool inside Letta's sandboxed
+    tool-execution environment, where env vars (passed via
+    ``tool_exec_environment_variables``) are the natural way an agent author
+    configures credentials without hardcoding them in tool source.
+    """
+
+    def __init__(
+        self,
+        *,
+        project_id: str | None = None,
+        project_key: str | None = None,
+        index_name: str,
+        top_k: int = 5,
+        alpha: float = 0.8,
+    ) -> None:
+        """Initialize the adapter with Moss credentials and index-query defaults."""
+        project_id = project_id or os.getenv("MOSS_PROJECT_ID")
+        project_key = project_key or os.getenv("MOSS_PROJECT_KEY")
+        if not project_id or not project_key:
+            raise ValueError(
+                "Moss credentials required. Pass project_id/project_key or set "
+                "MOSS_PROJECT_ID/MOSS_PROJECT_KEY env vars."
+            )
+        self._client = MossClient(project_id=project_id, project_key=project_key)
+        self._index_name = index_name
+        self._top_k = top_k
+        self._alpha = alpha
+        self._index_loaded = False
+        self._index_created = False
+
+    async def load_index(self) -> None:
+        """Preload the configured index for fast local queries. Idempotent.
+
+        If the index doesn't exist yet (no memory has ever been inserted),
+        this is a no-op rather than an error: call it again after the first
+        ``insert_memory()``, or rely on ``search_memory()``'s own internal
+        retry.
+        """
+        if self._index_loaded:
+            return
+        try:
+            await self._client.load_index(self._index_name)
+        except RuntimeError as e:
+            if "not found" not in str(e).lower():
+                raise
+            return
+        self._index_loaded = True
+
+    async def insert_memory(
+        self,
+        content: str,
+        *,
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        """Insert a new archival memory. Returns the generated memory id.
+
+        Creates the backing Moss index on the first insert if it doesn't
+        already exist, matching the pattern in
+        ``examples/cookbook/haystack/moss_haystack.py``'s ``write_documents``.
+        """
+        if metadata and "tags" in metadata:
+            raise ValueError(
+                "metadata must not contain a 'tags' key; pass tags via the tags= "
+                "parameter instead."
+            )
+        memory_id = str(uuid.uuid4())
+        full_meta = {**(metadata or {}), "tags": tags or []}
+        doc = DocumentInfo(id=memory_id, text=content, metadata=_serialize_metadata(full_meta))
+
+        if not self._index_created:
+            try:
+                await self._client.create_index(self._index_name, [doc])
+                self._index_created = True
+                return memory_id
+            except RuntimeError as e:
+                if "already exists" not in str(e).lower():
+                    raise
+                self._index_created = True
+                # Index already exists — fall through to add_docs below.
+
+        await self._client.add_docs(self._index_name, [doc], options=MutationOptions(upsert=True))
+        return memory_id
+
+    async def search_memory(
+        self,
+        query: str,
+        *,
+        top_k: int | None = None,
+        tags: list[str] | None = None,
+    ) -> list[ArchivalMemoryItem]:
+        """Semantically search archival memory.
+
+        Lazily loads the index if it isn't loaded yet (retrying is safe and
+        cheap once memories exist); returns an empty list if the index still
+        doesn't exist (nothing has been inserted).
+
+        ``tags`` is applied as a client-side post-filter (an item is kept if
+        it has any of the given tags), not a Moss-side query filter: tags are
+        JSON-encoded into a single string blob via the metadata scheme above,
+        and Moss's ``QueryOptions.filter`` grammar only supports ``$eq``-style
+        matching against scalar string fields, which can't express "contains
+        tag X" against that blob. When ``tags`` is set, the underlying Moss
+        query oversamples by ``_TAGS_OVERSAMPLE_FACTOR`` before the tag filter
+        runs and the result is truncated back to ``top_k``, so a tag-matching
+        memory ranked just outside the raw top-k window is less likely to be
+        silently dropped — though with no native tag filter, this remains a
+        bounded mitigation, not a guarantee of finding every match.
+        """
+        await self.load_index()
+        if not self._index_loaded:
+            return []
+        resolved_top_k = top_k if top_k is not None else self._top_k
+        query_top_k = resolved_top_k * _TAGS_OVERSAMPLE_FACTOR if tags else resolved_top_k
+        options = QueryOptions(top_k=query_top_k, alpha=self._alpha)
+        result = await self._client.query(self._index_name, query, options=options)
+        items = [_doc_to_item(doc, score=doc.score) for doc in result.docs]
+        if tags:
+            wanted = set(tags)
+            items = [item for item in items if wanted.intersection(item.tags)]
+        return items[:resolved_top_k]
+
+    async def delete_memory(self, memory_id: str) -> None:
+        """Delete an archival memory by id."""
+        await self._client.delete_docs(self._index_name, [memory_id])
+
+    async def get_memory(self, memory_id: str) -> ArchivalMemoryItem | None:
+        """Fetch a single archival memory by id, or ``None`` if it doesn't exist."""
+        docs = await self._client.get_docs(
+            self._index_name, GetDocumentsOptions(doc_ids=[memory_id])
+        )
+        if not docs:
+            return None
+        return _doc_to_item(docs[0])
+
+    async def list_memories(self, limit: int | None = None) -> list[ArchivalMemoryItem]:
+        """List all archival memories in the index, optionally capped at ``limit``."""
+        docs = await self._client.get_docs(self._index_name)
+        items = [_doc_to_item(doc) for doc in docs]
+        return items[:limit] if limit is not None else items

--- a/packages/letta-moss/src/letta_moss/memory.py
+++ b/packages/letta-moss/src/letta_moss/memory.py
@@ -228,7 +228,7 @@ class MossLettaMemory:
         query_top_k = resolved_top_k * _TAGS_OVERSAMPLE_FACTOR if tags else resolved_top_k
         options = QueryOptions(top_k=query_top_k, alpha=self._alpha)
         result = await self._client.query(self._index_name, query, options=options)
-        items = [_doc_to_item(doc, score=doc.score) for doc in result.docs]
+        items = [_doc_to_item(doc) for doc in result.docs]
         if tags:
             wanted = set(tags)
             items = [item for item in items if wanted.intersection(item.tags)]

--- a/packages/letta-moss/src/letta_moss/memory.py
+++ b/packages/letta-moss/src/letta_moss/memory.py
@@ -126,8 +126,20 @@ class MossLettaMemory:
         index_name: str,
         top_k: int = 5,
         alpha: float = 0.8,
+        auto_refresh: bool = True,
+        refresh_interval_seconds: int = 60,
     ) -> None:
-        """Initialize the adapter with Moss credentials and index-query defaults."""
+        """Initialize the adapter with Moss credentials and index-query defaults.
+
+        ``auto_refresh``/``refresh_interval_seconds`` are forwarded to the
+        underlying ``MossClient.load_index()`` call: they make the SDK poll
+        for and pull in changes made by *other* processes writing to the same
+        index (e.g. another sandboxed tool worker, or a script inserting
+        memories directly). This instance's own ``insert_memory``/
+        ``delete_memory`` calls are reflected immediately regardless, via the
+        generation-counter invalidation in ``load_index`` below — auto-refresh
+        only covers the cross-process case that local invalidation can't see.
+        """
         project_id = project_id or os.getenv("MOSS_PROJECT_ID")
         project_key = project_key or os.getenv("MOSS_PROJECT_KEY")
         if not project_id or not project_key:
@@ -139,6 +151,8 @@ class MossLettaMemory:
         self._index_name = index_name
         self._top_k = top_k
         self._alpha = alpha
+        self._auto_refresh = auto_refresh
+        self._refresh_interval_seconds = refresh_interval_seconds
         self._index_loaded = False
         self._index_created = False
         # Bumped by insert_memory/delete_memory. load_index() only marks the
@@ -160,7 +174,11 @@ class MossLettaMemory:
             return
         generation_at_start = self._generation
         try:
-            await self._client.load_index(self._index_name)
+            await self._client.load_index(
+                self._index_name,
+                auto_refresh=self._auto_refresh,
+                polling_interval_in_seconds=self._refresh_interval_seconds,
+            )
         except RuntimeError as e:
             if "not found" not in str(e).lower():
                 raise

--- a/packages/letta-moss/src/letta_moss/memory.py
+++ b/packages/letta-moss/src/letta_moss/memory.py
@@ -141,6 +141,12 @@ class MossLettaMemory:
         self._alpha = alpha
         self._index_loaded = False
         self._index_created = False
+        # Bumped by insert_memory/delete_memory. load_index() only marks the
+        # index loaded if this hasn't changed since the load started, so a
+        # mutation that lands while a load is in flight can't be shadowed by
+        # that load completing afterward and marking a now-stale snapshot as
+        # loaded.
+        self._generation = 0
 
     async def load_index(self) -> None:
         """Preload the configured index for fast local queries. Idempotent.
@@ -152,14 +158,16 @@ class MossLettaMemory:
         """
         if self._index_loaded:
             return
+        generation_at_start = self._generation
         try:
             await self._client.load_index(self._index_name)
         except RuntimeError as e:
             if "not found" not in str(e).lower():
                 raise
             return
-        self._index_loaded = True
         self._index_created = True
+        if generation_at_start == self._generation:
+            self._index_loaded = True
 
     async def insert_memory(
         self,
@@ -176,8 +184,7 @@ class MossLettaMemory:
         """
         if metadata and "tags" in metadata:
             raise ValueError(
-                "metadata must not contain a 'tags' key; pass tags via the tags= "
-                "parameter instead."
+                "metadata must not contain a 'tags' key; pass tags via the tags= parameter instead."
             )
         memory_id = str(uuid.uuid4())
         full_meta = {**(metadata or {}), "tags": tags or []}
@@ -187,6 +194,9 @@ class MossLettaMemory:
             try:
                 await self._client.create_index(self._index_name, [doc])
                 self._index_created = True
+                # A load_index() already in flight fetched a snapshot that predates
+                # this doc; bump the generation so it can't mark itself loaded.
+                self._generation += 1
                 return memory_id
             except RuntimeError as e:
                 if "already exists" not in str(e).lower():
@@ -195,9 +205,12 @@ class MossLettaMemory:
                 # Index already exists — fall through to add_docs below.
 
         await self._client.add_docs(self._index_name, [doc], options=MutationOptions(upsert=True))
-        # A loaded index is a point-in-time query snapshot; invalidate it so the
-        # next search_memory() reloads and can see this newly added memory.
+        # A loaded index is a point-in-time query snapshot; invalidate it (and
+        # bump the generation, so a load_index() already in flight can't mark
+        # this now-stale snapshot as loaded) so the next search_memory() reloads
+        # and can see this newly added memory.
         self._index_loaded = False
+        self._generation += 1
         return memory_id
 
     async def search_memory(
@@ -241,9 +254,12 @@ class MossLettaMemory:
     async def delete_memory(self, memory_id: str) -> None:
         """Delete an archival memory by id."""
         await self._client.delete_docs(self._index_name, [memory_id])
-        # Invalidate the loaded query snapshot so the next search_memory() reloads
-        # and doesn't return an already-deleted memory.
+        # Invalidate the loaded query snapshot (and bump the generation, so a
+        # load_index() already in flight can't mark this now-stale snapshot as
+        # loaded) so the next search_memory() reloads and doesn't return an
+        # already-deleted memory.
         self._index_loaded = False
+        self._generation += 1
 
     async def get_memory(self, memory_id: str) -> ArchivalMemoryItem | None:
         """Fetch a single archival memory by id, or ``None`` if it doesn't exist."""

--- a/packages/letta-moss/src/letta_moss/memory.py
+++ b/packages/letta-moss/src/letta_moss/memory.py
@@ -159,6 +159,7 @@ class MossLettaMemory:
                 raise
             return
         self._index_loaded = True
+        self._index_created = True
 
     async def insert_memory(
         self,
@@ -194,6 +195,9 @@ class MossLettaMemory:
                 # Index already exists — fall through to add_docs below.
 
         await self._client.add_docs(self._index_name, [doc], options=MutationOptions(upsert=True))
+        # A loaded index is a point-in-time query snapshot; invalidate it so the
+        # next search_memory() reloads and can see this newly added memory.
+        self._index_loaded = False
         return memory_id
 
     async def search_memory(
@@ -237,6 +241,9 @@ class MossLettaMemory:
     async def delete_memory(self, memory_id: str) -> None:
         """Delete an archival memory by id."""
         await self._client.delete_docs(self._index_name, [memory_id])
+        # Invalidate the loaded query snapshot so the next search_memory() reloads
+        # and doesn't return an already-deleted memory.
+        self._index_loaded = False
 
     async def get_memory(self, memory_id: str) -> ArchivalMemoryItem | None:
         """Fetch a single archival memory by id, or ``None`` if it doesn't exist."""

--- a/packages/letta-moss/src/letta_moss/memory.py
+++ b/packages/letta-moss/src/letta_moss/memory.py
@@ -182,6 +182,11 @@ class MossLettaMemory:
         except RuntimeError as e:
             if "not found" not in str(e).lower():
                 raise
+            # The index may have been deleted (by another process/user) since
+            # this instance last saw it exist; clear the cached "it exists"
+            # flag so insert_memory() attempts create_index() again instead of
+            # assuming a since-deleted index is still there.
+            self._index_created = False
             return
         self._index_created = True
         if generation_at_start == self._generation:
@@ -222,7 +227,22 @@ class MossLettaMemory:
                 self._index_created = True
                 # Index already exists — fall through to add_docs below.
 
-        await self._client.add_docs(self._index_name, [doc], options=MutationOptions(upsert=True))
+        try:
+            await self._client.add_docs(
+                self._index_name, [doc], options=MutationOptions(upsert=True)
+            )
+        except RuntimeError as e:
+            if "not found" not in str(e).lower():
+                raise
+            # The index existed when we last checked (self._index_created is a
+            # process-local cache) but has since been deleted by another
+            # process/user. Recreate it with this doc and retry once, rather
+            # than failing an insert_memory() call that promises to create a
+            # missing index.
+            self._index_created = False
+            await self._client.create_index(self._index_name, [doc])
+            self._index_created = True
+
         # A loaded index is a point-in-time query snapshot; invalidate it (and
         # bump the generation, so a load_index() already in flight can't mark
         # this now-stale snapshot as loaded) so the next search_memory() reloads

--- a/packages/letta-moss/src/letta_moss/tools.py
+++ b/packages/letta-moss/src/letta_moss/tools.py
@@ -38,7 +38,10 @@ async def _get_memory() -> MossLettaMemory:
         return _memory
     async with _memory_lock:
         if _memory is None:
-            memory = MossLettaMemory(index_name=os.environ["MOSS_INDEX_NAME"])
+            index_name = os.getenv("MOSS_INDEX_NAME")
+            if not index_name:
+                raise ValueError("MOSS_INDEX_NAME env var is required.")
+            memory = MossLettaMemory(index_name=index_name)
             await memory.load_index()
             _memory = memory
     return _memory
@@ -59,19 +62,23 @@ async def moss_memory_insert(content: str, tags: list[str] | None = None) -> str
     return await memory.insert_memory(content, tags=tags)
 
 
-async def moss_memory_search(query: str, top_k: int = 5) -> list[dict]:
+async def moss_memory_search(
+    query: str, top_k: int = 5, tags: list[str] | None = None
+) -> list[dict]:
     """Search Moss-backed archival storage for memories relevant to a query.
 
     Args:
         query: Natural-language query to search for.
         top_k: Maximum number of results to return.
+        tags: Optional list of tags to narrow results to — a memory is kept
+            if it has any of the given tags.
 
     Returns:
         A list of matching memories, each with ``id``, ``content``, ``tags``,
         ``metadata``, and ``score`` fields.
     """
     memory = await _get_memory()
-    items = await memory.search_memory(query, top_k=top_k)
+    items = await memory.search_memory(query, top_k=top_k, tags=tags)
     return [dataclasses.asdict(item) for item in items]
 
 

--- a/packages/letta-moss/src/letta_moss/tools.py
+++ b/packages/letta-moss/src/letta_moss/tools.py
@@ -1,0 +1,86 @@
+"""Plain-function tools for registering Moss archival memory with a Letta agent.
+
+Register these directly with ``client.tools.upsert_from_function(func=...)``
+so they run inside Letta's own sandboxed tool-execution environment — no
+separate server process required. Configure them via the
+``MOSS_PROJECT_ID`` / ``MOSS_PROJECT_KEY`` / ``MOSS_INDEX_NAME`` environment
+variables (Letta injects whatever you pass through
+``tool_exec_environment_variables`` at agent-creation time).
+
+These functions are named ``moss_memory_*``, deliberately distinct from
+Letta's built-in ``archival_memory_insert``/``archival_memory_search`` tools.
+Pass ``include_base_tools=False`` when creating the agent so it doesn't end
+up with two competing memory tool sets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import os
+
+from .memory import MossLettaMemory
+
+_memory: MossLettaMemory | None = None
+_memory_lock = asyncio.Lock()
+
+
+async def _get_memory() -> MossLettaMemory:
+    """Lazily build and load the module-level ``MossLettaMemory`` singleton.
+
+    A single instance is reused across tool calls within a sandbox process so
+    ``load_index()`` (and the underlying index download) only happens once.
+    Guarded by a lock so concurrent tool calls can't each construct and load
+    their own instance before the first one is stored.
+    """
+    global _memory
+    if _memory is not None:
+        return _memory
+    async with _memory_lock:
+        if _memory is None:
+            memory = MossLettaMemory(index_name=os.environ["MOSS_INDEX_NAME"])
+            await memory.load_index()
+            _memory = memory
+    return _memory
+
+
+async def moss_memory_insert(content: str, tags: list[str] | None = None) -> str:
+    """Insert a new memory into Moss-backed archival storage.
+
+    Args:
+        content: The text content of the memory to store.
+        tags: Optional list of tags to associate with the memory, usable
+            later to narrow ``moss_memory_search`` results.
+
+    Returns:
+        The id of the newly inserted memory.
+    """
+    memory = await _get_memory()
+    return await memory.insert_memory(content, tags=tags)
+
+
+async def moss_memory_search(query: str, top_k: int = 5) -> list[dict]:
+    """Search Moss-backed archival storage for memories relevant to a query.
+
+    Args:
+        query: Natural-language query to search for.
+        top_k: Maximum number of results to return.
+
+    Returns:
+        A list of matching memories, each with ``id``, ``content``, ``tags``,
+        ``metadata``, and ``score`` fields.
+    """
+    memory = await _get_memory()
+    items = await memory.search_memory(query, top_k=top_k)
+    return [dataclasses.asdict(item) for item in items]
+
+
+async def moss_memory_delete(memory_id: str) -> None:
+    """Delete a memory from Moss-backed archival storage by id.
+
+    Args:
+        memory_id: The id of the memory to delete, as returned by
+            ``moss_memory_insert`` or ``moss_memory_search``.
+    """
+    memory = await _get_memory()
+    await memory.delete_memory(memory_id)

--- a/packages/letta-moss/src/letta_moss/tools.py
+++ b/packages/letta-moss/src/letta_moss/tools.py
@@ -21,28 +21,42 @@ import os
 from .memory import MossLettaMemory
 
 _memory: MossLettaMemory | None = None
+_memory_key: tuple[str | None, str | None, str] | None = None
 _memory_lock = asyncio.Lock()
+
+
+def _current_memory_key() -> tuple[str | None, str | None, str]:
+    """Read the env vars that identify which Moss index/credentials to use."""
+    index_name = os.getenv("MOSS_INDEX_NAME")
+    if not index_name:
+        raise ValueError("MOSS_INDEX_NAME env var is required.")
+    return (os.getenv("MOSS_PROJECT_ID"), os.getenv("MOSS_PROJECT_KEY"), index_name)
 
 
 async def _get_memory() -> MossLettaMemory:
     """Lazily build and load the module-level ``MossLettaMemory`` singleton.
 
     A single instance is reused across tool calls within a sandbox process so
-    ``load_index()`` (and the underlying index download) only happens once.
-    Guarded by a lock so concurrent tool calls can't each construct and load
-    their own instance before the first one is stored.
+    ``load_index()`` (and the underlying index download) only happens once —
+    but only for as long as ``MOSS_PROJECT_ID``/``MOSS_PROJECT_KEY``/
+    ``MOSS_INDEX_NAME`` keep resolving to the same values. If a worker process
+    gets reused for a different agent/config (a different set of
+    ``tool_exec_environment_variables``), the cached instance is discarded and
+    rebuilt against the new env vars instead of silently leaking reads/writes
+    to the previous agent's index. Guarded by a lock so concurrent tool calls
+    can't each construct and load their own instance before the first one is
+    stored.
     """
-    global _memory
-    if _memory is not None:
+    global _memory, _memory_key
+    key = _current_memory_key()
+    if _memory is not None and _memory_key == key:
         return _memory
     async with _memory_lock:
-        if _memory is None:
-            index_name = os.getenv("MOSS_INDEX_NAME")
-            if not index_name:
-                raise ValueError("MOSS_INDEX_NAME env var is required.")
-            memory = MossLettaMemory(index_name=index_name)
+        if _memory is None or _memory_key != key:
+            memory = MossLettaMemory(index_name=key[2])
             await memory.load_index()
             _memory = memory
+            _memory_key = key
     return _memory
 
 

--- a/packages/letta-moss/src/letta_moss/tools.py
+++ b/packages/letta-moss/src/letta_moss/tools.py
@@ -16,7 +16,6 @@ up with two competing memory tool sets.
 from __future__ import annotations
 
 import asyncio
-import dataclasses
 import os
 
 from .memory import MossLettaMemory
@@ -58,6 +57,8 @@ async def moss_memory_insert(content: str, tags: list[str] | None = None) -> str
     Returns:
         The id of the newly inserted memory.
     """
+    from letta_moss.tools import _get_memory
+
     memory = await _get_memory()
     return await memory.insert_memory(content, tags=tags)
 
@@ -77,6 +78,10 @@ async def moss_memory_search(
         A list of matching memories, each with ``id``, ``content``, ``tags``,
         ``metadata``, and ``score`` fields.
     """
+    import dataclasses
+
+    from letta_moss.tools import _get_memory
+
     memory = await _get_memory()
     items = await memory.search_memory(query, top_k=top_k, tags=tags)
     return [dataclasses.asdict(item) for item in items]
@@ -89,5 +94,7 @@ async def moss_memory_delete(memory_id: str) -> None:
         memory_id: The id of the memory to delete, as returned by
             ``moss_memory_insert`` or ``moss_memory_search``.
     """
+    from letta_moss.tools import _get_memory
+
     memory = await _get_memory()
     await memory.delete_memory(memory_id)

--- a/packages/letta-moss/tests/test_mcp_app.py
+++ b/packages/letta-moss/tests/test_mcp_app.py
@@ -15,7 +15,7 @@ class FakeMemory:
     async def insert_memory(self, content, *, tags=None):
         return "generated-id"
 
-    async def search_memory(self, query, *, top_k=5):
+    async def search_memory(self, query, *, top_k=5, tags=None):
         from letta_moss.memory import ArchivalMemoryItem
 
         return [ArchivalMemoryItem(id="1", content="hit", tags=[], metadata={}, score=0.9)]

--- a/packages/letta-moss/tests/test_mcp_app.py
+++ b/packages/letta-moss/tests/test_mcp_app.py
@@ -1,0 +1,197 @@
+"""Unit tests for the MCP server app."""
+
+import os
+
+import pytest
+
+
+class FakeMemory:
+    def __init__(self):
+        self.load_index_calls = 0
+
+    async def load_index(self):
+        self.load_index_calls += 1
+
+    async def insert_memory(self, content, *, tags=None):
+        return "generated-id"
+
+    async def search_memory(self, query, *, top_k=5):
+        from letta_moss.memory import ArchivalMemoryItem
+
+        return [ArchivalMemoryItem(id="1", content="hit", tags=[], metadata={}, score=0.9)]
+
+    async def delete_memory(self, memory_id):
+        pass
+
+
+class TestCreateMcpApp:
+    def test_returns_fastmcp_with_expected_tools(self):
+        import asyncio
+
+        from mcp.server.fastmcp import FastMCP
+
+        from letta_moss.mcp_app import create_mcp_app
+
+        app = create_mcp_app(FakeMemory())
+        assert isinstance(app, FastMCP)
+
+        tools = asyncio.run(app.list_tools())
+        names = {t.name for t in tools}
+        assert names == {"moss_memory_insert", "moss_memory_search", "moss_memory_delete"}
+
+
+class TestMcpToolBehavior:
+    async def test_insert_tool_delegates(self):
+        from letta_moss.mcp_app import create_mcp_app
+
+        memory = FakeMemory()
+        app = create_mcp_app(memory)
+        fn = app._tool_manager.get_tool("moss_memory_insert").fn
+        result = await fn(content="hello", tags=["a"])
+        assert result == "generated-id"
+
+    async def test_search_tool_returns_dicts(self):
+        from letta_moss.mcp_app import create_mcp_app
+
+        app = create_mcp_app(FakeMemory())
+        fn = app._tool_manager.get_tool("moss_memory_search").fn
+        result = await fn(query="q", top_k=5)
+        assert result == [{"id": "1", "content": "hit", "tags": [], "metadata": {}, "score": 0.9}]
+
+
+class TestMcpErrorMapping:
+    async def test_insert_exception_is_raised_as_runtime_error(self):
+        from letta_moss.mcp_app import create_mcp_app
+
+        memory = FakeMemory()
+
+        async def broken_insert(content, *, tags=None):
+            raise ValueError("moss blew up")
+
+        memory.insert_memory = broken_insert
+        app = create_mcp_app(memory)
+        fn = app._tool_manager.get_tool("moss_memory_insert").fn
+
+        with pytest.raises(RuntimeError, match="Moss memory insert failed"):
+            await fn(content="x")
+
+    async def test_search_exception_is_raised_as_runtime_error(self):
+        from letta_moss.mcp_app import create_mcp_app
+
+        memory = FakeMemory()
+
+        async def broken_search(query, *, top_k=5):
+            raise ValueError("moss blew up")
+
+        memory.search_memory = broken_search
+        app = create_mcp_app(memory)
+        fn = app._tool_manager.get_tool("moss_memory_search").fn
+
+        with pytest.raises(RuntimeError, match="Moss memory search failed"):
+            await fn(query="x")
+
+    async def test_delete_exception_is_raised_as_runtime_error(self):
+        from letta_moss.mcp_app import create_mcp_app
+
+        memory = FakeMemory()
+
+        async def broken_delete(memory_id):
+            raise ValueError("moss blew up")
+
+        memory.delete_memory = broken_delete
+        app = create_mcp_app(memory)
+        fn = app._tool_manager.get_tool("moss_memory_delete").fn
+
+        with pytest.raises(RuntimeError, match="Moss memory delete failed"):
+            await fn(memory_id="1")
+
+
+_HAS_MOSS_CREDS = bool(os.environ.get("MOSS_PROJECT_ID")) and bool(
+    os.environ.get("MOSS_PROJECT_KEY")
+)
+_MOSS_INDEX = os.environ.get("MOSS_INDEX_NAME", "letta-moss-test")
+
+
+@pytest.mark.skipif(
+    not _HAS_MOSS_CREDS, reason="requires MOSS_PROJECT_ID + MOSS_PROJECT_KEY env vars"
+)
+class TestMcpRoundtrip:
+    async def test_insert_then_search_then_delete(self):
+        """Spin up the FastMCP streamable-HTTP app and round-trip a memory.
+
+        Uses the index named ``MOSS_INDEX_NAME`` (created automatically by
+        the first insert if it doesn't already exist).
+        """
+        import asyncio
+        import socket
+        from contextlib import asynccontextmanager
+
+        import httpx
+        import uvicorn
+        from mcp.client.session import ClientSession
+        from mcp.client.streamable_http import streamablehttp_client
+
+        from letta_moss import MossLettaMemory, create_mcp_app
+
+        def free_port() -> int:
+            with socket.socket() as s:
+                s.bind(("127.0.0.1", 0))
+                return s.getsockname()[1]
+
+        port = free_port()
+        memory = MossLettaMemory(
+            project_id=os.environ["MOSS_PROJECT_ID"],
+            project_key=os.environ["MOSS_PROJECT_KEY"],
+            index_name=_MOSS_INDEX,
+        )
+        app = create_mcp_app(memory)
+
+        config = uvicorn.Config(
+            app.streamable_http_app(), host="127.0.0.1", port=port, log_level="warning"
+        )
+        server = uvicorn.Server(config)
+
+        @asynccontextmanager
+        async def running_server():
+            task = asyncio.create_task(server.serve())
+            for _ in range(50):
+                try:
+                    async with httpx.AsyncClient() as http:
+                        r = await http.get(f"http://127.0.0.1:{port}/mcp", timeout=0.2)
+                        if r.status_code < 500:
+                            break
+                except (httpx.ConnectError, httpx.ReadTimeout):
+                    await asyncio.sleep(0.1)
+            try:
+                yield
+            finally:
+                server.should_exit = True
+                await task
+
+        async with running_server():
+            async with streamablehttp_client(f"http://127.0.0.1:{port}/mcp") as (read, write, _):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    tool_names = [t.name for t in (await session.list_tools()).tools]
+                    expected = {"moss_memory_insert", "moss_memory_search", "moss_memory_delete"}
+                    assert expected <= set(tool_names)
+
+                    insert_result = await session.call_tool(
+                        "moss_memory_insert",
+                        arguments={
+                            "content": "The user's favorite color is teal.",
+                            "tags": ["preference"],
+                        },
+                    )
+                    assert not insert_result.isError
+                    memory_id = insert_result.content[0].text.strip('"')
+
+                    search_result = await session.call_tool(
+                        "moss_memory_search", arguments={"query": "favorite color"}
+                    )
+                    assert not search_result.isError
+
+                    delete_result = await session.call_tool(
+                        "moss_memory_delete", arguments={"memory_id": memory_id}
+                    )
+                    assert not delete_result.isError

--- a/packages/letta-moss/tests/test_memory.py
+++ b/packages/letta-moss/tests/test_memory.py
@@ -1,0 +1,434 @@
+"""Unit tests for MossLettaMemory."""
+
+import pytest
+
+
+class FakeQueryResultDoc:
+    def __init__(self, id, text, metadata=None, score=None):
+        self.id = id
+        self.text = text
+        self.metadata = metadata
+        self.score = score
+
+
+class FakeQueryResult:
+    def __init__(self, docs):
+        self.docs = docs
+
+
+class FakeClient:
+    def __init__(self, *, project_id=None, project_key=None):
+        self.project_id = project_id
+        self.project_key = project_key
+        self.create_index_calls = []
+        self.add_docs_calls = []
+        self.delete_docs_calls = []
+        self.get_docs_calls = []
+        self.query_calls = []
+        self._get_docs_return = []
+        self._query_return = FakeQueryResult(docs=[])
+        self._create_index_error = None
+        self._load_index_error = None
+
+    async def load_index(self, index_name):
+        if self._load_index_error is not None:
+            raise self._load_index_error
+
+    async def create_index(self, name, docs, model_id=None):
+        self.create_index_calls.append((name, docs, model_id))
+        if self._create_index_error is not None:
+            raise self._create_index_error
+
+    async def add_docs(self, name, docs, options=None):
+        self.add_docs_calls.append((name, docs, options))
+
+    async def delete_docs(self, name, doc_ids):
+        self.delete_docs_calls.append((name, doc_ids))
+
+    async def get_docs(self, name, options=None):
+        self.get_docs_calls.append((name, options))
+        return self._get_docs_return
+
+    async def query(self, name, query, *, options=None):
+        self.query_calls.append((name, query, options))
+        return self._query_return
+
+
+class TestConstructor:
+    def test_uses_explicit_args(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        assert m._client.project_id == "p"
+        assert m._client.project_key == "k"
+        assert m._index_name == "idx"
+        assert m._index_loaded is False
+
+    def test_falls_back_to_env_vars(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        monkeypatch.setenv("MOSS_PROJECT_ID", "env-p")
+        monkeypatch.setenv("MOSS_PROJECT_KEY", "env-k")
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(index_name="idx")
+        assert m._client.project_id == "env-p"
+        assert m._client.project_key == "env-k"
+
+    def test_raises_without_credentials(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        monkeypatch.delenv("MOSS_PROJECT_ID", raising=False)
+        monkeypatch.delenv("MOSS_PROJECT_KEY", raising=False)
+        from letta_moss.memory import MossLettaMemory
+
+        with pytest.raises(ValueError, match="Moss credentials required"):
+            MossLettaMemory(index_name="idx")
+
+
+class TestLoadIndex:
+    async def test_delegates_and_marks_loaded(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        assert m._index_loaded is False
+        await m.load_index()
+        assert m._index_loaded is True
+
+    async def test_is_idempotent(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        load_calls = []
+
+        class TrackingClient(FakeClient):
+            async def load_index(self, index_name):
+                load_calls.append(index_name)
+
+        monkeypatch.setattr(memory_mod, "MossClient", TrackingClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        await m.load_index()
+        await m.load_index()
+        assert load_calls == ["idx"]
+
+    async def test_swallows_index_not_found(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        m._client._load_index_error = RuntimeError("Failed to load index 'idx': index not found")
+
+        await m.load_index()  # must not raise
+        assert m._index_loaded is False
+
+    async def test_reraises_other_errors(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        m._client._load_index_error = RuntimeError("unauthorized")
+
+        with pytest.raises(RuntimeError, match="unauthorized"):
+            await m.load_index()
+
+
+class TestInsertMemory:
+    async def test_creates_index_on_first_insert(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        memory_id = await m.insert_memory("hello world", tags=["a", "b"], metadata={"n": 1})
+
+        assert isinstance(memory_id, str) and len(memory_id) > 0
+        assert m._client.add_docs_calls == []
+        [(name, docs, _model_id)] = m._client.create_index_calls
+        assert name == "idx"
+        [doc] = docs
+        assert doc.id == memory_id
+        assert doc.text == "hello world"
+        # Non-string metadata values are JSON-encoded with the typed prefix.
+        assert doc.metadata["n"] == '__moss_typed__:1'
+        assert doc.metadata["tags"] == '__moss_typed__:["a", "b"]'
+        assert m._index_created is True
+
+    async def test_falls_through_to_add_docs_if_index_already_exists(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        m._client._create_index_error = RuntimeError("index 'idx' already exists")
+
+        memory_id = await m.insert_memory("hello world")
+
+        assert len(m._client.create_index_calls) == 1
+        [(name, docs, options)] = m._client.add_docs_calls
+        assert name == "idx"
+        assert options.upsert is True
+        [doc] = docs
+        assert doc.id == memory_id
+        assert m._index_created is True
+
+    async def test_second_insert_skips_create_index(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        await m.insert_memory("first")
+        await m.insert_memory("second")
+
+        assert len(m._client.create_index_calls) == 1
+        assert len(m._client.add_docs_calls) == 1
+
+    async def test_raises_on_other_create_index_errors(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        m._client._create_index_error = RuntimeError("unauthorized")
+
+        with pytest.raises(RuntimeError, match="unauthorized"):
+            await m.insert_memory("hello world")
+
+    async def test_rejects_metadata_with_reserved_tags_key(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        with pytest.raises(ValueError, match="'tags' key"):
+            await m.insert_memory("hello", metadata={"tags": "should not be allowed"})
+
+
+class TestSearchMemory:
+    async def test_returns_empty_list_if_index_does_not_exist_yet(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        m._client._load_index_error = RuntimeError("index not found")
+
+        assert await m.search_memory("q") == []
+        assert m._client.query_calls == []
+
+    async def test_lazily_loads_index_before_querying(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        assert m._index_loaded is False
+        await m.search_memory("q")
+        assert m._index_loaded is True
+
+    async def test_delegates_and_decodes_metadata(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx", top_k=3, alpha=0.5)
+        await m.load_index()
+        m._client._query_return = FakeQueryResult(
+            docs=[
+                FakeQueryResultDoc(
+                    id="1",
+                    text="hit",
+                    metadata={"tags": '__moss_typed__:["x"]', "note": "plain"},
+                    score=0.9,
+                )
+            ]
+        )
+
+        results = await m.search_memory("what is moss")
+
+        [(name, query, options)] = m._client.query_calls
+        assert name == "idx"
+        assert query == "what is moss"
+        # No tags filter requested, so top_k is passed through unscaled.
+        assert options.top_k == 3
+        assert options.alpha == 0.5
+
+        [item] = results
+        assert item.id == "1"
+        assert item.content == "hit"
+        assert item.tags == ["x"]
+        assert item.metadata == {"note": "plain"}
+        assert item.score == 0.9
+
+    async def test_tags_post_filter(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        await m.load_index()
+        m._client._query_return = FakeQueryResult(
+            docs=[
+                FakeQueryResultDoc(id="1", text="a", metadata={"tags": '__moss_typed__:["x"]'}),
+                FakeQueryResultDoc(id="2", text="b", metadata={"tags": '__moss_typed__:["y"]'}),
+            ]
+        )
+
+        results = await m.search_memory("q", tags=["y"])
+        assert [r.id for r in results] == ["2"]
+
+    async def test_oversamples_top_k_when_tags_given(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        await m.load_index()
+
+        await m.search_memory("q", top_k=5, tags=["y"])
+
+        [(_name, _query, options)] = m._client.query_calls
+        assert options.top_k == 5 * memory_mod._TAGS_OVERSAMPLE_FACTOR
+
+    async def test_truncates_to_requested_top_k_after_tag_filter(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        await m.load_index()
+        m._client._query_return = FakeQueryResult(
+            docs=[
+                FakeQueryResultDoc(id=str(i), text="x", metadata={"tags": '__moss_typed__:["y"]'})
+                for i in range(10)
+            ]
+        )
+
+        results = await m.search_memory("q", top_k=2, tags=["y"])
+        assert len(results) == 2
+
+
+class TestDeleteMemory:
+    async def test_delegates_to_delete_docs(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        await m.delete_memory("mem-1")
+        assert m._client.delete_docs_calls == [("idx", ["mem-1"])]
+
+
+class TestGetMemory:
+    async def test_returns_item_when_found(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        m._client._get_docs_return = [FakeQueryResultDoc(id="1", text="hi", metadata=None)]
+
+        item = await m.get_memory("1")
+        assert item is not None
+        assert item.id == "1"
+        [(name, options)] = m._client.get_docs_calls
+        assert name == "idx"
+        assert options.doc_ids == ["1"]
+
+    async def test_returns_none_when_not_found(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        m._client._get_docs_return = []
+
+        assert await m.get_memory("missing") is None
+
+
+class TestListMemories:
+    async def test_lists_all_docs_with_no_options(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        m._client._get_docs_return = [
+            FakeQueryResultDoc(id="1", text="a"),
+            FakeQueryResultDoc(id="2", text="b"),
+        ]
+
+        items = await m.list_memories()
+        assert [i.id for i in items] == ["1", "2"]
+        [(name, options)] = m._client.get_docs_calls
+        assert name == "idx"
+        assert options is None
+
+    async def test_applies_limit(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        m._client._get_docs_return = [
+            FakeQueryResultDoc(id="1", text="a"),
+            FakeQueryResultDoc(id="2", text="b"),
+        ]
+
+        items = await m.list_memories(limit=1)
+        assert [i.id for i in items] == ["1"]
+
+
+class TestMetadataRoundTrip:
+    def test_serialize_then_deserialize_restores_original(self):
+        from letta_moss.memory import _deserialize_metadata, _serialize_metadata
+
+        original = {"note": "plain string", "count": 3, "tags": ["a", "b"], "nested": {"x": 1}}
+        serialized = _serialize_metadata(original)
+        assert all(isinstance(v, str) for v in serialized.values())
+        assert _deserialize_metadata(serialized) == original
+
+    def test_handles_none(self):
+        from letta_moss.memory import _deserialize_metadata, _serialize_metadata
+
+        assert _serialize_metadata(None) is None
+        assert _deserialize_metadata(None) == {}
+
+    def test_escapes_plain_string_colliding_with_sentinel_prefix(self):
+        from letta_moss.memory import _deserialize_metadata, _serialize_metadata
+
+        original = {"label": '__moss_typed__:42', "note": '__moss_typed__:"quoted"'}
+        serialized = _serialize_metadata(original)
+        # The stored value must not be the bare original string, or it would
+        # be mistaken for a genuinely-encoded value on read-back.
+        assert serialized["label"] != original["label"]
+        assert _deserialize_metadata(serialized) == original

--- a/packages/letta-moss/tests/test_memory.py
+++ b/packages/letta-moss/tests/test_memory.py
@@ -29,8 +29,10 @@ class FakeClient:
         self._query_return = FakeQueryResult(docs=[])
         self._create_index_error = None
         self._load_index_error = None
+        self.load_index_calls = []
 
-    async def load_index(self, index_name):
+    async def load_index(self, index_name, auto_refresh=False, polling_interval_in_seconds=600):
+        self.load_index_calls.append((index_name, auto_refresh, polling_interval_in_seconds))
         if self._load_index_error is not None:
             raise self._load_index_error
 
@@ -103,6 +105,22 @@ class TestLoadIndex:
         await m.load_index()
         assert m._index_loaded is True
 
+    async def test_forwards_auto_refresh_settings_to_client(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(
+            project_id="p",
+            project_key="k",
+            index_name="idx",
+            auto_refresh=True,
+            refresh_interval_seconds=45,
+        )
+        await m.load_index()
+        assert m._client.load_index_calls == [("idx", True, 45)]
+
     async def test_marks_index_created_on_successful_load(self, monkeypatch):
         import letta_moss.memory as memory_mod
 
@@ -120,7 +138,9 @@ class TestLoadIndex:
         load_calls = []
 
         class TrackingClient(FakeClient):
-            async def load_index(self, index_name):
+            async def load_index(
+                self, index_name, auto_refresh=False, polling_interval_in_seconds=600
+            ):
                 load_calls.append(index_name)
 
         monkeypatch.setattr(memory_mod, "MossClient", TrackingClient)
@@ -164,9 +184,11 @@ class TestLoadIndex:
         release_load = asyncio.Event()
 
         class SlowClient(FakeClient):
-            async def load_index(self, index_name):
+            async def load_index(
+                self, index_name, auto_refresh=False, polling_interval_in_seconds=600
+            ):
                 await release_load.wait()
-                await super().load_index(index_name)
+                await super().load_index(index_name, auto_refresh, polling_interval_in_seconds)
 
         monkeypatch.setattr(memory_mod, "MossClient", SlowClient)
         from letta_moss.memory import MossLettaMemory

--- a/packages/letta-moss/tests/test_memory.py
+++ b/packages/letta-moss/tests/test_memory.py
@@ -103,6 +103,17 @@ class TestLoadIndex:
         await m.load_index()
         assert m._index_loaded is True
 
+    async def test_marks_index_created_on_successful_load(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        assert m._index_created is False
+        await m.load_index()
+        assert m._index_created is True
+
     async def test_is_idempotent(self, monkeypatch):
         import letta_moss.memory as memory_mod
 
@@ -185,6 +196,20 @@ class TestInsertMemory:
         [doc] = docs
         assert doc.id == memory_id
         assert m._index_created is True
+
+    async def test_add_docs_invalidates_loaded_index(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        await m.load_index()
+        assert m._index_loaded is True
+
+        await m.insert_memory("hello world")
+
+        assert m._index_loaded is False
 
     async def test_second_insert_skips_create_index(self, monkeypatch):
         import letta_moss.memory as memory_mod
@@ -342,6 +367,20 @@ class TestDeleteMemory:
         m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
         await m.delete_memory("mem-1")
         assert m._client.delete_docs_calls == [("idx", ["mem-1"])]
+
+    async def test_invalidates_loaded_index(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        await m.load_index()
+        assert m._index_loaded is True
+
+        await m.delete_memory("mem-1")
+
+        assert m._index_loaded is False
 
 
 class TestGetMemory:

--- a/packages/letta-moss/tests/test_memory.py
+++ b/packages/letta-moss/tests/test_memory.py
@@ -155,6 +155,37 @@ class TestLoadIndex:
         with pytest.raises(RuntimeError, match="unauthorized"):
             await m.load_index()
 
+    async def test_mutation_during_load_prevents_stale_loaded_flag(self, monkeypatch):
+        """A load in flight during a mutation must not mark a stale snapshot loaded."""
+        import asyncio
+
+        import letta_moss.memory as memory_mod
+
+        release_load = asyncio.Event()
+
+        class SlowClient(FakeClient):
+            async def load_index(self, index_name):
+                await release_load.wait()
+                await super().load_index(index_name)
+
+        monkeypatch.setattr(memory_mod, "MossClient", SlowClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+
+        load_task = asyncio.create_task(m.load_index())
+        await asyncio.sleep(0)  # let load_index() capture generation_at_start and block
+
+        await m.insert_memory("mutated while load was in flight")
+        assert m._index_loaded is False
+
+        release_load.set()
+        await load_task
+
+        # The load that was already in flight must not mark this stale snapshot loaded.
+        assert m._index_loaded is False
+        assert m._index_created is True
+
 
 class TestInsertMemory:
     async def test_creates_index_on_first_insert(self, monkeypatch):
@@ -174,7 +205,7 @@ class TestInsertMemory:
         assert doc.id == memory_id
         assert doc.text == "hello world"
         # Non-string metadata values are JSON-encoded with the typed prefix.
-        assert doc.metadata["n"] == '__moss_typed__:1'
+        assert doc.metadata["n"] == "__moss_typed__:1"
         assert doc.metadata["tags"] == '__moss_typed__:["a", "b"]'
         assert m._index_created is True
 
@@ -465,7 +496,7 @@ class TestMetadataRoundTrip:
     def test_escapes_plain_string_colliding_with_sentinel_prefix(self):
         from letta_moss.memory import _deserialize_metadata, _serialize_metadata
 
-        original = {"label": '__moss_typed__:42', "note": '__moss_typed__:"quoted"'}
+        original = {"label": "__moss_typed__:42", "note": '__moss_typed__:"quoted"'}
         serialized = _serialize_metadata(original)
         # The stored value must not be the bare original string, or it would
         # be mistaken for a genuinely-encoded value on read-back.

--- a/packages/letta-moss/tests/test_memory.py
+++ b/packages/letta-moss/tests/test_memory.py
@@ -29,6 +29,7 @@ class FakeClient:
         self._query_return = FakeQueryResult(docs=[])
         self._create_index_error = None
         self._load_index_error = None
+        self._add_docs_error = None
         self.load_index_calls = []
 
     async def load_index(self, index_name, auto_refresh=False, polling_interval_in_seconds=600):
@@ -43,6 +44,8 @@ class FakeClient:
 
     async def add_docs(self, name, docs, options=None):
         self.add_docs_calls.append((name, docs, options))
+        if self._add_docs_error is not None:
+            raise self._add_docs_error
 
     async def delete_docs(self, name, doc_ids):
         self.delete_docs_calls.append((name, doc_ids))
@@ -163,6 +166,21 @@ class TestLoadIndex:
         await m.load_index()  # must not raise
         assert m._index_loaded is False
 
+    async def test_clears_stale_index_created_flag_when_index_not_found(self, monkeypatch):
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        # Simulate a previous successful load/create having cached "it exists".
+        m._index_created = True
+        m._client._load_index_error = RuntimeError("index not found")
+
+        await m.load_index()
+
+        assert m._index_created is False
+
     async def test_reraises_other_errors(self, monkeypatch):
         import letta_moss.memory as memory_mod
 
@@ -246,6 +264,32 @@ class TestInsertMemory:
         [(name, docs, options)] = m._client.add_docs_calls
         assert name == "idx"
         assert options.upsert is True
+        [doc] = docs
+        assert doc.id == memory_id
+        assert m._index_created is True
+
+    async def test_recreates_index_if_deleted_externally_before_add_docs(self, monkeypatch):
+        """A stale ``_index_created`` should trigger a create_index() retry, not an error.
+
+        Simulates the index having been deleted by another process/user after
+        this instance last confirmed it existed: add_docs() fails with "not
+        found", which should trigger a one-shot create_index() retry rather
+        than propagating the error.
+        """
+        import letta_moss.memory as memory_mod
+
+        monkeypatch.setattr(memory_mod, "MossClient", FakeClient)
+        from letta_moss.memory import MossLettaMemory
+
+        m = MossLettaMemory(project_id="p", project_key="k", index_name="idx")
+        m._index_created = True  # process-local cache, now stale
+        m._client._add_docs_error = RuntimeError("index 'idx' not found")
+
+        memory_id = await m.insert_memory("hello world")
+
+        assert len(m._client.add_docs_calls) == 1
+        [(name, docs, _model_id)] = m._client.create_index_calls
+        assert name == "idx"
         [doc] = docs
         assert doc.id == memory_id
         assert m._index_created is True

--- a/packages/letta-moss/tests/test_tools.py
+++ b/packages/letta-moss/tests/test_tools.py
@@ -1,0 +1,99 @@
+"""Unit tests for the plain-function custom tools."""
+
+import asyncio
+import dataclasses
+
+import pytest
+
+
+class FakeMemory:
+    instances = []
+
+    def __init__(self, *, index_name):
+        self.index_name = index_name
+        self.load_index_calls = 0
+        self.insert_calls = []
+        self.search_calls = []
+        self.delete_calls = []
+        FakeMemory.instances.append(self)
+
+    async def load_index(self):
+        # Yield control so concurrent _get_memory() callers can interleave,
+        # exercising the lock guarding construction.
+        await asyncio.sleep(0)
+        self.load_index_calls += 1
+
+    async def insert_memory(self, content, *, tags=None):
+        self.insert_calls.append((content, tags))
+        return "generated-id"
+
+    async def search_memory(self, query, *, top_k=5):
+        self.search_calls.append((query, top_k))
+        from letta_moss.memory import ArchivalMemoryItem
+
+        return [ArchivalMemoryItem(id="1", content="hit", tags=[], metadata={}, score=0.9)]
+
+    async def delete_memory(self, memory_id):
+        self.delete_calls.append(memory_id)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton(monkeypatch):
+    import letta_moss.tools as tools_mod
+
+    FakeMemory.instances = []
+    monkeypatch.setattr(tools_mod, "MossLettaMemory", FakeMemory)
+    monkeypatch.setattr(tools_mod, "_memory", None)
+    monkeypatch.setenv("MOSS_INDEX_NAME", "idx")
+    yield
+    monkeypatch.setattr(tools_mod, "_memory", None)
+
+
+class TestLazySingleton:
+    async def test_get_memory_constructs_once(self):
+        from letta_moss.tools import _get_memory
+
+        first = await _get_memory()
+        second = await _get_memory()
+        assert first is second
+        assert len(FakeMemory.instances) == 1
+        assert first.load_index_calls == 1
+        assert first.index_name == "idx"
+
+    async def test_concurrent_calls_construct_only_one_instance(self):
+        from letta_moss.tools import _get_memory
+
+        results = await asyncio.gather(*(_get_memory() for _ in range(10)))
+        assert len(FakeMemory.instances) == 1
+        assert all(r is results[0] for r in results)
+
+
+class TestMossMemoryInsert:
+    async def test_delegates_to_memory(self):
+        from letta_moss.tools import moss_memory_insert
+
+        result = await moss_memory_insert("hello", tags=["a"])
+        assert result == "generated-id"
+        [memory] = FakeMemory.instances
+        assert memory.insert_calls == [("hello", ["a"])]
+
+
+class TestMossMemorySearch:
+    async def test_returns_list_of_dicts(self):
+        from letta_moss.memory import ArchivalMemoryItem
+        from letta_moss.tools import moss_memory_search
+
+        results = await moss_memory_search("query", top_k=2)
+        [memory] = FakeMemory.instances
+        assert memory.search_calls == [("query", 2)]
+        expected_item = ArchivalMemoryItem(id="1", content="hit", tags=[], metadata={}, score=0.9)
+        assert results == [dataclasses.asdict(expected_item)]
+
+
+class TestMossMemoryDelete:
+    async def test_delegates_to_memory(self):
+        from letta_moss.tools import moss_memory_delete
+
+        await moss_memory_delete("mem-1")
+        [memory] = FakeMemory.instances
+        assert memory.delete_calls == ["mem-1"]

--- a/packages/letta-moss/tests/test_tools.py
+++ b/packages/letta-moss/tests/test_tools.py
@@ -27,8 +27,8 @@ class FakeMemory:
         self.insert_calls.append((content, tags))
         return "generated-id"
 
-    async def search_memory(self, query, *, top_k=5):
-        self.search_calls.append((query, top_k))
+    async def search_memory(self, query, *, top_k=5, tags=None):
+        self.search_calls.append((query, top_k, tags))
         from letta_moss.memory import ArchivalMemoryItem
 
         return [ArchivalMemoryItem(id="1", content="hit", tags=[], metadata={}, score=0.9)]
@@ -85,7 +85,7 @@ class TestMossMemorySearch:
 
         results = await moss_memory_search("query", top_k=2)
         [memory] = FakeMemory.instances
-        assert memory.search_calls == [("query", 2)]
+        assert memory.search_calls == [("query", 2, None)]
         expected_item = ArchivalMemoryItem(id="1", content="hit", tags=[], metadata={}, score=0.9)
         assert results == [dataclasses.asdict(expected_item)]
 

--- a/packages/letta-moss/tests/test_tools.py
+++ b/packages/letta-moss/tests/test_tools.py
@@ -44,9 +44,11 @@ def _reset_singleton(monkeypatch):
     FakeMemory.instances = []
     monkeypatch.setattr(tools_mod, "MossLettaMemory", FakeMemory)
     monkeypatch.setattr(tools_mod, "_memory", None)
+    monkeypatch.setattr(tools_mod, "_memory_key", None)
     monkeypatch.setenv("MOSS_INDEX_NAME", "idx")
     yield
     monkeypatch.setattr(tools_mod, "_memory", None)
+    monkeypatch.setattr(tools_mod, "_memory_key", None)
 
 
 class TestLazySingleton:
@@ -66,6 +68,27 @@ class TestLazySingleton:
         results = await asyncio.gather(*(_get_memory() for _ in range(10)))
         assert len(FakeMemory.instances) == 1
         assert all(r is results[0] for r in results)
+
+    async def test_rebuilds_when_index_name_env_var_changes(self, monkeypatch):
+        from letta_moss.tools import _get_memory
+
+        first = await _get_memory()
+        monkeypatch.setenv("MOSS_INDEX_NAME", "other-idx")
+        second = await _get_memory()
+
+        assert first is not second
+        assert len(FakeMemory.instances) == 2
+        assert second.index_name == "other-idx"
+
+    async def test_rebuilds_when_project_credentials_env_vars_change(self, monkeypatch):
+        from letta_moss.tools import _get_memory
+
+        first = await _get_memory()
+        monkeypatch.setenv("MOSS_PROJECT_ID", "new-project")
+        second = await _get_memory()
+
+        assert first is not second
+        assert len(FakeMemory.instances) == 2
 
 
 class TestMossMemoryInsert:


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read the CONTRIBUTING guide.
- [x] I have updated the documentation (if applicable).
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Description

Adds `packages/letta-moss/`, a Python package that backs Letta (MemGPT) archival memory with a Moss index.

Letta removed its old pluggable storage-backend abstraction for archival memory today it's hardcoded to Postgres/pgvector, Turbopuffer, or Pinecone with no public extension point to register a fourth backend without forking Letta. Letta's own docs recommend "External RAG through custom tools or MCP" as the sanctioned path for exactly this case.

This PR follows that pattern: `MossLettaMemory` wraps the Moss SDK with insert/search/delete/get/list operations, exposed through two integration surfaces plain async functions for `client.tools.upsert_from_function()`, and a FastMCP server for out-of-process use. No code in the `letta` package is touched. Users opt in with `include_base_tools=False` at agent creation.

Fixes #339

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update, adding README + AGENTS.md row

## Testing

- 37 unit tests, all mocking `MossClient`; 1 credential-gated test skips in CI.
- `ruff check` passes clean.
- Verified install against the real published `moss` package.
