### PR TITLE
ci: pin ruff to 0.15.22 to unbreak main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ruff mypy
+        # Pin ruff: 0.16.0 (released 2026-07-23) turned on a large new rule
+        # surface that flags ~460 pre-existing findings across the repo and
+        # breaks CI on every PR. Pinned to the last green version; bump only
+        # once those findings are addressed (see python-sdk-test for the twin).
+        pip install ruff==0.15.22 mypy
         if [ -f examples/python/requirements.txt ]; then pip install -r examples/python/requirements.txt; fi
     - name: Lint with ruff
       run: ruff check . --extend-exclude '**/*.ipynb'
@@ -91,7 +95,7 @@ jobs:
     - name: Lint with ruff
       working-directory: sdks/python/sdk
       run: |
-        pip install ruff
+        pip install ruff==0.15.22  # pinned; see python-lint job for why (ruff 0.16.0 regression)
         ruff check src/ tests/
     - name: Type check with mypy
       working-directory: sdks/python/sdk


### PR DESCRIPTION
## Problem

`main` and every open PR are currently red on the required checks **`python-lint`** and **`python-sdk-test`** (all Python versions).

Root cause is a floating linter, not any code change:

- Both jobs install ruff **unpinned** (`pip install ruff` in the `python-lint` job and again in the `python-sdk-test` "Lint with ruff" step).
- **ruff 0.16.0** was published `2026-07-23T19:10:46Z`. The next `main` run (`378d72b`/`c3e6ddb`) executed at `19:14Z` — ~4 minutes later — and picked it up.
- 0.16.0 turned on a large new default rule surface, which flags **~460 pre-existing findings** repo-wide: `UP045` (120), `I001` (84), `UP006` (79), `BLE001` (71), `UP035` (31), plus `S110`, `RUF*`, `SIM*`, `DTZ005`, etc.

The last green `main` runs (01:00Z the same day) used **ruff 0.15.22**. **No `.py` changed** between those and the first red run (only `.yml` / lockfiles), so this is purely the ruff version.

## Fix

Pin both installs to `ruff==0.15.22` (the last green version), with a comment explaining why.

## Verification (local, on current `main`)

- `ruff==0.15.22 check . --extend-exclude '**/*.ipynb'` -> **All checks passed!**
- `ruff==0.15.22 check src/ tests/` in `sdks/python/sdk` -> **All checks passed!**

## Note

This is a deliberate stopgap to unblock merges immediately. The 460 findings under 0.16.0 are real lint signal; a follow-up can address (or selectively `ignore`) them and then bump the pin. Filing/So they don't get lost, happy to open that follow-up.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/usemoss/moss/pull/480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

