### PR TITLE
fix(sdk/js): stop dropping the metadata filter on cloud fallback queries

### DIFF
--- a/sdks/javascript/sdk/src/client/internalMossClient.ts
+++ b/sdks/javascript/sdk/src/client/internalMossClient.ts
@@ -223,6 +223,17 @@ export class InternalMossClient {
       return this.indexManager.queryText(indexName, query, topK, alpha, options?.filter);
     }
 
+    if (options?.filter !== undefined) {
+      throw new Error(
+        `The filter query option requires a locally loaded index; call loadIndex('${indexName}') first`,
+      );
+    }
+    if (options?.alpha !== undefined) {
+      console.warn(
+        `moss: alpha is ignored for cloud queries on '${indexName}'; call loadIndex('${indexName}') to control hybrid weighting`,
+      );
+    }
+
     const topK = options?.topK ?? 5;
     const queryEmbedding = options?.embedding;
     return this.cloudClient.makeQueryRequest<SearchResult>(

--- a/sdks/javascript/sdk/src/models.ts
+++ b/sdks/javascript/sdk/src/models.ts
@@ -160,12 +160,14 @@ export interface QueryOptions {
 
   /**
    * Weight for hybrid search fusion (0.0 to 1.0).
+   * Only applies to locally loaded indexes; cloud queries ignore it and warn.
    * @default 0.8
    */
   alpha?: number;
 
   /**
    * Optional metadata filter to narrow query results.
+   * Requires a locally loaded index; cloud queries throw instead of returning unfiltered results.
    *
    * Supports field conditions and logical operators:
    * - Field: `{ field: "city", condition: { $eq: "NYC" } }`

--- a/sdks/javascript/sdk/test/mossClient.test.ts
+++ b/sdks/javascript/sdk/test/mossClient.test.ts
@@ -25,32 +25,38 @@ const mockIndexLoadQueryModel = vi.fn();
 const mockIndexGetIndexInfo = vi.fn();
 
 vi.mock("../src/utils/cloudApiClient", () => ({
-  CloudApiClient: vi.fn().mockImplementation(() => ({
-    makeQueryRequest: mockMakeQueryRequest,
-  })),
+  CloudApiClient: vi.fn(function () {
+    return {
+      makeQueryRequest: mockMakeQueryRequest,
+    };
+  }),
 }));
 
 vi.mock("@moss-dev/moss-core", () => ({
-  ManageClient: vi.fn().mockImplementation(() => ({
-    createIndex: mockManageCreateIndex,
-    addDocs: mockManageAddDocs,
-    deleteDocs: mockManageDeleteDocs,
-    getJobStatus: mockManageGetJobStatus,
-    getIndex: mockManageGetIndex,
-    listIndexes: mockManageListIndexes,
-    deleteIndex: mockManageDeleteIndex,
-    getDocs: mockManageGetDocs,
-  })),
-  IndexManager: vi.fn().mockImplementation(() => ({
-    loadIndex: mockIndexLoadIndex,
-    unloadIndex: vi.fn(),
-    hasIndex: mockIndexHasIndex,
-    query: mockIndexQuery,
-    queryText: mockIndexQueryText,
-    loadQueryModel: mockIndexLoadQueryModel,
-    refreshIndex: vi.fn(),
-    getIndexInfo: mockIndexGetIndexInfo,
-  })),
+  ManageClient: vi.fn(function () {
+    return {
+      createIndex: mockManageCreateIndex,
+      addDocs: mockManageAddDocs,
+      deleteDocs: mockManageDeleteDocs,
+      getJobStatus: mockManageGetJobStatus,
+      getIndex: mockManageGetIndex,
+      listIndexes: mockManageListIndexes,
+      deleteIndex: mockManageDeleteIndex,
+      getDocs: mockManageGetDocs,
+    };
+  }),
+  IndexManager: vi.fn(function () {
+    return {
+      loadIndex: mockIndexLoadIndex,
+      unloadIndex: vi.fn(),
+      hasIndex: mockIndexHasIndex,
+      query: mockIndexQuery,
+      queryText: mockIndexQueryText,
+      loadQueryModel: mockIndexLoadQueryModel,
+      refreshIndex: vi.fn(),
+      getIndexInfo: mockIndexGetIndexInfo,
+    };
+  }),
   JobStatus: {
     PendingUpload: "pending_upload",
     Uploading: "uploading",
@@ -207,6 +213,43 @@ describe("InternalMossClient", () => {
       5,
       undefined,
     );
+  });
+
+  it("query rejects a filter on the cloud path instead of dropping it", async () => {
+    mockIndexHasIndex.mockResolvedValueOnce(false);
+    const client = new InternalMossClient("proj", "key");
+
+    await expect(
+      client.query("idx", "hello", {
+        filter: { field: "tenant", condition: { $eq: "acme" } },
+      }),
+    ).rejects.toThrow(
+      /filter query option requires a locally loaded index; call loadIndex\('idx'\) first/,
+    );
+    expect(mockMakeQueryRequest).not.toHaveBeenCalled();
+  });
+
+  it("query warns about alpha on the cloud path but still returns results", async () => {
+    mockIndexHasIndex.mockResolvedValueOnce(false);
+    mockMakeQueryRequest.mockResolvedValueOnce({ docs: [{ id: "cloud" }] });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const client = new InternalMossClient("proj", "key");
+
+    await expect(client.query("idx", "hello", { alpha: 0 })).resolves.toEqual({
+      docs: [{ id: "cloud" }],
+    });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("alpha is ignored for cloud queries"));
+    warn.mockRestore();
+  });
+
+  it("query still allows topK and embedding on the cloud path", async () => {
+    mockIndexHasIndex.mockResolvedValueOnce(false);
+    mockMakeQueryRequest.mockResolvedValueOnce({ docs: [] });
+    const client = new InternalMossClient("proj", "key");
+
+    await client.query("idx", "hello", { topK: 3, embedding: [0.1] });
+
+    expect(mockMakeQueryRequest).toHaveBeenCalledWith("idx", "hello", 3, [0.1]);
   });
 });
 


### PR DESCRIPTION
when an index isn't loaded, `query()` fell back to the cloud api and never forwarded `filter`, so a scoped query silently returned unfiltered results. now throws, like the go sdk and the cli already do. `alpha` only warns, since mastra-moss and next-js pass it without loading. test mocks fixed so the suite runs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/usemoss/moss/pull/489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

