### PR TITLE
chore(deps): bump langchain to 1.3.14 in daytona cookbook lockfile

### DIFF
--- a/examples/cookbook/daytona/uv.lock
+++ b/examples/cookbook/daytona/uv.lock
@@ -771,16 +771,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.9"
+version = "1.3.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/7c/651d0dc4913a7a892156c03dd343b99cfe19ee729e6911ab1f4fe7567b8b/langchain-1.3.9.tar.gz", hash = "sha256:9b14ef0db9ef314299ded858b22ca2a40b8f1b05c8c9cb6b82d53a53075fef00", size = 631514, upload-time = "2026-06-12T16:53:27.083Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/68/a6dbad9c22df4087a0f9e79ddd46226c442b30128bfeee538d5889492a73/langchain-1.3.14.tar.gz", hash = "sha256:1b6696c72ba3bbbce54d745e0180742c9f6ece8bbc59ed5a46c3e20b9a435929", size = 645181, upload-time = "2026-07-16T13:28:18.29Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/55/3481619d21b9bdfbfda8680fba5cfc6cfe926789b8eaaad95353078cfa20/langchain-1.3.9-py3-none-any.whl", hash = "sha256:4af49ad1095799e4408b489fb79d4b8b49292453618b202d8a697fca59bb6871", size = 132873, upload-time = "2026-06-12T16:53:25.489Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ec/0f942e78a621f8e3162ff1ed24284f469aaf51fb4607ee5831c626f2b2bc/langchain-1.3.14-py3-none-any.whl", hash = "sha256:4d10dbe91005952cddd56d0dc77aa108964da6bae90ab20063653957e901f782", size = 139560, upload-time = "2026-07-16T13:28:16.498Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Pull Request Checklist

Please ensure that your PR meets the following requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [ ] I have updated the documentation (if applicable). — N/A, lockfile-only change
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works. — N/A, dependency bump
- [ ] New and existing unit tests pass locally with my changes. — no test suite in this cookbook; verification notes below

## Description

Bumps the locked `langchain` from 1.3.9 to 1.3.14 (latest release) in `examples/cookbook/daytona/uv.lock`, following the pattern of #442. The `pyproject.toml` constraint (`langchain>=1.3.9`) already allows it, so this is a lockfile-only change (3 lines). No other packages moved; the existing `langchain-core` 1.5.0 pin satisfies 1.3.14's requirements.

How verified: `uv lock --upgrade-package langchain` resolved cleanly (88 packages); `uv sync` builds the full environment on Python 3.12 and `import langchain` / `import langchain_core` succeed, with `langchain.__version__` reporting 1.3.14.

Fixes #425


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/usemoss/moss/pull/482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

