### PR TITLE
build(deps): roll tar forward to 7.5.21

### DIFF
--- a/apps/livekit-moss-vercel/agent-react/pnpm-lock.yaml
+++ b/apps/livekit-moss-vercel/agent-react/pnpm-lock.yaml
@@ -2416,8 +2416,8 @@ packages:
     resolution: {integrity: sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==}
     engines: {node: '>=6'}
 
-  tar@7.5.13:
-    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+  tar@7.5.21:
+    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.13:
@@ -3208,7 +3208,7 @@ snapshots:
   '@tailwindcss/oxide@4.1.13':
     dependencies:
       detect-libc: 2.1.2
-      tar: 7.5.13
+      tar: 7.5.21
     optionalDependencies:
       '@tailwindcss/oxide-android-arm64': 4.1.13
       '@tailwindcss/oxide-darwin-arm64': 4.1.13
@@ -4875,7 +4875,7 @@ snapshots:
 
   tapable@2.2.3: {}
 
-  tar@7.5.13:
+  tar@7.5.21:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/moss-live-labs/examples/image-search/setup-js/package.json
+++ b/moss-live-labs/examples/image-search/setup-js/package.json
@@ -41,7 +41,7 @@
   ],
   "overrides": {
     "onnxruntime-node": {
-      "tar": "^7.5.13"
+      "tar": "^7.5.21"
     },
     "onnxruntime-web": {
       "protobufjs": "^7.5.5"


### PR DESCRIPTION
## Pull Request Checklist

Please ensure that your PR meets the following requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [x] I have updated the documentation (if applicable). — N/A, dependency bump
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works. — N/A, lockfile/pin bump
- [ ] New and existing unit tests pass locally with my changes. — no test suite in the touched examples; verification notes below

## Description

Rolls `tar` forward to 7.5.21 (latest), per #475:

- `apps/livekit-moss-vercel/agent-react/pnpm-lock.yaml`: bumps the locked transitive `tar` 7.5.13 → 7.5.21 (pulled in via `@tailwindcss/oxide`, whose `^7.4.3` range allows it). Lockfile-only; no manifest changes.
- `moss-live-labs/examples/image-search/setup-js/package.json`: raises the `onnxruntime-node` override pin `^7.5.13` → `^7.5.21` to match. Note: this override currently has no effect on the resolved tree (`onnxruntime-node` is not in this example's current dependency graph), so its lockfile is unchanged.

How verified:

- `pnpm install` (pnpm 9.15.9, matching the app's `packageManager` pin) completes cleanly against the updated lockfile.
- I attempted `pnpm build` of agent-react for full verification, but it fails identically on unmodified `main` in my environment (Windows; module-resolution errors unrelated to this change) — so no build regression is attributable to this change, but flagging honestly that I could not build-verify locally.

Fixes #475


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/usemoss/moss/pull/481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

