### PR TITLE
feat(sdk): add .NET SDK over libmoss (closes #431)

### DIFF
--- a/sdks/dotnet/.gitignore
+++ b/sdks/dotnet/.gitignore
@@ -1,0 +1,16 @@
+## .NET build output
+bin/
+obj/
+*.user
+
+## Test / coverage artifacts
+[Tt]est[Rr]esults/
+*.trx
+*.coverage
+coverage*.json
+coverage*.xml
+coverage*.cobertura.xml
+
+## NuGet
+*.nupkg
+*.snupkg

--- a/sdks/dotnet/Moss.sln
+++ b/sdks/dotnet/Moss.sln
@@ -1,0 +1,27 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Moss", "src\Moss\Moss.csproj", "{A1B2C3D4-0001-4000-8000-000000000001}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Moss.Tests", "tests\Moss.Tests\Moss.Tests.csproj", "{A1B2C3D4-0002-4000-8000-000000000002}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-0001-4000-8000-000000000001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-0001-4000-8000-000000000001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-0001-4000-8000-000000000001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-0001-4000-8000-000000000001}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-0002-4000-8000-000000000002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-0002-4000-8000-000000000002}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-0002-4000-8000-000000000002}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-0002-4000-8000-000000000002}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/sdks/dotnet/README.md
+++ b/sdks/dotnet/README.md
@@ -1,0 +1,112 @@
+# Moss .NET SDK
+
+The .NET SDK for [Moss](https://github.com/usemoss/moss) — fast on-device
+retrieval. It wraps the native `libmoss` runtime through P/Invoke and exposes an
+idiomatic, async C# API for index management, hybrid search, and metadata
+filtering.
+
+## Architecture
+
+```
+        ┌──────────────────────────────────┐
+        │      Your application code       │
+        └──────────────┬───────────────────┘
+                       │
+        ┌──────────────▼───────────────────┐
+        │  Moss  (managed C#)              │  ← src/Moss
+        │  MossClient — async API for      │
+        │  indexing, querying, management  │
+        └──────────────┬───────────────────┘
+                       │  P/Invoke ([DllImport("moss")])
+        ┌──────────────▼───────────────────┐
+        │  libmoss  (native C ABI)         │  ← prebuilt runtime
+        │  hybrid search, data models      │
+        └──────────────────────────────────┘
+```
+
+- `src/Moss/` — the public SDK. `MossClient` plus the data models.
+- `src/Moss/Interop/` — the P/Invoke layer: raw `libmoss` declarations, C-ABI
+  struct mirrors, UTF-8 marshaling, and native-memory conversion/cleanup.
+
+The interop layer targets the same stable C ABI (`libmoss.h`) that the Go
+bindings bind via cgo.
+
+## Quick start
+
+```csharp
+using Moss;
+
+using var client = new MossClient("your_project_id", "your_project_key");
+
+await client.CreateIndexAsync("support-docs", new[]
+{
+    new DocumentInfo("1", "Refunds are processed within 3-5 business days."),
+    new DocumentInfo("2", "You can track your order on the dashboard."),
+});
+
+await client.LoadIndexAsync("support-docs");
+
+var results = await client.QueryAsync(
+    "support-docs", "how long do refunds take?", new QueryOptions { TopK = 3 });
+
+foreach (var doc in results.Docs)
+    Console.WriteLine($"[{doc.Score:F3}] {doc.Text}");
+```
+
+### Metadata filtering
+
+Attach string metadata at index time and pass a JSON filter at query time:
+
+```csharp
+await client.AddDocsAsync("support-docs", new[]
+{
+    new DocumentInfo("3", "EU refund policy…",
+        metadata: new Dictionary<string, string> { ["region"] = "eu" }),
+});
+
+var results = await client.QueryAsync("support-docs", "refund policy",
+    new QueryOptions
+    {
+        TopK = 5,
+        FilterJson = "{\"region\": \"eu\"}",
+    });
+```
+
+## API surface
+
+| Area | Methods |
+|------|---------|
+| Indexes | `CreateIndexAsync`, `GetIndexAsync`, `ListIndexesAsync`, `DeleteIndexAsync` |
+| Documents | `AddDocsAsync`, `DeleteDocsAsync`, `GetDocsAsync` |
+| Jobs | `GetJobStatusAsync` |
+| Local runtime | `LoadIndexAsync`, `UnloadIndexAsync`, `RefreshIndexAsync`, `QueryAsync` |
+
+All methods are asynchronous and accept a `CancellationToken`. Failures from the
+native runtime surface as `MossException` (carrying the status `Code` and the
+`moss_last_error` message).
+
+## The native runtime
+
+The SDK calls into `libmoss`, distributed as a prebuilt native library
+(`libmoss.so` on Linux, `libmoss.dylib` on macOS, `moss.dll` on Windows). It
+must be discoverable at runtime — on the standard library search path, next to
+your application, or via `NativeLibrary` resolution. Building and unit-testing
+the SDK does **not** require the native library; only running queries does.
+
+## Building and testing
+
+Requires the [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0).
+
+```bash
+cd sdks/dotnet
+dotnet build
+dotnet test        # unit tests run without libmoss
+```
+
+The unit tests cover the managed logic and the marshaling layer (UTF-8
+round-trips, native buffer packing, ABI struct sizes) and do not load the native
+library.
+
+## License
+
+[BSD 2-Clause License](../../LICENSE)

--- a/sdks/dotnet/src/Moss/Interop/MossClientHandle.cs
+++ b/sdks/dotnet/src/Moss/Interop/MossClientHandle.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Moss.Interop;
+
+/// <summary>
+/// Owns the native <c>MossClient*</c>. Deriving from <see cref="SafeHandle"/>
+/// means the handle is reference-counted during P/Invoke calls and freed via
+/// <c>moss_client_free</c> from <see cref="ReleaseHandle"/> — including during
+/// finalization, so a leaked (undisposed) client still releases native state.
+/// </summary>
+internal sealed class MossClientHandle : SafeHandle
+{
+    public MossClientHandle() : base(IntPtr.Zero, ownsHandle: true) { }
+
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    /// <summary>Adopt a raw handle produced by <c>moss_client_new</c>.</summary>
+    internal void SetRawHandle(IntPtr raw) => SetHandle(raw);
+
+    protected override bool ReleaseHandle()
+    {
+        NativeMethods.moss_client_free(handle);
+        return true;
+    }
+}

--- a/sdks/dotnet/src/Moss/Interop/Native.cs
+++ b/sdks/dotnet/src/Moss/Interop/Native.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Moss.Interop;
+
+/// <summary>UTF-8 string marshaling helpers for the native boundary.</summary>
+internal static class Utf8
+{
+    /// <summary>Allocates a NUL-terminated UTF-8 copy of <paramref name="value"/>, or
+    /// <see cref="IntPtr.Zero"/> when it is null. Free with <see cref="Marshal.FreeCoTaskMem"/>.</summary>
+    public static IntPtr Alloc(string? value)
+        => value is null ? IntPtr.Zero : Marshal.StringToCoTaskMemUTF8(value);
+
+    /// <summary>Reads a NUL-terminated UTF-8 string, mapping a null pointer to "".</summary>
+    public static string Read(IntPtr ptr)
+        => ptr == IntPtr.Zero ? string.Empty : Marshal.PtrToStringUTF8(ptr) ?? string.Empty;
+
+    /// <summary>Reads a NUL-terminated UTF-8 string, preserving null as null (for optional fields).</summary>
+    public static string? ReadOptional(IntPtr ptr)
+        => ptr == IntPtr.Zero ? null : Marshal.PtrToStringUTF8(ptr);
+}
+
+/// <summary>
+/// Tracks native allocations made while marshaling inputs and frees them all on
+/// <see cref="Dispose"/>. Strings are allocated via CoTaskMem; raw blocks via HGlobal.
+/// </summary>
+internal sealed class NativeArena : IDisposable
+{
+    private readonly List<IntPtr> _coTaskMem = new();
+    private readonly List<IntPtr> _hGlobal = new();
+
+    /// <summary>Allocate a UTF-8 string tracked by this arena.</summary>
+    public IntPtr String(string? value)
+    {
+        IntPtr p = Utf8.Alloc(value);
+        if (p != IntPtr.Zero) _coTaskMem.Add(p);
+        return p;
+    }
+
+    /// <summary>Allocate a raw block of <paramref name="bytes"/> bytes tracked by this arena.</summary>
+    public IntPtr Alloc(int bytes)
+    {
+        IntPtr p = Marshal.AllocHGlobal(bytes);
+        _hGlobal.Add(p);
+        return p;
+    }
+
+    /// <summary>Marshal an array of contiguous structs into a tracked native block.</summary>
+    public IntPtr StructArray<T>(IReadOnlyList<T> items) where T : struct
+    {
+        if (items.Count == 0) return IntPtr.Zero;
+        int size = Marshal.SizeOf<T>();
+        IntPtr block = Alloc(size * items.Count);
+        for (int i = 0; i < items.Count; i++)
+            Marshal.StructureToPtr(items[i], block + i * size, false);
+        return block;
+    }
+
+    /// <summary>Marshal an array of floats into a tracked native block.</summary>
+    public IntPtr FloatArray(IReadOnlyList<float>? values)
+    {
+        if (values is null || values.Count == 0) return IntPtr.Zero;
+        IntPtr block = Alloc(sizeof(float) * values.Count);
+        var tmp = new float[values.Count];
+        for (int i = 0; i < values.Count; i++) tmp[i] = values[i];
+        Marshal.Copy(tmp, 0, block, tmp.Length);
+        return block;
+    }
+
+    /// <summary>Marshal an array of UTF-8 strings into a tracked native array of char*.</summary>
+    public IntPtr StringArray(IReadOnlyList<string> values)
+    {
+        if (values.Count == 0) return IntPtr.Zero;
+        IntPtr block = Alloc(IntPtr.Size * values.Count);
+        for (int i = 0; i < values.Count; i++)
+            Marshal.WriteIntPtr(block, i * IntPtr.Size, String(values[i]));
+        return block;
+    }
+
+    public void Dispose()
+    {
+        foreach (IntPtr p in _coTaskMem) Marshal.FreeCoTaskMem(p);
+        foreach (IntPtr p in _hGlobal) Marshal.FreeHGlobal(p);
+        _coTaskMem.Clear();
+        _hGlobal.Clear();
+    }
+}

--- a/sdks/dotnet/src/Moss/Interop/NativeClient.cs
+++ b/sdks/dotnet/src/Moss/Interop/NativeClient.cs
@@ -1,0 +1,427 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Moss.Interop;
+
+/// <summary>
+/// Thin, synchronous wrapper over the native <c>libmoss</c> client handle. It
+/// owns the <c>MossClient*</c>, marshals managed inputs, checks status codes,
+/// reads outputs back into managed models, and releases every native
+/// allocation. All public methods are serialized behind a lock, mirroring the
+/// per-client mutex the Go bindings use.
+/// </summary>
+internal sealed class NativeClient : IDisposable
+{
+    private readonly object _gate = new();
+    private IntPtr _handle;
+
+    public NativeClient(string projectId, string projectKey)
+    {
+        using var arena = new NativeArena();
+        Check(NativeMethods.moss_client_new(arena.String(projectId), arena.String(projectKey), out _handle));
+        if (_handle == IntPtr.Zero)
+            throw new MossException(-1, "moss_client_new returned a null client");
+    }
+
+    // ---- Management ------------------------------------------------------
+
+    public MutationResult CreateIndex(string name, IReadOnlyList<DocumentInfo> docs, string? modelId)
+    {
+        lock (_gate)
+        {
+            EnsureOpen();
+            using var arena = new NativeArena();
+            IntPtr docsPtr = BuildDocuments(arena, docs);
+            Check(NativeMethods.moss_client_create_index(
+                _handle, arena.String(name), docsPtr, (nuint)docs.Count, arena.String(modelId), out IntPtr outPtr));
+            return ReadMutationResult(outPtr);
+        }
+    }
+
+    public MutationResult AddDocs(string name, IReadOnlyList<DocumentInfo> docs, MutationOptions? options)
+    {
+        lock (_gate)
+        {
+            EnsureOpen();
+            using var arena = new NativeArena();
+            IntPtr docsPtr = BuildDocuments(arena, docs);
+            IntPtr optsPtr = IntPtr.Zero;
+            if (options?.Upsert is bool upsert)
+            {
+                var native = new MossMutationOptions { upsert = upsert };
+                optsPtr = arena.StructArray(new[] { native });
+            }
+            Check(NativeMethods.moss_client_add_docs(
+                _handle, arena.String(name), docsPtr, (nuint)docs.Count, optsPtr, out IntPtr outPtr));
+            return ReadMutationResult(outPtr);
+        }
+    }
+
+    public MutationResult DeleteDocs(string name, IReadOnlyList<string> docIds)
+    {
+        lock (_gate)
+        {
+            EnsureOpen();
+            using var arena = new NativeArena();
+            Check(NativeMethods.moss_client_delete_docs(
+                _handle, arena.String(name), arena.StringArray(docIds), (nuint)docIds.Count, out IntPtr outPtr));
+            return ReadMutationResult(outPtr);
+        }
+    }
+
+    public IReadOnlyList<DocumentInfo> GetDocs(string name, IReadOnlyList<string> docIds)
+    {
+        lock (_gate)
+        {
+            EnsureOpen();
+            using var arena = new NativeArena();
+            Check(NativeMethods.moss_client_get_docs(
+                _handle, arena.String(name), arena.StringArray(docIds), (nuint)docIds.Count,
+                out IntPtr outDocs, out nuint count));
+            try
+            {
+                return ReadDocuments(outDocs, count);
+            }
+            finally
+            {
+                NativeMethods.moss_free_documents(outDocs, count);
+            }
+        }
+    }
+
+    public IndexInfo GetIndex(string name)
+    {
+        lock (_gate)
+        {
+            EnsureOpen();
+            using var arena = new NativeArena();
+            Check(NativeMethods.moss_client_get_index(_handle, arena.String(name), out IntPtr outPtr));
+            try
+            {
+                return ReadIndexInfo(Marshal.PtrToStructure<MossIndexInfo>(outPtr));
+            }
+            finally
+            {
+                NativeMethods.moss_free_index_info(outPtr);
+            }
+        }
+    }
+
+    public IReadOnlyList<IndexInfo> ListIndexes()
+    {
+        lock (_gate)
+        {
+            EnsureOpen();
+            Check(NativeMethods.moss_client_list_indexes(_handle, out IntPtr outPtr, out nuint count));
+            try
+            {
+                int size = Marshal.SizeOf<MossIndexInfo>();
+                var result = new List<IndexInfo>((int)count);
+                for (nuint i = 0; i < count; i++)
+                {
+                    var native = Marshal.PtrToStructure<MossIndexInfo>(outPtr + (int)i * size);
+                    result.Add(ReadIndexInfo(native));
+                }
+                return result;
+            }
+            finally
+            {
+                NativeMethods.moss_free_index_info_list(outPtr, count);
+            }
+        }
+    }
+
+    public bool DeleteIndex(string name)
+    {
+        lock (_gate)
+        {
+            EnsureOpen();
+            using var arena = new NativeArena();
+            Check(NativeMethods.moss_client_delete_index(_handle, arena.String(name), out bool deleted));
+            return deleted;
+        }
+    }
+
+    public JobStatusResponse GetJobStatus(string jobId)
+    {
+        lock (_gate)
+        {
+            EnsureOpen();
+            using var arena = new NativeArena();
+            Check(NativeMethods.moss_client_get_job_status(_handle, arena.String(jobId), out IntPtr outPtr));
+            try
+            {
+                var n = Marshal.PtrToStructure<MossJobStatusResponse>(outPtr);
+                return new JobStatusResponse
+                {
+                    JobId = Utf8.Read(n.job_id),
+                    Status = Utf8.Read(n.status),
+                    Progress = n.progress,
+                    CurrentPhase = Utf8.ReadOptional(n.current_phase),
+                    Error = Utf8.ReadOptional(n.error),
+                    CreatedAt = Utf8.Read(n.created_at),
+                    UpdatedAt = Utf8.Read(n.updated_at),
+                    CompletedAt = Utf8.ReadOptional(n.completed_at),
+                };
+            }
+            finally
+            {
+                NativeMethods.moss_free_job_status_response(outPtr);
+            }
+        }
+    }
+
+    // ---- Local runtime ---------------------------------------------------
+
+    public IndexInfo LoadIndex(string name, LoadIndexOptions? options)
+    {
+        lock (_gate)
+        {
+            EnsureOpen();
+            using var arena = new NativeArena();
+            IntPtr optsPtr = IntPtr.Zero;
+            if (options is not null)
+            {
+                var native = new MossLoadIndexOptions
+                {
+                    auto_refresh = options.AutoRefresh,
+                    polling_interval_secs = options.PollingIntervalInSeconds,
+                };
+                optsPtr = arena.StructArray(new[] { native });
+            }
+            Check(NativeMethods.moss_client_load_index(_handle, arena.String(name), optsPtr, out IntPtr outPtr));
+            try
+            {
+                return ReadIndexInfo(Marshal.PtrToStructure<MossIndexInfo>(outPtr));
+            }
+            finally
+            {
+                NativeMethods.moss_free_index_info(outPtr);
+            }
+        }
+    }
+
+    public void UnloadIndex(string name)
+    {
+        lock (_gate)
+        {
+            EnsureOpen();
+            using var arena = new NativeArena();
+            Check(NativeMethods.moss_client_unload_index(_handle, arena.String(name)));
+        }
+    }
+
+    public RefreshResult RefreshIndex(string name)
+    {
+        lock (_gate)
+        {
+            EnsureOpen();
+            using var arena = new NativeArena();
+            Check(NativeMethods.moss_client_refresh_index(_handle, arena.String(name), out IntPtr outPtr));
+            try
+            {
+                var n = Marshal.PtrToStructure<MossRefreshResult>(outPtr);
+                return new RefreshResult
+                {
+                    IndexName = Utf8.Read(n.index_name),
+                    PreviousUpdatedAt = Utf8.Read(n.previous_updated_at),
+                    NewUpdatedAt = Utf8.Read(n.new_updated_at),
+                    WasUpdated = n.was_updated,
+                };
+            }
+            finally
+            {
+                NativeMethods.moss_free_refresh_result(outPtr);
+            }
+        }
+    }
+
+    public SearchResult Query(string name, string query, QueryOptions options)
+    {
+        lock (_gate)
+        {
+            EnsureOpen();
+            using var arena = new NativeArena();
+            var native = new MossQueryOptions
+            {
+                top_k = (nuint)Math.Max(0, options.TopK),
+                alpha = options.Alpha,
+                filter_json = arena.String(options.FilterJson),
+                embedding = arena.FloatArray(options.Embedding),
+                embedding_dim = (nuint)(options.Embedding?.Count ?? 0),
+            };
+            IntPtr optsPtr = arena.StructArray(new[] { native });
+            Check(NativeMethods.moss_client_query(
+                _handle, arena.String(name), arena.String(query), optsPtr, out IntPtr outPtr));
+            try
+            {
+                return ReadSearchResult(outPtr);
+            }
+            finally
+            {
+                NativeMethods.moss_free_search_result(outPtr);
+            }
+        }
+    }
+
+    // ---- Input marshaling ------------------------------------------------
+
+    private static IntPtr BuildDocuments(NativeArena arena, IReadOnlyList<DocumentInfo> docs)
+    {
+        if (docs.Count == 0) return IntPtr.Zero;
+        var natives = new MossDocumentInfo[docs.Count];
+        for (int i = 0; i < docs.Count; i++)
+        {
+            DocumentInfo doc = docs[i];
+            IntPtr metaPtr = IntPtr.Zero;
+            int metaCount = 0;
+            if (doc.Metadata is { Count: > 0 })
+            {
+                var entries = new List<MossMetadataEntry>(doc.Metadata.Count);
+                foreach (KeyValuePair<string, string> kv in doc.Metadata)
+                    entries.Add(new MossMetadataEntry { key = arena.String(kv.Key), value = arena.String(kv.Value) });
+                metaPtr = arena.StructArray(entries);
+                metaCount = entries.Count;
+            }
+            natives[i] = new MossDocumentInfo
+            {
+                id = arena.String(doc.Id),
+                text = arena.String(doc.Text),
+                metadata = metaPtr,
+                metadata_count = (nuint)metaCount,
+                embedding = arena.FloatArray(doc.Embedding),
+                embedding_dim = (nuint)(doc.Embedding?.Count ?? 0),
+            };
+        }
+        return arena.StructArray(natives);
+    }
+
+    // ---- Output marshaling -----------------------------------------------
+
+    private static MutationResult ReadMutationResult(IntPtr ptr)
+    {
+        try
+        {
+            var n = Marshal.PtrToStructure<MossMutationResult>(ptr);
+            return new MutationResult
+            {
+                JobId = Utf8.Read(n.job_id),
+                IndexName = Utf8.Read(n.index_name),
+                DocCount = (int)n.doc_count,
+            };
+        }
+        finally
+        {
+            NativeMethods.moss_free_mutation_result(ptr);
+        }
+    }
+
+    private static IndexInfo ReadIndexInfo(MossIndexInfo n) => new()
+    {
+        Id = Utf8.Read(n.id),
+        Name = Utf8.Read(n.name),
+        Version = Utf8.ReadOptional(n.version),
+        Status = Utf8.Read(n.status),
+        DocCount = (int)n.doc_count,
+        CreatedAt = Utf8.ReadOptional(n.created_at),
+        UpdatedAt = Utf8.ReadOptional(n.updated_at),
+        Model = new ModelRef { Id = Utf8.Read(n.model.id), Version = Utf8.ReadOptional(n.model.version) },
+    };
+
+    private static IReadOnlyList<DocumentInfo> ReadDocuments(IntPtr ptr, nuint count)
+    {
+        if (ptr == IntPtr.Zero || count == 0) return Array.Empty<DocumentInfo>();
+        int size = Marshal.SizeOf<MossDocumentInfo>();
+        var result = new List<DocumentInfo>((int)count);
+        for (nuint i = 0; i < count; i++)
+        {
+            var n = Marshal.PtrToStructure<MossDocumentInfo>(ptr + (int)i * size);
+            result.Add(new DocumentInfo
+            {
+                Id = Utf8.Read(n.id),
+                Text = Utf8.Read(n.text),
+                Metadata = ReadMetadata(n.metadata, n.metadata_count),
+                Embedding = ReadFloats(n.embedding, n.embedding_dim),
+            });
+        }
+        return result;
+    }
+
+    private static SearchResult ReadSearchResult(IntPtr ptr)
+    {
+        var n = Marshal.PtrToStructure<MossSearchResult>(ptr);
+        var docs = new List<ScoredDocument>((int)n.doc_count);
+        if (n.docs != IntPtr.Zero && n.doc_count > 0)
+        {
+            int size = Marshal.SizeOf<MossSearchResultDoc>();
+            for (nuint i = 0; i < n.doc_count; i++)
+            {
+                var d = Marshal.PtrToStructure<MossSearchResultDoc>(n.docs + (int)i * size);
+                docs.Add(new ScoredDocument
+                {
+                    Id = Utf8.Read(d.id),
+                    Text = Utf8.Read(d.text),
+                    Metadata = ReadMetadata(d.metadata, d.metadata_count),
+                    Score = d.score,
+                });
+            }
+        }
+        return new SearchResult
+        {
+            Docs = docs,
+            Query = Utf8.Read(n.query),
+            IndexName = Utf8.ReadOptional(n.index_name),
+            TimeTakenMs = (int)n.time_taken_ms,
+        };
+    }
+
+    private static IReadOnlyDictionary<string, string>? ReadMetadata(IntPtr entries, nuint count)
+    {
+        if (entries == IntPtr.Zero || count == 0) return null;
+        int size = Marshal.SizeOf<MossMetadataEntry>();
+        var map = new Dictionary<string, string>((int)count);
+        for (nuint i = 0; i < count; i++)
+        {
+            var e = Marshal.PtrToStructure<MossMetadataEntry>(entries + (int)i * size);
+            map[Utf8.Read(e.key)] = Utf8.Read(e.value);
+        }
+        return map;
+    }
+
+    private static IReadOnlyList<float>? ReadFloats(IntPtr ptr, nuint count)
+    {
+        if (ptr == IntPtr.Zero || count == 0) return null;
+        var values = new float[(int)count];
+        Marshal.Copy(ptr, values, 0, (int)count);
+        return values;
+    }
+
+    // ---- Lifetime + errors ----------------------------------------------
+
+    private void EnsureOpen()
+    {
+        if (_handle == IntPtr.Zero)
+            throw new ObjectDisposedException(nameof(MossClient));
+    }
+
+    private static void Check(MossResult result)
+    {
+        if (result == MossResult.Ok) return;
+        IntPtr msgPtr = NativeMethods.moss_last_error();
+        string message = msgPtr == IntPtr.Zero ? "libmoss call failed" : Utf8.Read(msgPtr);
+        throw new MossException((int)result, message);
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_handle != IntPtr.Zero)
+            {
+                NativeMethods.moss_client_free(_handle);
+                _handle = IntPtr.Zero;
+            }
+        }
+    }
+}

--- a/sdks/dotnet/src/Moss/Interop/NativeClient.cs
+++ b/sdks/dotnet/src/Moss/Interop/NativeClient.cs
@@ -14,14 +14,16 @@ namespace Moss.Interop;
 internal sealed class NativeClient : IDisposable
 {
     private readonly object _gate = new();
-    private IntPtr _handle;
+    private readonly MossClientHandle _handle;
 
     public NativeClient(string projectId, string projectKey)
     {
         using var arena = new NativeArena();
-        Check(NativeMethods.moss_client_new(arena.String(projectId), arena.String(projectKey), out _handle));
-        if (_handle == IntPtr.Zero)
+        Check(NativeMethods.moss_client_new(arena.String(projectId), arena.String(projectKey), out IntPtr raw));
+        if (raw == IntPtr.Zero)
             throw new MossException(-1, "moss_client_new returned a null client");
+        _handle = new MossClientHandle();
+        _handle.SetRawHandle(raw);
     }
 
     // ---- Management ------------------------------------------------------
@@ -401,7 +403,7 @@ internal sealed class NativeClient : IDisposable
 
     private void EnsureOpen()
     {
-        if (_handle == IntPtr.Zero)
+        if (_handle.IsInvalid || _handle.IsClosed)
             throw new ObjectDisposedException(nameof(MossClient));
     }
 
@@ -417,11 +419,7 @@ internal sealed class NativeClient : IDisposable
     {
         lock (_gate)
         {
-            if (_handle != IntPtr.Zero)
-            {
-                NativeMethods.moss_client_free(_handle);
-                _handle = IntPtr.Zero;
-            }
+            _handle.Dispose();
         }
     }
 }

--- a/sdks/dotnet/src/Moss/Interop/NativeMethods.cs
+++ b/sdks/dotnet/src/Moss/Interop/NativeMethods.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Moss.Interop;
+
+/// <summary>
+/// Raw P/Invoke declarations for the native <c>libmoss</c> runtime. Every
+/// pointer is passed as <see cref="IntPtr"/> so marshaling stays explicit and
+/// identical across platforms. The library name "moss" resolves to
+/// <c>libmoss.so</c> (Linux), <c>libmoss.dylib</c> (macOS), or <c>moss.dll</c>
+/// (Windows) via the standard .NET native-library search.
+/// </summary>
+internal static class NativeMethods
+{
+    private const string Lib = "moss";
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern MossResult moss_client_new(IntPtr projectId, IntPtr projectKey, out IntPtr client);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void moss_client_free(IntPtr client);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern MossResult moss_client_create_index(
+        IntPtr client, IntPtr name, IntPtr docs, nuint count, IntPtr modelId, out IntPtr outResult);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern MossResult moss_client_add_docs(
+        IntPtr client, IntPtr name, IntPtr docs, nuint count, IntPtr options, out IntPtr outResult);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern MossResult moss_client_delete_docs(
+        IntPtr client, IntPtr name, IntPtr ids, nuint count, out IntPtr outResult);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern MossResult moss_client_get_docs(
+        IntPtr client, IntPtr name, IntPtr ids, nuint count, out IntPtr outDocs, out nuint outCount);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern MossResult moss_client_get_index(IntPtr client, IntPtr name, out IntPtr outInfo);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern MossResult moss_client_list_indexes(IntPtr client, out IntPtr outInfos, out nuint outCount);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern MossResult moss_client_delete_index(
+        IntPtr client, IntPtr name, [MarshalAs(UnmanagedType.I1)] out bool deleted);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern MossResult moss_client_get_job_status(IntPtr client, IntPtr jobId, out IntPtr outResult);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern MossResult moss_client_load_index(
+        IntPtr client, IntPtr name, IntPtr options, out IntPtr outInfo);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern MossResult moss_client_unload_index(IntPtr client, IntPtr name);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern MossResult moss_client_refresh_index(IntPtr client, IntPtr name, out IntPtr outResult);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern MossResult moss_client_query(
+        IntPtr client, IntPtr name, IntPtr query, IntPtr options, out IntPtr outResult);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr moss_last_error();
+
+    // Deallocators for every heap object handed back across the boundary.
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void moss_free_documents(IntPtr docs, nuint count);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void moss_free_index_info(IntPtr info);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void moss_free_index_info_list(IntPtr infos, nuint count);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void moss_free_job_status_response(IntPtr response);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void moss_free_mutation_result(IntPtr result);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void moss_free_refresh_result(IntPtr result);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void moss_free_search_result(IntPtr result);
+}

--- a/sdks/dotnet/src/Moss/Interop/NativeMethods.cs
+++ b/sdks/dotnet/src/Moss/Interop/NativeMethods.cs
@@ -4,11 +4,12 @@ using System.Runtime.InteropServices;
 namespace Moss.Interop;
 
 /// <summary>
-/// Raw P/Invoke declarations for the native <c>libmoss</c> runtime. Every
-/// pointer is passed as <see cref="IntPtr"/> so marshaling stays explicit and
-/// identical across platforms. The library name "moss" resolves to
-/// <c>libmoss.so</c> (Linux), <c>libmoss.dylib</c> (macOS), or <c>moss.dll</c>
-/// (Windows) via the standard .NET native-library search.
+/// Raw P/Invoke declarations for the native <c>libmoss</c> runtime. The client
+/// parameter is a <see cref="MossClientHandle"/> so the marshaler keeps it alive
+/// (and prevents handle recycling) for the duration of each call. Other pointers
+/// are passed as <see cref="IntPtr"/> so marshaling stays explicit. The library
+/// name "moss" resolves to <c>libmoss.so</c> / <c>libmoss.dylib</c> /
+/// <c>moss.dll</c> via the standard .NET native-library search.
 /// </summary>
 internal static class NativeMethods
 {
@@ -17,51 +18,52 @@ internal static class NativeMethods
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
     public static extern MossResult moss_client_new(IntPtr projectId, IntPtr projectKey, out IntPtr client);
 
+    // Called by MossClientHandle.ReleaseHandle with the raw handle.
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
     public static extern void moss_client_free(IntPtr client);
 
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
     public static extern MossResult moss_client_create_index(
-        IntPtr client, IntPtr name, IntPtr docs, nuint count, IntPtr modelId, out IntPtr outResult);
+        MossClientHandle client, IntPtr name, IntPtr docs, nuint count, IntPtr modelId, out IntPtr outResult);
 
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
     public static extern MossResult moss_client_add_docs(
-        IntPtr client, IntPtr name, IntPtr docs, nuint count, IntPtr options, out IntPtr outResult);
+        MossClientHandle client, IntPtr name, IntPtr docs, nuint count, IntPtr options, out IntPtr outResult);
 
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
     public static extern MossResult moss_client_delete_docs(
-        IntPtr client, IntPtr name, IntPtr ids, nuint count, out IntPtr outResult);
+        MossClientHandle client, IntPtr name, IntPtr ids, nuint count, out IntPtr outResult);
 
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
     public static extern MossResult moss_client_get_docs(
-        IntPtr client, IntPtr name, IntPtr ids, nuint count, out IntPtr outDocs, out nuint outCount);
+        MossClientHandle client, IntPtr name, IntPtr ids, nuint count, out IntPtr outDocs, out nuint outCount);
 
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
-    public static extern MossResult moss_client_get_index(IntPtr client, IntPtr name, out IntPtr outInfo);
+    public static extern MossResult moss_client_get_index(MossClientHandle client, IntPtr name, out IntPtr outInfo);
 
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
-    public static extern MossResult moss_client_list_indexes(IntPtr client, out IntPtr outInfos, out nuint outCount);
+    public static extern MossResult moss_client_list_indexes(MossClientHandle client, out IntPtr outInfos, out nuint outCount);
 
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
     public static extern MossResult moss_client_delete_index(
-        IntPtr client, IntPtr name, [MarshalAs(UnmanagedType.I1)] out bool deleted);
+        MossClientHandle client, IntPtr name, [MarshalAs(UnmanagedType.I1)] out bool deleted);
 
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
-    public static extern MossResult moss_client_get_job_status(IntPtr client, IntPtr jobId, out IntPtr outResult);
+    public static extern MossResult moss_client_get_job_status(MossClientHandle client, IntPtr jobId, out IntPtr outResult);
 
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
     public static extern MossResult moss_client_load_index(
-        IntPtr client, IntPtr name, IntPtr options, out IntPtr outInfo);
+        MossClientHandle client, IntPtr name, IntPtr options, out IntPtr outInfo);
 
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
-    public static extern MossResult moss_client_unload_index(IntPtr client, IntPtr name);
+    public static extern MossResult moss_client_unload_index(MossClientHandle client, IntPtr name);
 
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
-    public static extern MossResult moss_client_refresh_index(IntPtr client, IntPtr name, out IntPtr outResult);
+    public static extern MossResult moss_client_refresh_index(MossClientHandle client, IntPtr name, out IntPtr outResult);
 
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
     public static extern MossResult moss_client_query(
-        IntPtr client, IntPtr name, IntPtr query, IntPtr options, out IntPtr outResult);
+        MossClientHandle client, IntPtr name, IntPtr query, IntPtr options, out IntPtr outResult);
 
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
     public static extern IntPtr moss_last_error();

--- a/sdks/dotnet/src/Moss/Interop/NativeStructs.cs
+++ b/sdks/dotnet/src/Moss/Interop/NativeStructs.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Moss.Interop;
+
+// These structs mirror the C ABI declared in libmoss.h (the same surface the
+// Go bindings bind via cgo). Field order, types, and layout must match exactly.
+// char*  -> IntPtr (NUL-terminated UTF-8)
+// uintptr_t / size_t -> nuint
+// bool   -> [MarshalAs(I1)] bool
+// float  -> float, double -> double, uint64_t -> ulong
+
+/// <summary>Status code returned by every native call. 0 == success.</summary>
+internal enum MossResult
+{
+    Ok = 0,
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct MossMetadataEntry
+{
+    public IntPtr key;
+    public IntPtr value;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct MossDocumentInfo
+{
+    public IntPtr id;
+    public IntPtr text;
+    public IntPtr metadata;        // MossMetadataEntry*
+    public nuint metadata_count;
+    public IntPtr embedding;       // float*
+    public nuint embedding_dim;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct MossMutationOptions
+{
+    [MarshalAs(UnmanagedType.I1)] public bool upsert;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct MossMutationResult
+{
+    public IntPtr job_id;
+    public IntPtr index_name;
+    public nuint doc_count;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct MossModelRef
+{
+    public IntPtr id;
+    public IntPtr version;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct MossIndexInfo
+{
+    public IntPtr id;
+    public IntPtr name;
+    public IntPtr version;
+    public IntPtr status;
+    public nuint doc_count;
+    public IntPtr created_at;
+    public IntPtr updated_at;
+    public MossModelRef model;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct MossJobStatusResponse
+{
+    public IntPtr job_id;
+    public IntPtr status;
+    public double progress;
+    public IntPtr current_phase;
+    public IntPtr error;
+    public IntPtr created_at;
+    public IntPtr updated_at;
+    public IntPtr completed_at;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct MossLoadIndexOptions
+{
+    [MarshalAs(UnmanagedType.I1)] public bool auto_refresh;
+    public ulong polling_interval_secs;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct MossQueryOptions
+{
+    public nuint top_k;
+    public float alpha;
+    public IntPtr filter_json;     // char*
+    public IntPtr embedding;       // float*
+    public nuint embedding_dim;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct MossSearchResultDoc
+{
+    public IntPtr id;
+    public IntPtr text;
+    public IntPtr metadata;        // MossMetadataEntry*
+    public nuint metadata_count;
+    public double score;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct MossSearchResult
+{
+    public IntPtr docs;            // MossSearchResultDoc*
+    public nuint doc_count;
+    public IntPtr query;
+    public IntPtr index_name;
+    public nuint time_taken_ms;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct MossRefreshResult
+{
+    public IntPtr index_name;
+    public IntPtr previous_updated_at;
+    public IntPtr new_updated_at;
+    [MarshalAs(UnmanagedType.I1)] public bool was_updated;
+}

--- a/sdks/dotnet/src/Moss/Models.cs
+++ b/sdks/dotnet/src/Moss/Models.cs
@@ -1,0 +1,135 @@
+using System.Collections.Generic;
+
+namespace Moss;
+
+/// <summary>A document to index or a document returned from the store.</summary>
+public sealed class DocumentInfo
+{
+    /// <summary>Stable, caller-supplied identifier for the document.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>The document text that gets embedded and searched.</summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>Optional string-to-string metadata used for filtering.</summary>
+    public IReadOnlyDictionary<string, string>? Metadata { get; set; }
+
+    /// <summary>Optional precomputed embedding. When null, Moss embeds the text.</summary>
+    public IReadOnlyList<float>? Embedding { get; set; }
+
+    public DocumentInfo() { }
+
+    public DocumentInfo(string id, string text,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        IReadOnlyList<float>? embedding = null)
+    {
+        Id = id;
+        Text = text;
+        Metadata = metadata;
+        Embedding = embedding;
+    }
+}
+
+/// <summary>Options controlling how documents are written.</summary>
+public sealed class MutationOptions
+{
+    /// <summary>When true, existing documents with the same id are overwritten.</summary>
+    public bool? Upsert { get; set; }
+}
+
+/// <summary>Result of a create/add/delete documents operation.</summary>
+public sealed class MutationResult
+{
+    public string JobId { get; init; } = string.Empty;
+    public string IndexName { get; init; } = string.Empty;
+    public int DocCount { get; init; }
+}
+
+/// <summary>Reference to the embedding model backing an index.</summary>
+public sealed class ModelRef
+{
+    public string Id { get; init; } = string.Empty;
+    public string? Version { get; init; }
+}
+
+/// <summary>Metadata describing an index.</summary>
+public sealed class IndexInfo
+{
+    public string Id { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string? Version { get; init; }
+    public string Status { get; init; } = string.Empty;
+    public int DocCount { get; init; }
+    public string? CreatedAt { get; init; }
+    public string? UpdatedAt { get; init; }
+    public ModelRef Model { get; init; } = new();
+}
+
+/// <summary>Status of an asynchronous indexing job.</summary>
+public sealed class JobStatusResponse
+{
+    public string JobId { get; init; } = string.Empty;
+    public string Status { get; init; } = string.Empty;
+    public double Progress { get; init; }
+    public string? CurrentPhase { get; init; }
+    public string? Error { get; init; }
+    public string CreatedAt { get; init; } = string.Empty;
+    public string UpdatedAt { get; init; } = string.Empty;
+    public string? CompletedAt { get; init; }
+}
+
+/// <summary>Options for loading an index into the local runtime.</summary>
+public sealed class LoadIndexOptions
+{
+    /// <summary>Poll the cloud for updates and hot-reload the local copy.</summary>
+    public bool AutoRefresh { get; set; }
+
+    /// <summary>Interval between refresh polls, in seconds.</summary>
+    public ulong PollingIntervalInSeconds { get; set; }
+}
+
+/// <summary>Options controlling a query.</summary>
+public sealed class QueryOptions
+{
+    /// <summary>Maximum number of results to return.</summary>
+    public int TopK { get; set; } = 10;
+
+    /// <summary>
+    /// Hybrid weighting between lexical and semantic scores, in [0, 1].
+    /// 0 = lexical only, 1 = semantic only.
+    /// </summary>
+    public float Alpha { get; set; } = 0.5f;
+
+    /// <summary>Optional metadata filter, expressed as a JSON string.</summary>
+    public string? FilterJson { get; set; }
+
+    /// <summary>Optional precomputed query embedding. When null, Moss embeds the query text.</summary>
+    public IReadOnlyList<float>? Embedding { get; set; }
+}
+
+/// <summary>A single scored document returned by a query.</summary>
+public sealed class ScoredDocument
+{
+    public string Id { get; init; } = string.Empty;
+    public string Text { get; init; } = string.Empty;
+    public IReadOnlyDictionary<string, string>? Metadata { get; init; }
+    public double Score { get; init; }
+}
+
+/// <summary>Result of a query.</summary>
+public sealed class SearchResult
+{
+    public IReadOnlyList<ScoredDocument> Docs { get; init; } = System.Array.Empty<ScoredDocument>();
+    public string Query { get; init; } = string.Empty;
+    public string? IndexName { get; init; }
+    public int TimeTakenMs { get; init; }
+}
+
+/// <summary>Result of refreshing a locally loaded index.</summary>
+public sealed class RefreshResult
+{
+    public string IndexName { get; init; } = string.Empty;
+    public string PreviousUpdatedAt { get; init; } = string.Empty;
+    public string NewUpdatedAt { get; init; } = string.Empty;
+    public bool WasUpdated { get; init; }
+}

--- a/sdks/dotnet/src/Moss/Moss.csproj
+++ b/sdks/dotnet/src/Moss/Moss.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Don't require an XML doc comment on every public member. -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+
+    <!-- NuGet package metadata -->
+    <PackageId>Moss</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Moss contributors</Authors>
+    <Description>Official .NET SDK for Moss — fast on-device retrieval. Wraps the native libmoss runtime for index management, hybrid search, and metadata filtering.</Description>
+    <PackageProjectUrl>https://github.com/usemoss/moss</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/usemoss/moss</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
+    <PackageTags>moss;vector-search;retrieval;rag;embeddings;semantic-search;on-device</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="\" Condition="Exists('../../README.md')" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Moss.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/sdks/dotnet/src/Moss/MossClient.cs
+++ b/sdks/dotnet/src/Moss/MossClient.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moss.Interop;
+
+namespace Moss;
+
+/// <summary>
+/// Client for Moss — fast on-device retrieval. Wraps the native <c>libmoss</c>
+/// runtime and exposes an async API for index management, hybrid search, and
+/// metadata filtering.
+/// </summary>
+/// <remarks>
+/// The client owns native resources; dispose it when finished. Native calls are
+/// blocking and are marshaled onto the thread pool; access to the underlying
+/// handle is serialized, so a single client may be shared across tasks.
+/// </remarks>
+public sealed class MossClient : IDisposable
+{
+    private readonly NativeClient _native;
+    private int _disposed;
+
+    /// <summary>Create a client for the given Moss project credentials.</summary>
+    /// <exception cref="ArgumentException">A credential is null or empty.</exception>
+    /// <exception cref="MossException">The native runtime failed to initialize.</exception>
+    public MossClient(string projectId, string projectKey)
+    {
+        if (string.IsNullOrEmpty(projectId)) throw new ArgumentException("projectId is required", nameof(projectId));
+        if (string.IsNullOrEmpty(projectKey)) throw new ArgumentException("projectKey is required", nameof(projectKey));
+        _native = new NativeClient(projectId, projectKey);
+    }
+
+    // ---- Management ------------------------------------------------------
+
+    /// <summary>Create a new index and enqueue the supplied documents for indexing.</summary>
+    public Task<MutationResult> CreateIndexAsync(
+        string name, IEnumerable<DocumentInfo> docs, string? modelId = null, CancellationToken cancellationToken = default)
+    {
+        RequireName(name);
+        IReadOnlyList<DocumentInfo> list = Materialize(docs, nameof(docs));
+        return Run(() => _native.CreateIndex(name, list, modelId), cancellationToken);
+    }
+
+    /// <summary>Add (or upsert) documents to an existing index.</summary>
+    public Task<MutationResult> AddDocsAsync(
+        string name, IEnumerable<DocumentInfo> docs, MutationOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        RequireName(name);
+        IReadOnlyList<DocumentInfo> list = Materialize(docs, nameof(docs));
+        return Run(() => _native.AddDocs(name, list, options), cancellationToken);
+    }
+
+    /// <summary>Delete documents from an index by id.</summary>
+    public Task<MutationResult> DeleteDocsAsync(
+        string name, IEnumerable<string> docIds, CancellationToken cancellationToken = default)
+    {
+        RequireName(name);
+        IReadOnlyList<string> ids = Materialize(docIds, nameof(docIds));
+        return Run(() => _native.DeleteDocs(name, ids), cancellationToken);
+    }
+
+    /// <summary>Fetch documents from an index by id.</summary>
+    public Task<IReadOnlyList<DocumentInfo>> GetDocsAsync(
+        string name, IEnumerable<string> docIds, CancellationToken cancellationToken = default)
+    {
+        RequireName(name);
+        IReadOnlyList<string> ids = Materialize(docIds, nameof(docIds));
+        return Run(() => _native.GetDocs(name, ids), cancellationToken);
+    }
+
+    /// <summary>Get metadata for a single index.</summary>
+    public Task<IndexInfo> GetIndexAsync(string name, CancellationToken cancellationToken = default)
+    {
+        RequireName(name);
+        return Run(() => _native.GetIndex(name), cancellationToken);
+    }
+
+    /// <summary>List all indexes in the project.</summary>
+    public Task<IReadOnlyList<IndexInfo>> ListIndexesAsync(CancellationToken cancellationToken = default)
+        => Run(() => _native.ListIndexes(), cancellationToken);
+
+    /// <summary>Delete an index. Returns true if an index was removed.</summary>
+    public Task<bool> DeleteIndexAsync(string name, CancellationToken cancellationToken = default)
+    {
+        RequireName(name);
+        return Run(() => _native.DeleteIndex(name), cancellationToken);
+    }
+
+    /// <summary>Poll the status of an asynchronous indexing job.</summary>
+    public Task<JobStatusResponse> GetJobStatusAsync(string jobId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(jobId)) throw new ArgumentException("jobId is required", nameof(jobId));
+        return Run(() => _native.GetJobStatus(jobId), cancellationToken);
+    }
+
+    // ---- Local runtime ---------------------------------------------------
+
+    /// <summary>Load an index into the local runtime so it can be queried on-device.</summary>
+    public Task<IndexInfo> LoadIndexAsync(
+        string name, LoadIndexOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        RequireName(name);
+        return Run(() => _native.LoadIndex(name, options), cancellationToken);
+    }
+
+    /// <summary>Unload a previously loaded index from the local runtime.</summary>
+    public Task UnloadIndexAsync(string name, CancellationToken cancellationToken = default)
+    {
+        RequireName(name);
+        return Run(() => { _native.UnloadIndex(name); return true; }, cancellationToken);
+    }
+
+    /// <summary>Refresh a locally loaded index against the latest cloud state.</summary>
+    public Task<RefreshResult> RefreshIndexAsync(string name, CancellationToken cancellationToken = default)
+    {
+        RequireName(name);
+        return Run(() => _native.RefreshIndex(name), cancellationToken);
+    }
+
+    /// <summary>Run a hybrid (lexical + semantic) query against a loaded index.</summary>
+    public Task<SearchResult> QueryAsync(
+        string name, string query, QueryOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        RequireName(name);
+        if (query is null) throw new ArgumentNullException(nameof(query));
+        QueryOptions opts = options ?? new QueryOptions();
+        return Run(() => _native.Query(name, query, opts), cancellationToken);
+    }
+
+    // ---- Helpers ---------------------------------------------------------
+
+    private Task<T> Run<T>(Func<T> action, CancellationToken cancellationToken)
+    {
+        ThrowIfDisposed();
+        return Task.Run(action, cancellationToken);
+    }
+
+    private static void RequireName(string name)
+    {
+        if (string.IsNullOrEmpty(name)) throw new ArgumentException("index name is required", nameof(name));
+    }
+
+    private static IReadOnlyList<T> Materialize<T>(IEnumerable<T> items, string paramName)
+    {
+        if (items is null) throw new ArgumentNullException(paramName);
+        return items as IReadOnlyList<T> ?? items.ToList();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (Volatile.Read(ref _disposed) != 0) throw new ObjectDisposedException(nameof(MossClient));
+    }
+
+    /// <summary>Release the native client and its resources.</summary>
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        _native.Dispose();
+    }
+}

--- a/sdks/dotnet/src/Moss/MossClient.cs
+++ b/sdks/dotnet/src/Moss/MossClient.cs
@@ -14,12 +14,15 @@ namespace Moss;
 /// </summary>
 /// <remarks>
 /// The client owns native resources; dispose it when finished. Native calls are
-/// blocking and are marshaled onto the thread pool; access to the underlying
-/// handle is serialized, so a single client may be shared across tasks.
+/// blocking and are marshaled onto the thread pool. Operations are serialized
+/// through a cancellable gate, so a single client may be shared across tasks.
+/// Inputs are snapshotted before work is queued, so callers may safely mutate
+/// their own collections after an async method returns.
 /// </remarks>
 public sealed class MossClient : IDisposable
 {
     private readonly NativeClient _native;
+    private readonly SemaphoreSlim _gate = new(1, 1);
     private int _disposed;
 
     /// <summary>Create a client for the given Moss project credentials.</summary>
@@ -39,8 +42,8 @@ public sealed class MossClient : IDisposable
         string name, IEnumerable<DocumentInfo> docs, string? modelId = null, CancellationToken cancellationToken = default)
     {
         RequireName(name);
-        IReadOnlyList<DocumentInfo> list = Materialize(docs, nameof(docs));
-        return Run(() => _native.CreateIndex(name, list, modelId), cancellationToken);
+        DocumentInfo[] snapshot = SnapshotDocs(docs);
+        return RunAsync(() => _native.CreateIndex(name, snapshot, modelId), cancellationToken);
     }
 
     /// <summary>Add (or upsert) documents to an existing index.</summary>
@@ -48,8 +51,9 @@ public sealed class MossClient : IDisposable
         string name, IEnumerable<DocumentInfo> docs, MutationOptions? options = null, CancellationToken cancellationToken = default)
     {
         RequireName(name);
-        IReadOnlyList<DocumentInfo> list = Materialize(docs, nameof(docs));
-        return Run(() => _native.AddDocs(name, list, options), cancellationToken);
+        DocumentInfo[] snapshot = SnapshotDocs(docs);
+        MutationOptions? optionsCopy = options is null ? null : new MutationOptions { Upsert = options.Upsert };
+        return RunAsync(() => _native.AddDocs(name, snapshot, optionsCopy), cancellationToken);
     }
 
     /// <summary>Delete documents from an index by id.</summary>
@@ -57,8 +61,8 @@ public sealed class MossClient : IDisposable
         string name, IEnumerable<string> docIds, CancellationToken cancellationToken = default)
     {
         RequireName(name);
-        IReadOnlyList<string> ids = Materialize(docIds, nameof(docIds));
-        return Run(() => _native.DeleteDocs(name, ids), cancellationToken);
+        string[] snapshot = SnapshotIds(docIds);
+        return RunAsync(() => _native.DeleteDocs(name, snapshot), cancellationToken);
     }
 
     /// <summary>Fetch documents from an index by id.</summary>
@@ -66,33 +70,33 @@ public sealed class MossClient : IDisposable
         string name, IEnumerable<string> docIds, CancellationToken cancellationToken = default)
     {
         RequireName(name);
-        IReadOnlyList<string> ids = Materialize(docIds, nameof(docIds));
-        return Run(() => _native.GetDocs(name, ids), cancellationToken);
+        string[] snapshot = SnapshotIds(docIds);
+        return RunAsync(() => _native.GetDocs(name, snapshot), cancellationToken);
     }
 
     /// <summary>Get metadata for a single index.</summary>
     public Task<IndexInfo> GetIndexAsync(string name, CancellationToken cancellationToken = default)
     {
         RequireName(name);
-        return Run(() => _native.GetIndex(name), cancellationToken);
+        return RunAsync(() => _native.GetIndex(name), cancellationToken);
     }
 
     /// <summary>List all indexes in the project.</summary>
     public Task<IReadOnlyList<IndexInfo>> ListIndexesAsync(CancellationToken cancellationToken = default)
-        => Run(() => _native.ListIndexes(), cancellationToken);
+        => RunAsync(() => _native.ListIndexes(), cancellationToken);
 
     /// <summary>Delete an index. Returns true if an index was removed.</summary>
     public Task<bool> DeleteIndexAsync(string name, CancellationToken cancellationToken = default)
     {
         RequireName(name);
-        return Run(() => _native.DeleteIndex(name), cancellationToken);
+        return RunAsync(() => _native.DeleteIndex(name), cancellationToken);
     }
 
     /// <summary>Poll the status of an asynchronous indexing job.</summary>
     public Task<JobStatusResponse> GetJobStatusAsync(string jobId, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(jobId)) throw new ArgumentException("jobId is required", nameof(jobId));
-        return Run(() => _native.GetJobStatus(jobId), cancellationToken);
+        return RunAsync(() => _native.GetJobStatus(jobId), cancellationToken);
     }
 
     // ---- Local runtime ---------------------------------------------------
@@ -102,21 +106,24 @@ public sealed class MossClient : IDisposable
         string name, LoadIndexOptions? options = null, CancellationToken cancellationToken = default)
     {
         RequireName(name);
-        return Run(() => _native.LoadIndex(name, options), cancellationToken);
+        LoadIndexOptions? optionsCopy = options is null
+            ? null
+            : new LoadIndexOptions { AutoRefresh = options.AutoRefresh, PollingIntervalInSeconds = options.PollingIntervalInSeconds };
+        return RunAsync(() => _native.LoadIndex(name, optionsCopy), cancellationToken);
     }
 
     /// <summary>Unload a previously loaded index from the local runtime.</summary>
     public Task UnloadIndexAsync(string name, CancellationToken cancellationToken = default)
     {
         RequireName(name);
-        return Run(() => { _native.UnloadIndex(name); return true; }, cancellationToken);
+        return RunAsync(() => { _native.UnloadIndex(name); return true; }, cancellationToken);
     }
 
     /// <summary>Refresh a locally loaded index against the latest cloud state.</summary>
     public Task<RefreshResult> RefreshIndexAsync(string name, CancellationToken cancellationToken = default)
     {
         RequireName(name);
-        return Run(() => _native.RefreshIndex(name), cancellationToken);
+        return RunAsync(() => _native.RefreshIndex(name), cancellationToken);
     }
 
     /// <summary>Run a hybrid (lexical + semantic) query against a loaded index.</summary>
@@ -125,27 +132,65 @@ public sealed class MossClient : IDisposable
     {
         RequireName(name);
         if (query is null) throw new ArgumentNullException(nameof(query));
-        QueryOptions opts = options ?? new QueryOptions();
-        return Run(() => _native.Query(name, query, opts), cancellationToken);
+        QueryOptions snapshot = SnapshotQuery(options ?? new QueryOptions());
+        return RunAsync(() => _native.Query(name, query, snapshot), cancellationToken);
     }
 
-    // ---- Helpers ---------------------------------------------------------
+    // ---- Serialization + cancellation ------------------------------------
 
-    private Task<T> Run<T>(Func<T> action, CancellationToken cancellationToken)
+    private async Task<T> RunAsync<T>(Func<T> action, CancellationToken cancellationToken)
     {
         ThrowIfDisposed();
-        return Task.Run(action, cancellationToken);
+        // WaitAsync honors cancellation while the operation is still queued, so a
+        // cancelled call never reaches the native layer.
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return await Task.Run(action, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
     }
+
+    // ---- Input snapshots -------------------------------------------------
+
+    private static DocumentInfo[] SnapshotDocs(IEnumerable<DocumentInfo> docs)
+    {
+        if (docs is null) throw new ArgumentNullException(nameof(docs));
+        return docs.Select(SnapshotDoc).ToArray();
+    }
+
+    internal static DocumentInfo SnapshotDoc(DocumentInfo doc)
+    {
+        if (doc is null) throw new ArgumentNullException(nameof(doc));
+        IReadOnlyDictionary<string, string>? metadata =
+            doc.Metadata is null ? null : new Dictionary<string, string>(doc.Metadata);
+        IReadOnlyList<float>? embedding = doc.Embedding?.ToArray();
+        return new DocumentInfo(doc.Id, doc.Text, metadata, embedding);
+    }
+
+    private static string[] SnapshotIds(IEnumerable<string> docIds)
+    {
+        if (docIds is null) throw new ArgumentNullException(nameof(docIds));
+        return docIds.ToArray();
+    }
+
+    internal static QueryOptions SnapshotQuery(QueryOptions options) => new()
+    {
+        TopK = options.TopK,
+        Alpha = options.Alpha,
+        FilterJson = options.FilterJson,
+        Embedding = options.Embedding?.ToArray(),
+    };
+
+    // ---- Helpers ---------------------------------------------------------
 
     private static void RequireName(string name)
     {
         if (string.IsNullOrEmpty(name)) throw new ArgumentException("index name is required", nameof(name));
-    }
-
-    private static IReadOnlyList<T> Materialize<T>(IEnumerable<T> items, string paramName)
-    {
-        if (items is null) throw new ArgumentNullException(paramName);
-        return items as IReadOnlyList<T> ?? items.ToList();
     }
 
     private void ThrowIfDisposed()
@@ -158,5 +203,6 @@ public sealed class MossClient : IDisposable
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
         _native.Dispose();
+        _gate.Dispose();
     }
 }

--- a/sdks/dotnet/src/Moss/MossClient.cs
+++ b/sdks/dotnet/src/Moss/MossClient.cs
@@ -166,16 +166,36 @@ public sealed class MossClient : IDisposable
     internal static DocumentInfo SnapshotDoc(DocumentInfo doc)
     {
         if (doc is null) throw new ArgumentNullException(nameof(doc));
-        IReadOnlyDictionary<string, string>? metadata =
-            doc.Metadata is null ? null : new Dictionary<string, string>(doc.Metadata);
+        // Required C-ABI strings must never be marshaled as NULL. Nullable
+        // annotations don't protect against nullable-disabled callers,
+        // deserialization, or `null!`, so validate explicitly.
+        if (doc.Id is null) throw new ArgumentException("DocumentInfo.Id must not be null", nameof(doc));
+        if (doc.Text is null) throw new ArgumentException("DocumentInfo.Text must not be null", nameof(doc));
+
+        IReadOnlyDictionary<string, string>? metadata = null;
+        if (doc.Metadata is not null)
+        {
+            var copy = new Dictionary<string, string>(doc.Metadata.Count);
+            foreach (KeyValuePair<string, string> kv in doc.Metadata)
+            {
+                if (kv.Key is null) throw new ArgumentException("DocumentInfo.Metadata keys must not be null", nameof(doc));
+                if (kv.Value is null) throw new ArgumentException("DocumentInfo.Metadata values must not be null", nameof(doc));
+                copy[kv.Key] = kv.Value;
+            }
+            metadata = copy;
+        }
+
         IReadOnlyList<float>? embedding = doc.Embedding?.ToArray();
         return new DocumentInfo(doc.Id, doc.Text, metadata, embedding);
     }
 
-    private static string[] SnapshotIds(IEnumerable<string> docIds)
+    internal static string[] SnapshotIds(IEnumerable<string> docIds)
     {
         if (docIds is null) throw new ArgumentNullException(nameof(docIds));
-        return docIds.ToArray();
+        string[] array = docIds.ToArray();
+        foreach (string id in array)
+            if (id is null) throw new ArgumentException("document ids must not be null", nameof(docIds));
+        return array;
     }
 
     internal static QueryOptions SnapshotQuery(QueryOptions options) => new()
@@ -203,6 +223,10 @@ public sealed class MossClient : IDisposable
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
         _native.Dispose();
-        _gate.Dispose();
+        // Intentionally not disposing _gate: an in-flight RunAsync still owns it
+        // and releases it in its finally block, so disposing here would race and
+        // surface a spurious ObjectDisposedException from Release(). SemaphoreSlim
+        // holds no unmanaged resource unless its AvailableWaitHandle is
+        // materialized, which this type never does.
     }
 }

--- a/sdks/dotnet/src/Moss/MossException.cs
+++ b/sdks/dotnet/src/Moss/MossException.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Moss;
+
+/// <summary>
+/// Thrown when a call into the native <c>libmoss</c> runtime fails.
+/// <see cref="Code"/> carries the raw <c>MossResult</c> status code and
+/// <see cref="Exception.Message"/> the human-readable message from
+/// <c>moss_last_error</c>.
+/// </summary>
+public sealed class MossException : Exception
+{
+    /// <summary>The raw <c>MossResult</c> status code returned by the native call.</summary>
+    public int Code { get; }
+
+    public MossException(int code, string message) : base(message)
+    {
+        Code = code;
+    }
+}

--- a/sdks/dotnet/tests/Moss.Tests/ClientValidationTests.cs
+++ b/sdks/dotnet/tests/Moss.Tests/ClientValidationTests.cs
@@ -1,0 +1,28 @@
+using System;
+using Moss;
+using Xunit;
+
+namespace Moss.Tests;
+
+/// <summary>
+/// Credential validation happens before any native call, so these run without
+/// libmoss present.
+/// </summary>
+public class ClientValidationTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Constructor_RejectsMissingProjectId(string? projectId)
+    {
+        Assert.Throws<ArgumentException>(() => new MossClient(projectId!, "key"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Constructor_RejectsMissingProjectKey(string? projectKey)
+    {
+        Assert.Throws<ArgumentException>(() => new MossClient("project", projectKey!));
+    }
+}

--- a/sdks/dotnet/tests/Moss.Tests/InteropTests.cs
+++ b/sdks/dotnet/tests/Moss.Tests/InteropTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Moss.Interop;
+using Xunit;
+
+namespace Moss.Tests;
+
+/// <summary>
+/// Exercises the marshaling helpers and native struct layouts. None of these
+/// call into libmoss, so they run anywhere.
+/// </summary>
+public class InteropTests
+{
+    [Theory]
+    [InlineData("hello")]
+    [InlineData("")]
+    [InlineData("café über 日本語 🚀")]
+    public void Utf8_RoundTrips(string value)
+    {
+        IntPtr p = Utf8.Alloc(value);
+        try
+        {
+            Assert.Equal(value, Utf8.Read(p));
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(p);
+        }
+    }
+
+    [Fact]
+    public void Utf8_NullPointerReadsAsEmptyOrNull()
+    {
+        Assert.Equal(string.Empty, Utf8.Read(IntPtr.Zero));
+        Assert.Null(Utf8.ReadOptional(IntPtr.Zero));
+    }
+
+    [Fact]
+    public void Utf8_AllocNullReturnsZero()
+    {
+        Assert.Equal(IntPtr.Zero, Utf8.Alloc(null));
+    }
+
+    [Fact]
+    public void NativeArena_FloatArrayRoundTrips()
+    {
+        var values = new[] { 1.5f, -2.25f, 3.0f };
+        using var arena = new NativeArena();
+        IntPtr p = arena.FloatArray(values);
+        Assert.NotEqual(IntPtr.Zero, p);
+
+        var read = new float[values.Length];
+        Marshal.Copy(p, read, 0, values.Length);
+        Assert.Equal(values, read);
+    }
+
+    [Fact]
+    public void NativeArena_EmptyCollectionsReturnZero()
+    {
+        using var arena = new NativeArena();
+        Assert.Equal(IntPtr.Zero, arena.FloatArray(Array.Empty<float>()));
+        Assert.Equal(IntPtr.Zero, arena.StringArray(Array.Empty<string>()));
+        Assert.Equal(IntPtr.Zero, arena.FloatArray(null));
+    }
+
+    [Fact]
+    public void NativeArena_StringArrayWritesReadablePointers()
+    {
+        var values = new[] { "alpha", "beta" };
+        using var arena = new NativeArena();
+        IntPtr block = arena.StringArray(values);
+        Assert.NotEqual(IntPtr.Zero, block);
+
+        for (int i = 0; i < values.Length; i++)
+        {
+            IntPtr strPtr = Marshal.ReadIntPtr(block, i * IntPtr.Size);
+            Assert.Equal(values[i], Utf8.Read(strPtr));
+        }
+    }
+
+    [Fact]
+    public void NativeArena_DisposeIsIdempotent()
+    {
+        var arena = new NativeArena();
+        arena.String("x");
+        arena.Dispose();
+        arena.Dispose(); // must not throw
+    }
+
+    // Layout sanity: sizes are pointer-derived, so these catch accidental field
+    // reordering or type changes in the ABI mirror structs.
+    [Fact]
+    public void NativeStructs_HaveExpectedSizes()
+    {
+        Assert.Equal(2 * IntPtr.Size, Marshal.SizeOf<MossMetadataEntry>());
+        Assert.Equal(2 * IntPtr.Size, Marshal.SizeOf<MossModelRef>());
+        // 4 pointers + 2 nuint
+        Assert.Equal(6 * IntPtr.Size, Marshal.SizeOf<MossDocumentInfo>());
+    }
+}

--- a/sdks/dotnet/tests/Moss.Tests/ModelTests.cs
+++ b/sdks/dotnet/tests/Moss.Tests/ModelTests.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using Moss;
+using Xunit;
+
+namespace Moss.Tests;
+
+public class ModelTests
+{
+    [Fact]
+    public void QueryOptions_HasSensibleDefaults()
+    {
+        var opts = new QueryOptions();
+        Assert.Equal(10, opts.TopK);
+        Assert.Equal(0.5f, opts.Alpha);
+        Assert.Null(opts.FilterJson);
+        Assert.Null(opts.Embedding);
+    }
+
+    [Fact]
+    public void DocumentInfo_ConstructorSetsFields()
+    {
+        var meta = new Dictionary<string, string> { ["lang"] = "en" };
+        var embedding = new[] { 0.1f, 0.2f };
+        var doc = new DocumentInfo("doc-1", "hello world", meta, embedding);
+
+        Assert.Equal("doc-1", doc.Id);
+        Assert.Equal("hello world", doc.Text);
+        Assert.Same(meta, doc.Metadata);
+        Assert.Same(embedding, doc.Embedding);
+    }
+
+    [Fact]
+    public void DocumentInfo_DefaultsAreEmptyNotNull()
+    {
+        var doc = new DocumentInfo();
+        Assert.Equal(string.Empty, doc.Id);
+        Assert.Equal(string.Empty, doc.Text);
+        Assert.Null(doc.Metadata);
+        Assert.Null(doc.Embedding);
+    }
+
+    [Fact]
+    public void SearchResult_DefaultsToEmptyDocs()
+    {
+        var result = new SearchResult();
+        Assert.NotNull(result.Docs);
+        Assert.Empty(result.Docs);
+    }
+}

--- a/sdks/dotnet/tests/Moss.Tests/Moss.Tests.csproj
+++ b/sdks/dotnet/tests/Moss.Tests/Moss.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Moss/Moss.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sdks/dotnet/tests/Moss.Tests/SnapshotTests.cs
+++ b/sdks/dotnet/tests/Moss.Tests/SnapshotTests.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using Moss;
+using Xunit;
+
+namespace Moss.Tests;
+
+/// <summary>
+/// Verifies that inputs are defensively copied, so a caller mutating their own
+/// collections after an async call cannot change what gets sent to native code.
+/// </summary>
+public class SnapshotTests
+{
+    [Fact]
+    public void SnapshotDoc_DeepCopiesMetadataAndEmbedding()
+    {
+        var meta = new Dictionary<string, string> { ["k"] = "v" };
+        var embedding = new List<float> { 1f, 2f };
+        var doc = new DocumentInfo("1", "text", meta, embedding);
+
+        DocumentInfo snap = MossClient.SnapshotDoc(doc);
+
+        // Mutate the caller's originals after snapshotting.
+        meta["k"] = "changed";
+        embedding[0] = 9f;
+
+        Assert.Equal("v", snap.Metadata!["k"]);
+        Assert.Equal(1f, snap.Embedding![0]);
+        Assert.NotSame(doc.Metadata, snap.Metadata);
+        Assert.NotSame(doc.Embedding, snap.Embedding);
+    }
+
+    [Fact]
+    public void SnapshotDoc_PreservesNullMetadataAndEmbedding()
+    {
+        DocumentInfo snap = MossClient.SnapshotDoc(new DocumentInfo("1", "text"));
+        Assert.Null(snap.Metadata);
+        Assert.Null(snap.Embedding);
+    }
+
+    [Fact]
+    public void SnapshotQuery_CopiesEmbeddingAndScalars()
+    {
+        var embedding = new List<float> { 0.5f };
+        var opts = new QueryOptions { TopK = 3, Alpha = 0.2f, FilterJson = "{}", Embedding = embedding };
+
+        QueryOptions snap = MossClient.SnapshotQuery(opts);
+        embedding[0] = 9f;
+
+        Assert.Equal(3, snap.TopK);
+        Assert.Equal(0.2f, snap.Alpha);
+        Assert.Equal("{}", snap.FilterJson);
+        Assert.Equal(0.5f, snap.Embedding![0]);
+    }
+}

--- a/sdks/dotnet/tests/Moss.Tests/SnapshotTests.cs
+++ b/sdks/dotnet/tests/Moss.Tests/SnapshotTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Moss;
 using Xunit;
@@ -50,5 +51,30 @@ public class SnapshotTests
         Assert.Equal(0.2f, snap.Alpha);
         Assert.Equal("{}", snap.FilterJson);
         Assert.Equal(0.5f, snap.Embedding![0]);
+    }
+
+    [Fact]
+    public void SnapshotDoc_ThrowsOnNullId()
+    {
+        Assert.Throws<ArgumentException>(() => MossClient.SnapshotDoc(new DocumentInfo(null!, "text")));
+    }
+
+    [Fact]
+    public void SnapshotDoc_ThrowsOnNullText()
+    {
+        Assert.Throws<ArgumentException>(() => MossClient.SnapshotDoc(new DocumentInfo("1", null!)));
+    }
+
+    [Fact]
+    public void SnapshotDoc_ThrowsOnNullMetadataValue()
+    {
+        var meta = new Dictionary<string, string> { ["k"] = null! };
+        Assert.Throws<ArgumentException>(() => MossClient.SnapshotDoc(new DocumentInfo("1", "text", meta)));
+    }
+
+    [Fact]
+    public void SnapshotIds_ThrowsOnNullEntry()
+    {
+        Assert.Throws<ArgumentException>(() => MossClient.SnapshotIds(new[] { "a", null! }));
     }
 }


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [x] I have updated the documentation (if applicable). — added sdks/dotnet/README.md
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Description

Adds a .NET SDK for Moss under `sdks/dotnet/`, following the same two-layer
structure as the existing SDKs: an idiomatic async client (`src/Moss`) over a
P/Invoke interop layer (`src/Moss/Interop`) that binds the native `libmoss`
C ABI — the same surface the Go bindings use via cgo.

Covers the issue scope: index management (create/get/list/delete), document
operations (add/delete/get), local runtime (load/unload/refresh), hybrid
search (`QueryAsync`), and metadata filtering. Failures surface as
`MossException` carrying the native status code and `moss_last_error` message.

- Target framework: net8.0 (async, Task-based API)
- 18 unit tests covering models, argument validation, UTF-8 marshaling, native
  buffer packing, and ABI struct layouts — all run without the native library
- README with quickstart, architecture, and build/test instructions

Note: the compiled `libmoss` runtime is required only to run queries, not to
build or unit-test the SDK.

Fixes #431

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/usemoss/moss/pull/460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

