### PR TITLE
docs(ten-moss): latency-breakdown example

### DIFF
--- a/packages/ten-moss/CHANGELOG.md
+++ b/packages/ten-moss/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `MossSessionManager.last_time_taken_ms` — the engine-measured retrieval time (ms) from the most recent `query_context` call (`SearchResult.time_taken_ms`); `None` before the first query or on error.
+- `examples/latency_breakdown.py` — prints the one-time session-open cost and per-turn retrieval latency (engine `time_taken_ms` and wall-clock; p50/p95/mean).
 
 ### Changed
 - First public release to PyPI (`pip install ten-moss`).

--- a/packages/ten-moss/README.md
+++ b/packages/ten-moss/README.md
@@ -82,6 +82,18 @@ export MOSS_PROJECT_ID=... MOSS_PROJECT_KEY=... MOSS_INDEX_NAME=...
 python examples/create_index.py
 ```
 
+## Latency breakdown
+
+See exactly where time goes — the one-time session-open cost vs the per-turn
+retrieval time (engine `time_taken_ms` from the `SearchResult`, and wall-clock):
+
+```bash
+python examples/latency_breakdown.py        # run examples/create_index.py first
+```
+
+Typical shape: session open is a one-time cost at startup, then per-turn retrieval
+is single-digit-to-low-tens of milliseconds — in-process, no network round-trip.
+
 ## Development
 
 ```bash

--- a/packages/ten-moss/examples/latency_breakdown.py
+++ b/packages/ten-moss/examples/latency_breakdown.py
@@ -1,0 +1,120 @@
+"""Latency breakdown for a Moss session managed by ``ten-moss``.
+
+Shows exactly where time goes when you ground a turn with Moss:
+
+* the **one-time** cost of opening the session (create-or-resume + load the
+  in-process index), paid once at startup, and
+* the **per-turn** retrieval cost — both the engine-measured time from the
+  ``SearchResult`` (``MossSessionManager.last_time_taken_ms``) and the wall-clock
+  time around ``query_context`` (which also includes query embedding + Python).
+
+Run ``examples/create_index.py`` first to populate ``MOSS_INDEX_NAME``.
+
+Usage:
+    export MOSS_PROJECT_ID=... MOSS_PROJECT_KEY=... MOSS_INDEX_NAME=...
+    python examples/latency_breakdown.py            # default question set
+    python examples/latency_breakdown.py -n 200     # more samples
+"""
+
+import argparse
+import asyncio
+import os
+import statistics
+import time
+
+from ten_moss import MossSessionManager
+
+try:  # python-dotenv is optional; real env vars work too.
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover
+
+    def load_dotenv(*args, **kwargs):
+        """No-op fallback when python-dotenv is not installed."""
+        return False
+
+
+QUESTIONS = [
+    "How long do refunds take?",
+    "Can I cancel my order after I place it?",
+    "Which payment methods can I use?",
+    "How fast is express shipping?",
+    "How do I track my order?",
+]
+
+
+def _pct(values: list[float], p: float) -> float:
+    """Nearest-rank percentile (values need not be pre-sorted)."""
+    s = sorted(values)
+    return s[min(len(s) - 1, int(p * len(s)))]
+
+
+def _fmt(values: list[float]) -> str:
+    return (
+        f"p50={_pct(values, 0.50):6.1f} ms   "
+        f"p95={_pct(values, 0.95):6.1f} ms   "
+        f"mean={statistics.mean(values):6.1f} ms"
+    )
+
+
+async def main(samples: int) -> None:
+    load_dotenv()
+    session = MossSessionManager(
+        project_id=os.environ["MOSS_PROJECT_ID"],
+        project_key=os.environ["MOSS_PROJECT_KEY"],
+        index_name=os.environ.get("MOSS_INDEX_NAME", "ten-moss-demo"),
+        top_k=5,
+        alpha=0.8,
+    )
+
+    # --- one-time: open the session (create-or-resume + load the index) ---
+    t0 = time.perf_counter()
+    await session.open()
+    open_ms = (time.perf_counter() - t0) * 1000.0
+
+    # warm-up (first query loads the embedding model; not measured)
+    for q in QUESTIONS:
+        await session.query_context(q)
+
+    # --- per-turn: measure query_context over `samples` calls ---
+    engine_ms: list[float] = []  # SearchResult.time_taken_ms (engine)
+    wall_ms: list[float] = []  # wall-clock around query_context (engine + embed + python)
+    i = 0
+    while len(wall_ms) < samples:
+        q = QUESTIONS[i % len(QUESTIONS)]
+        i += 1
+        t = time.perf_counter()
+        await session.query_context(q)
+        wall_ms.append((time.perf_counter() - t) * 1000.0)
+        if session.last_time_taken_ms is not None:
+            engine_ms.append(float(session.last_time_taken_ms))
+
+    print("\nMoss session · latency breakdown")
+    print(f"  index: {os.environ.get('MOSS_INDEX_NAME', 'ten-moss-demo')}   docs: {session.doc_count}\n")
+
+    print("One-time (paid once at startup)")
+    print(f"  session open (create-or-resume + load index): {open_ms:8.1f} ms\n")
+
+    print(f"Per-turn retrieval · query_context  (n={len(wall_ms)})")
+    if engine_ms:
+        emean = statistics.mean(engine_ms)
+        if emean < 1:
+            # int-ms field rounds sub-millisecond search to 0 — say so plainly.
+            print("  hybrid search engine (SearchResult.time_taken_ms):  <1 ms  (sub-millisecond, in-process)")
+        else:
+            print(f"  hybrid search engine (SearchResult.time_taken_ms):  {_fmt(engine_ms)}")
+    print(f"  end-to-end query_context (search + query embed):    {_fmt(wall_ms)}\n")
+
+    print("  The hybrid search itself is sub-millisecond; the end-to-end cost is mostly")
+    print("  query embedding. Either way it's in-process — no network hop. For contrast, a")
+    print("  cloud retrieval round-trip is typically 200-1500 ms, paid on EVERY turn.")
+
+
+def _cli() -> None:
+    parser = argparse.ArgumentParser(description="Moss session latency breakdown via ten-moss.")
+    parser.add_argument("-n", "--samples", type=int, default=100, help="number of query_context samples")
+    args = parser.parse_args()
+    asyncio.run(main(args.samples))
+
+
+if __name__ == "__main__":
+    _cli()

--- a/packages/ten-moss/examples/latency_breakdown.py
+++ b/packages/ten-moss/examples/latency_breakdown.py
@@ -120,6 +120,8 @@ def _cli() -> None:
     parser = argparse.ArgumentParser(description="Moss session latency breakdown via ten-moss.")
     parser.add_argument("-n", "--samples", type=int, default=100, help="number of query_context samples")
     args = parser.parse_args()
+    if args.samples < 1:
+        parser.error("--samples must be a positive integer")
     asyncio.run(main(args.samples))
 
 

--- a/packages/ten-moss/examples/latency_breakdown.py
+++ b/packages/ten-moss/examples/latency_breakdown.py
@@ -18,6 +18,7 @@ Usage:
 
 import argparse
 import asyncio
+import math
 import os
 import statistics
 import time
@@ -43,9 +44,10 @@ QUESTIONS = [
 
 
 def _pct(values: list[float], p: float) -> float:
-    """Nearest-rank percentile (values need not be pre-sorted)."""
+    """Nearest-rank percentile — ceil(p*N) (values need not be pre-sorted)."""
     s = sorted(values)
-    return s[min(len(s) - 1, int(p * len(s)))]
+    idx = max(0, math.ceil(p * len(s)) - 1)
+    return s[min(len(s) - 1, idx)]
 
 
 def _fmt(values: list[float]) -> str:
@@ -78,6 +80,7 @@ async def main(samples: int) -> None:
     # --- per-turn: measure query_context over `samples` calls ---
     engine_ms: list[float] = []  # SearchResult.time_taken_ms (engine)
     wall_ms: list[float] = []  # wall-clock around query_context (engine + embed + python)
+    missing_engine = 0  # calls that produced no engine timing (no-hit/error turns)
     i = 0
     while len(wall_ms) < samples:
         q = QUESTIONS[i % len(QUESTIONS)]
@@ -85,7 +88,9 @@ async def main(samples: int) -> None:
         t = time.perf_counter()
         await session.query_context(q)
         wall_ms.append((time.perf_counter() - t) * 1000.0)
-        if session.last_time_taken_ms is not None:
+        if session.last_time_taken_ms is None:
+            missing_engine += 1
+        else:
             engine_ms.append(float(session.last_time_taken_ms))
 
     print("\nMoss session · latency breakdown")
@@ -96,12 +101,14 @@ async def main(samples: int) -> None:
 
     print(f"Per-turn retrieval · query_context  (n={len(wall_ms)})")
     if engine_ms:
-        emean = statistics.mean(engine_ms)
-        if emean < 1:
-            # int-ms field rounds sub-millisecond search to 0 — say so plainly.
+        if max(engine_ms) < 1:
+            # Collapse to "<1 ms" only when EVERY sample is sub-ms (int field rounds
+            # to 0); otherwise show the full distribution so the tail isn't hidden.
             print("  hybrid search engine (SearchResult.time_taken_ms):  <1 ms  (sub-millisecond, in-process)")
         else:
             print(f"  hybrid search engine (SearchResult.time_taken_ms):  {_fmt(engine_ms)}")
+    if missing_engine:
+        print(f"  note: {missing_engine}/{len(wall_ms)} calls returned no engine timing (no-hit/error turns)")
     print(f"  end-to-end query_context (search + query embed):    {_fmt(wall_ms)}\n")
 
     print("  The hybrid search itself is sub-millisecond; the end-to-end cost is mostly")


### PR DESCRIPTION
Adds a runnable example that shows the **latency breakdown** of a Moss session via `ten-moss`.

> **Stacked on #453** (base = `chore/release-ten-moss`). #453 adds `MossSessionManager.last_time_taken_ms`, which this example reads. Merge #453 first; GitHub will retarget this to `main`.

## What
- **`examples/latency_breakdown.py`** — opens a session (times the one-time open), warms up, then measures `query_context` over N calls and prints:
  - **hybrid search engine** time (`SearchResult.time_taken_ms`)
  - **end-to-end** `query_context` wall-clock (search + query embedding), p50/p95/mean
- README **Latency breakdown** section + CHANGELOG line.

## Live output (10-doc support KB)
```
One-time (paid once at startup)
  session open (create-or-resume + load index):   ~2000 ms

Per-turn retrieval · query_context
  hybrid search engine (SearchResult.time_taken_ms):  <1 ms  (sub-millisecond, in-process)
  end-to-end query_context (search + query embed):    p50=10.7 ms  p95=12.0 ms  mean=10.5 ms
```
Hybrid search is sub-millisecond; end-to-end (~10 ms) is mostly query embedding — all in-process, no network hop.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/usemoss/moss/pull/454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

