### PR TITLE
build(deps): update @ai-sdk/provider-utils to 5.0.12

### DIFF
--- a/packages/vercel-sdk/package-lock.json
+++ b/packages/vercel-sdk/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@moss-dev/moss": "1.3.1",
         "@types/node": "22.13.14",
-        "ai": "7.0.8",
+        "ai": "7.0.35",
         "tsup": "8.4.0",
         "typescript": "5.8.2",
         "vitest": "3.2.6",
@@ -24,14 +24,14 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.6.tgz",
-      "integrity": "sha512-8GjssUxXeTd8tst2fYXNOFbtNNZFv3sG7aq7wKnQYrU2eB3JFR7np6o4F3Snp/fy/rJZSeH28LvjSWq5wkdL8Q==",
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.27.tgz",
+      "integrity": "sha512-gqTMvV0N8/JirIZ3OzwjSZRYxzwZu/PeOFCKb8NB9fstWH39tI+L6CkeMNVou5/HCKEYAw6RCOHW59Vhquv8vA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "4.0.1",
-        "@ai-sdk/provider-utils": "5.0.2",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.12",
         "@vercel/oidc": "3.2.0"
       },
       "engines": {
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.1.tgz",
-      "integrity": "sha512-6p3C/vGqVIjcptBu1DnVd/BZJ2wWmV9TUv9192vT6ZvT9KNED8EwRTqyqFpoQZKgSbMDSvBSq3dqR524Nt/Crw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
+      "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -55,13 +55,13 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.2.tgz",
-      "integrity": "sha512-EcmdjJb7yggsZPCbS3MFBpvAUnKaPW+QvanU5GzF00XCq0bqqAmvJ3MN19ejlmOETbW8sJNiq6qam48wTcbUNw==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.12.tgz",
+      "integrity": "sha512-bbhlOgHeYwrIGheLkM6fhS8hVger8uFPmcOLg+kxc9EFh7y30XYorWhthlYAgpadO3SJhFZrIcEknN7qEqEVvA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "4.0.1",
+        "@ai-sdk/provider": "4.0.3",
         "@standard-schema/spec": "^1.1.0",
         "@workflow/serde": "4.1.0",
         "eventsource-parser": "^3.0.8"
@@ -1191,15 +1191,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/ai": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.8.tgz",
-      "integrity": "sha512-vTEKl6fDBZ2IxBXTRaZOajf9W2Ev57Ju8iKtUvqlmDk8Z9BrEP4c22SWJsg1RcWHSFmJMSBa/s5dlUBHUq3YwA==",
+      "version": "7.0.35",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.35.tgz",
+      "integrity": "sha512-en8xnTNoVJVWk/Y7TsXuTkc463ehuQUqrofjPs/TAd4O3h14QKmq4rWWG3/Eb05r3f2MvvxfCuXNnvhTdzyoTg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "4.0.6",
-        "@ai-sdk/provider": "4.0.1",
-        "@ai-sdk/provider-utils": "5.0.2"
+        "@ai-sdk/gateway": "4.0.27",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.12"
       },
       "engines": {
         "node": ">=22"

--- a/packages/vercel-sdk/package.json
+++ b/packages/vercel-sdk/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@moss-dev/moss": "1.3.1",
     "@types/node": "22.13.14",
-    "ai": "7.0.8",
+    "ai": "7.0.35",
     "tsup": "8.4.0",
     "typescript": "5.8.2",
     "vitest": "3.2.6",


### PR DESCRIPTION
## Summary

- update the Vercel AI SDK development dependency from `ai` 7.0.8 to 7.0.35
- refresh its lockfile dependency chain so `@ai-sdk/provider-utils` moves from 5.0.2 to 5.0.12
- keep the change scoped to `packages/vercel-sdk`

## Why

`@ai-sdk/provider-utils` is pinned transitively by `ai`, so updating the parent patch release is required to resolve the latest provider-utils version without adding an unnecessary direct dependency or lockfile override.

Fixes #421

## Validation

- `npm run typecheck`
- `npm test` (26 tests passed)
- `npm run build`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/usemoss/moss/pull/464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

