### PR TITLE
fix(voice-agent): compact voice replies + top_k=3

### DIFF
--- a/moss-live-labs/examples/voice-agent/agent.py
+++ b/moss-live-labs/examples/voice-agent/agent.py
@@ -31,10 +31,14 @@ class MossSemanticRetrievalAgent(Agent):
     def __init__(self, moss_client: MossClient):
         super().__init__(
             instructions="""
-                You are a helpful customer support voice assistant.
-                You have access to a knowledge base which will be provided to you as context.
-                Always answer the user's question based on the provided context.
-                If the context doesn't contain the answer, politely say you don't know.
+                You are a helpful customer-support voice assistant. Answer using
+                only the knowledge-base context provided to you as context.
+
+                Keep every reply short and conversational — one or two sentences,
+                the way you would say it out loud. Do NOT use lists, numbered steps,
+                bullet points, markdown, or headings; give the direct answer, not a
+                how-to guide. If the context does not contain the answer, briefly
+                say you are not sure.
             """
         )
         self.moss = moss_client
@@ -51,7 +55,7 @@ class MossSemanticRetrievalAgent(Agent):
             results = await self.moss.query(
                 INDEX_NAME,
                 user_query,
-                QueryOptions(top_k=5, alpha=0.8)
+                QueryOptions(top_k=3, alpha=0.8)
             )
             
             # 2. Context Injection


### PR DESCRIPTION
The voice agent returned long, numbered how-to guides (see screenshot) — bad for a spoken interface. 

- **Prompt**: instruct 1-2 sentence conversational answers, no lists/markdown/numbered steps; direct answer, not a how-to guide; say "not sure" when the context lacks it.
- **top_k 5 → 3**: tighter, more focused grounding per turn.

File: `moss-live-labs/examples/voice-agent/agent.py` (LiveKit).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/usemoss/moss/pull/455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

