### PR TITLE
ci: run the packages/* pytest suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,59 @@ jobs:
       working-directory: sdks/python/sdk
       run: pytest tests/ -v
 
+  # Runs the pytest suites under packages/*. Before this job they executed
+  # nowhere: ci.yml only covered sdks/python/sdk and the langchain cookbook, and
+  # the publish-*.yml workflows only smoke-test `import <package>`.
+  #
+  # Python 3.12 is deliberate, not arbitrary. Several connector tests patch
+  # `moss_connector_<x>.ingest.MossClient`, but each package's __init__ does
+  # `from .ingest import ingest`, shadowing the submodule with the function.
+  # unittest.mock resolves that target on 3.12+ and raises AttributeError on
+  # 3.10/3.11, so a wider matrix would fail on a test-only issue. Widen it once
+  # those patch targets stop relying on the shadowed name.
+  #
+  # Not covered: packages/moss-cli — `moss completions bash|zsh` is broken
+  # (commands/completions.py exits 1 even when its fallback import succeeds) and
+  # tests/test_completions.py fails accordingly. Add moss-cli here with that fix.
+  python-package-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - agora-moss
+          - dspy-moss
+          - moss-data-connector/moss-connector-dynamodb
+          - moss-data-connector/moss-connector-huggingface
+          - moss-data-connector/moss-connector-mongodb
+          - moss-data-connector/moss-connector-mysql
+          - moss-data-connector/moss-connector-s3
+          - moss-data-connector/moss-connector-sqlite
+          - moss-data-connector/moss-connector-supabase
+          - sim-moss
+          - strands-agents-moss
+          - ten-moss
+          - vapi-moss
+    name: python-package-test (${{ matrix.package }})
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install uv
+      run: pip install uv
+    - name: Install package with dev dependencies
+      working-directory: packages/${{ matrix.package }}
+      # --all-extras covers the [project.optional-dependencies] convention used
+      # by the connectors; uv installs the default [dependency-groups] dev group
+      # used by the rest. pytest is added at run time because some packages
+      # (e.g. strands-agents-moss) don't declare it themselves.
+      run: uv sync --all-extras --python 3.12
+    - name: Run tests
+      working-directory: packages/${{ matrix.package }}
+      run: uv run --no-sync --with pytest --with pytest-asyncio pytest tests -v
+
   next-js-test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Pull Request Checklist

Please ensure that your PR meets the following requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [ ] I have updated the documentation (if applicable).
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Description

The pytest suites under `packages/*` ran nowhere: `ci.yml` covered only`sdks/python/sdk` and the langchain cookbook, and the `publish-*.yml` workflows only smoke-test `import <package>`.

Adds a `python-package-test` matrix job covering the 13 packages whose suites currently pass — ~120 tests. Verified locally with the exact commands the job runs:

```
    cd packages/<pkg>
    uv sync --all-extras --python 3.12
    uv run --no-sync --with pytest --with pytest-asyncio pytest tests -v
````

Two constraints, both documented in comments in the workflow:

- **Pinned to Python 3.12**, not the SDK's 3.10–3.14 matrix. Several connector tests patch `moss_connector_<x>.ingest.MossClient`, but each package's `__init__.py` does `from .ingest import ingest`, shadowing the submodule with the function. `unittest.mock` resolves that target on 3.12+ and raises `AttributeError` on 3.10/3.11. Test-only the packages themselves are fine on 3.10.
- **`packages/moss-cli` is excluded.** `moss completions bash|zsh` exits 1 even when its fallback import succeeds (`commands/completions.py`), so `tests/test_completions.py` fails: `2 failed, 28 passed`. Worth a follow-up PR that fixes the command and adds moss-cli to the matrix.

## Type of Change

CI / tooling — no runtime code changes.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/usemoss/moss/pull/492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

