### PR TITLE
build(deps): bump lodash to 4.18.1 in n8n-nodes-moss

### DIFF
--- a/packages/n8n-nodes-moss/package-lock.json
+++ b/packages/n8n-nodes-moss/package-lock.json
@@ -1962,9 +1962,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/packages/n8n-nodes-moss/package.json
+++ b/packages/n8n-nodes-moss/package.json
@@ -54,5 +54,8 @@
 	},
 	"peerDependencies": {
 		"n8n-workflow": "*"
+	},
+	"overrides": {
+		"lodash": "^4.18.1"
 	}
 }


### PR DESCRIPTION
## Pull Request Checklist

Please ensure that your PR meets the following requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [ ] I have updated the documentation (if applicable).
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Description

Bumps `lodash` from `4.17.23` to the patched `4.18.1` release in `packages/n8n-nodes-moss`, the only project in the repo still resolving a vulnerable lodash version. `lodash` is pulled in transitively (dev-only) via `n8n-workflow` → `@n8n/expression-runtime`, which pins an exact `4.17.23`, so a top-level `overrides` entry was added to `package.json` (matching the pattern already used at the repo root and in `vitepress-plugin-moss`) to force resolution to `^4.18.1`, then `package-lock.json` was regenerated via `npm install`.

4.18.0/4.18.1 fix a prototype-pollution issue in `_.unset`/`_.omit` (GHSA-f23m-r3pf-42rh) and a code-injection issue in `_.template` (GHSA-r5fr-rjxr-66jc, CVE-2026-4800), plus a follow-up bugfix. Other lockfiles in the repo that reference lodash (`apps/livekit-moss-vercel/agent-react`, `apps/moss-vscode`, `sdks/javascript/sdk`) were already on `4.18.1`; the rest only contain unrelated standalone packages (`lodash.merge`, `lodash.sortby`, etc.) unaffected by this bump.

Fixes #467

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update fill it accordingly


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/usemoss/moss/pull/474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

