### PR TITLE
sdk/go: expose GetIndexInfo for locally loaded indexes

### DIFF
--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -8,7 +8,7 @@ The Go work now has the same two-layer direction as the other Moss SDKs:
 Current status:
 
 - bindings-backed manage operations for mutations and metadata reads
-- local `LoadIndex` / `UnloadIndex` / local `Query` via `libmoss`
+- local `LoadIndex` / `UnloadIndex` / `GetIndexInfo` / local `Query` via `libmoss`
 - examples under `examples/go/` and unit tests
 - env-gated integration test scaffold
 

--- a/sdks/go/sdk/README.md
+++ b/sdks/go/sdk/README.md
@@ -12,7 +12,7 @@ The Go SDK now has two layers:
 - typed Go client and models
 - bindings-backed index creation and document mutation
 - bindings-backed index metadata and document reads
-- local index loading and query via native bindings
+- local index loading, metadata, and query via native bindings
 - cloud query fallback when an index is not loaded locally
 - optional caller-provided embeddings for custom indexes
 - env-gated live integration tests

--- a/sdks/go/sdk/client_test.go
+++ b/sdks/go/sdk/client_test.go
@@ -529,6 +529,82 @@ func TestLoadIndexRejectsUnsupportedCachePath(t *testing.T) {
 	}
 }
 
+func TestGetIndexInfoUsesLocalRuntime(t *testing.T) {
+	manageCalled := false
+	client := newTestClient(&fakeManageRuntime{
+		getIndexFn: func(name string) (mosscore.IndexInfo, error) {
+			manageCalled = true
+			return mosscore.IndexInfo{}, nil
+		},
+	}, &fakeIndexRuntime{
+		getIndexInfoFn: func(indexName string) (mosscore.IndexInfo, error) {
+			if indexName != "support-docs" {
+				t.Fatalf("unexpected index name: %q", indexName)
+			}
+			version := "v1"
+			createdAt := "2026-01-02T03:04:05Z"
+			updatedAt := "2026-01-03T03:04:05Z"
+			modelVersion := "0.8.7"
+			return mosscore.IndexInfo{
+				ID:        "idx-local",
+				Name:      "support-docs",
+				Version:   &version,
+				Status:    "Ready",
+				DocCount:  42,
+				CreatedAt: &createdAt,
+				UpdatedAt: &updatedAt,
+				Model:     mosscore.ModelRef{ID: string(ModelMossMiniLM), Version: &modelVersion},
+			}, nil
+		},
+	})
+
+	info, err := client.GetIndexInfo(context.Background(), "support-docs")
+	if err != nil {
+		t.Fatalf("GetIndexInfo returned error: %v", err)
+	}
+	if manageCalled {
+		t.Fatal("expected GetIndexInfo to use local index runtime, not manage runtime")
+	}
+	if info.ID != "idx-local" || info.Name != "support-docs" || info.DocCount != 42 {
+		t.Fatalf("unexpected index info: %#v", info)
+	}
+	if info.Version == nil || *info.Version != "v1" {
+		t.Fatalf("unexpected version: %#v", info.Version)
+	}
+	if info.Model.ID != string(ModelMossMiniLM) || info.Model.Version == nil || *info.Model.Version != "0.8.7" {
+		t.Fatalf("unexpected model: %#v", info.Model)
+	}
+}
+
+func TestGetIndexInfoValidatesCredentialsBeforeInitializingRuntime(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		projectID  string
+		projectKey string
+		wantErr    error
+	}{
+		{name: "missing project ID", projectID: "", projectKey: "project-key", wantErr: ErrMissingProjectID},
+		{name: "missing project key", projectID: "project-id", projectKey: "", wantErr: ErrMissingProjectKey},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := NewClient(tc.projectID, tc.projectKey)
+			factoryCalled := false
+			client.indexFactory = func(projectID, projectKey string) (indexRuntime, error) {
+				factoryCalled = true
+				return &fakeIndexRuntime{}, nil
+			}
+
+			_, err := client.GetIndexInfo(context.Background(), "support-docs")
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected %v, got %v", tc.wantErr, err)
+			}
+			if factoryCalled {
+				t.Fatal("expected index runtime initialization to be skipped")
+			}
+		})
+	}
+}
+
 func TestRefreshIndexValidatesCredentialsBeforeInitializingRuntime(t *testing.T) {
 	for _, tc := range []struct {
 		name       string

--- a/sdks/go/sdk/local.go
+++ b/sdks/go/sdk/local.go
@@ -88,3 +88,24 @@ func (c *Client) RefreshIndex(ctx context.Context, indexName string) (RefreshRes
 		WasUpdated:        result.WasUpdated,
 	}, nil
 }
+
+// GetIndexInfo returns metadata for a locally loaded index.
+func (c *Client) GetIndexInfo(ctx context.Context, indexName string) (IndexInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return IndexInfo{}, err
+	}
+	if err := c.validateManageRequest(indexName); err != nil {
+		return IndexInfo{}, err
+	}
+
+	manager, err := c.ensureIndexManager()
+	if err != nil {
+		return IndexInfo{}, err
+	}
+
+	info, err := manager.GetIndexInfo(indexName)
+	if err != nil {
+		return IndexInfo{}, err
+	}
+	return fromCoreIndexInfo(info), nil
+}


### PR DESCRIPTION
## What

Adds `Client.GetIndexInfo(ctx, indexName)` to the Go SDK's public API.

## Why

`bindings/libmoss.go` already implements `IndexManager.GetIndexInfo` against the native runtime, but nothing in `sdk/` exposed it. The existing `Client.GetIndex` only queries the cloud/manage-plane index metadata and there was no way to ask "what does the copy I currently have loaded in memory look like right now" (doc count, model, staleness relative to a `RefreshIndex` call, etc.) without dropping down to the internal bindings package directly.

## Changes

- `sdk/local.go`: new `Client.GetIndexInfo`, mirroring the existing `RefreshIndex` method and validates credentials, gets the index  runtime, delegates to `manager.GetIndexInfo`, converts via  `fromCoreIndexInfo`.
- `sdk/client_test.go`: two new tests 
  - confirms `GetIndexInfo` reads from the local index runtime, not the manage runtime (this is the whole point of the method)
  - confirms credential validation happens before the index runtime is ever initialized, consistent with the pattern used by `RefreshIndex`
- `sdks/go/README.md` / `sdks/go/sdk/README.md`: updated capability lists to mention `GetIndexInfo`.

## Testing

`go test ./...` passes locally (stub build, no native `libmoss` required and this method has no cgo-specific logic of its own, it's a thin wrapper, consistent with the rest of `local.go`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/usemoss/moss/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

