### PR TITLE
fix: close <label> with </label> in upload-section.tsx

### DIFF
--- a/apps/moss-llamaindex/frontend/components/demo/upload-section.tsx
+++ b/apps/moss-llamaindex/frontend/components/demo/upload-section.tsx
@@ -89,7 +89,7 @@ export default function UploadSection({ onUpload, isUploading }: UploadSectionPr
 						<p className='mt-1 text-xs text-[--color-moss-muted]'>Up to 5 documents, PDF format</p>
 					</div>
 				</div>
-			</div>
+			</label>
 
 			{/* File list */}
 			{files.length > 0 && (


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [ ] I have updated the documentation (if applicable). — N/A, one-line tag fix
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective. — N/A, syntax fix
- [x] New and existing unit tests pass locally with my changes.

## Description

The drop-zone `<label>` element in
`apps/moss-llamaindex/frontend/components/demo/upload-section.tsx` was closed
with `</div>` instead of `</label>` (line 92), causing Turbopack to fail on
`npm run build` with `Expected '</', got 'jsx text'`.

Changed the closing tag to `</label>`. Verified the file now parses cleanly.

Fixes #440

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/usemoss/moss/pull/443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

