### PR TITLE
chore(deps): bump @hono/node-server to 1.19.15

### DIFF
--- a/examples/cookbook/mastra/package-lock.json
+++ b/examples/cookbook/mastra/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@mastra/core": "^1.26.0",
-        "@moss-dev/moss": "*",
+        "@moss-dev/moss": "latest",
         "dotenv": "^16.4.5",
         "zod": "^3.23.8"
       },
@@ -623,9 +623,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.15",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
+      "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"

--- a/examples/cookbook/mastra/package-lock.json
+++ b/examples/cookbook/mastra/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@mastra/core": "^1.26.0",
-        "@moss-dev/moss": "latest",
+        "@moss-dev/moss": "*",
         "dotenv": "^16.4.5",
         "zod": "^3.23.8"
       },

--- a/packages/mastra-moss/package-lock.json
+++ b/packages/mastra-moss/package-lock.json
@@ -638,9 +638,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.15",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
+      "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Pull Request Checklist

- [x] I have read the CONTRIBUTING (CONTRIBUTING.md) guide.
- [ ] I have updated the documentation (if applicable). not applicable, no user-facing docs affected
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.  not applicable, this is a dependency version bump; existing tests cover behavior
- [x] New and existing unit tests pass locally with my changes.

Description

Bumps @hono/node-server to its latest release (1.19.14 → 1.19.15) in the two package-lock.json files that reference it (packages/mastra-moss and examples/cookbook/mastra), where it's pulled in transitively via @modelcontextprotocol/sdk (a nested dependency of @mastra/core). No package.json changes were needed since @hono/node-server isn't declared directly anywhere in the repo. Note: @modelcontextprotocol/sdk@1.29.0 (itself already latest) constrains the dependency to ^1.19.9, so 1.19.15 is the newest version currently resolvable within that range moving to the v2 line would require an upstream update to @modelcontextprotocol/sdk first.

Fixes #476

Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/usemoss/moss/pull/487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

