### PR TITLE
feat(cli): add moss playground command with WASM-based query UI

### DIFF
--- a/packages/moss-cli/README.md
+++ b/packages/moss-cli/README.md
@@ -167,16 +167,21 @@ moss playground --no-open
 When you run `moss playground`, it prints a URL that includes a per-run token in the
 `#<token>` fragment, e.g. `http://127.0.0.1:8765/#Abc123...`. Open that exact URL in
 your browser. With `--no-open`, copy the full URL printed by the command — including
-the `#<token>` fragment — since the token is required to authenticate API requests.
+the `#<token>` fragment — since the token is required to fetch the project credentials
+from the server.
 
-The playground serves a single-page app that lets you:
+The playground serves a single-page app that loads the Moss WASM SDK
+(`@moss-dev/moss-web`) from the unpkg CDN and runs index loading and semantic search
+entirely in the browser. You can:
 
 - Browse and load indexes
 - Run semantic search with configurable `topK` and `alpha`
 - View results with scores and metadata
 
-All API calls are proxied through the server, so your project key is never exposed
-to the browser.
+When credentials are available (via CLI flags, `MOSS_PROJECT_ID`/`MOSS_PROJECT_KEY`
+env vars, or a `--profile`), the server injects them through a token-protected
+`/api/config` endpoint and the app connects automatically. If no credentials are
+configured, the app shows a connection form where you can enter them in the browser.
 
 ### Job Tracking
 

--- a/packages/moss-cli/README.md
+++ b/packages/moss-cli/README.md
@@ -15,6 +15,7 @@ Moss CLI wraps the [Moss Python SDK](https://docs.moss.dev/) so you can build an
 - **Multiple output formats** — rich tables for humans, `--json` for scripts
 - **Job tracking** — poll background jobs with live progress display
 - **Pipe-friendly** — stdin/stdout support for composing with other tools
+- **Local Playground** — browser-based UI for interactive querying without any frontend code
 
 ## Installation
 
@@ -144,6 +145,28 @@ echo "what is AI" | moss query my-index
 # JSON output for scripting
 moss query my-index "query" --json | jq '.docs[0].text'
 ```
+
+### Playground
+
+Start a local web UI for interactive semantic search — no frontend code required.
+
+```bash
+# Start the playground on the default port (8765)
+moss playground
+
+# Specify a custom port
+moss playground --port 9000
+
+# Skip opening the browser automatically
+moss playground --no-open
+```
+
+The playground serves a single-page app at `http://localhost:<port>` that lets you:
+
+- Browse and load indexes
+- Run semantic search with configurable `topK` and `alpha`
+- View results with scores and metadata
+- All API calls are proxied through the server — your project key is never exposed to the browser
 
 ### Job Tracking
 

--- a/packages/moss-cli/README.md
+++ b/packages/moss-cli/README.md
@@ -151,22 +151,32 @@ moss query my-index "query" --json | jq '.docs[0].text'
 Start a local web UI for interactive semantic search — no frontend code required.
 
 ```bash
-# Start the playground on the default port (8765)
+# Start the playground (port 8765 when available, otherwise the next free port)
 moss playground
 
-# Specify a custom port
+# Use a specific port
 moss playground --port 9000
+
+# Use a specific credential profile
+moss playground --profile staging
 
 # Skip opening the browser automatically
 moss playground --no-open
 ```
 
-The playground serves a single-page app at `http://localhost:<port>` that lets you:
+When you run `moss playground`, it prints a URL that includes a per-run token in the
+`#<token>` fragment, e.g. `http://127.0.0.1:8765/#Abc123...`. Open that exact URL in
+your browser. With `--no-open`, copy the full URL printed by the command — including
+the `#<token>` fragment — since the token is required to authenticate API requests.
+
+The playground serves a single-page app that lets you:
 
 - Browse and load indexes
 - Run semantic search with configurable `topK` and `alpha`
 - View results with scores and metadata
-- All API calls are proxied through the server — your project key is never exposed to the browser
+
+All API calls are proxied through the server, so your project key is never exposed
+to the browser.
 
 ### Job Tracking
 

--- a/packages/moss-cli/pyproject.toml
+++ b/packages/moss-cli/pyproject.toml
@@ -50,6 +50,9 @@ where = ["src"]
 [tool.setuptools.package-dir]
 "" = "src"
 
+[tool.setuptools.package-data]
+moss_cli = ["playground/*.html"]
+
 [tool.black]
 line-length = 88
 target-version = ['py310']

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -62,7 +62,6 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(body)
 

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -8,6 +8,7 @@ MossClient — the project key never reaches the browser.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import secrets
 import socket
@@ -58,13 +59,14 @@ class AsyncWorker:
     def submit(self, coro_fn: Callable[[], Any]) -> Any:
         """Run coro_fn() entirely on the worker loop/thread and return its result.
 
-        coro_fn must be a zero-arg callable. It may return an awaitable
-        (coroutine/Future) or a plain value — either is handled.
+        coro_fn must be a zero-arg callable. It may return any awaitable
+        object (coroutine, Future, or a custom __await__-based object)
+        or a plain value — either is handled.
         """
 
         async def runner():
             result = coro_fn()
-            if asyncio.iscoroutine(result) or asyncio.isfuture(result):
+            if inspect.isawaitable(result):
                 return await result
             return result
 
@@ -90,6 +92,20 @@ def _index_info_to_dict(info: Any) -> Dict[str, Any]:
         "updatedAt": getattr(info, "updated_at", ""),
         "model": model_dict,
     }
+
+
+class DaemonThreadingHTTPServer(ThreadingHTTPServer):
+    """ThreadingHTTPServer whose per-request threads are daemons.
+
+    By default ThreadingHTTPServer's request threads are non-daemon, so
+    server_close() blocks waiting for any in-flight request thread to
+    finish. If a handler is parked in worker.submit(...) (e.g. a slow
+    /api/query) when the user hits Ctrl+C, shutdown would hang before
+    worker.stop() ever runs. Daemonizing request threads lets process
+    exit proceed without waiting on them.
+    """
+
+    daemon_threads = True
 
 
 class PlaygroundHandler(SimpleHTTPRequestHandler):
@@ -343,7 +359,7 @@ def playground_command(
     PlaygroundHandler._token = secrets.token_urlsafe(32)
     PlaygroundHandler._server_host = f"127.0.0.1:{final_port}"
 
-    server = ThreadingHTTPServer(server_addr, PlaygroundHandler)
+    server = DaemonThreadingHTTPServer(server_addr, PlaygroundHandler)
     url = f"http://127.0.0.1:{final_port}"
     frag_url = f"{url}/#{PlaygroundHandler._token}"
 
@@ -366,5 +382,6 @@ def playground_command(
         server.serve_forever()
     except KeyboardInterrupt:
         console.print("\n[yellow]Shutting down...[/yellow]")
+    finally:
         server.server_close()
         worker.stop()

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -62,11 +62,13 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             self._send_json(403, {"error": "Forbidden: invalid or missing token"})
             return False
         host = self.headers.get("Host", "")
-        if host and host != self._server_host and host != self._server_host.replace("127.0.0.1", "localhost"):
+        allowed_hosts = {self._server_host, self._server_host.replace("127.0.0.1", "localhost")}
+        if host and host not in allowed_hosts:
             self._send_json(403, {"error": "Forbidden: invalid Host header"})
             return False
         origin = self.headers.get("Origin", "")
-        if origin and origin != f"http://{self._server_host}":
+        allowed_origins = {f"http://{h}" for h in allowed_hosts}
+        if origin and origin not in allowed_origins:
             self._send_json(403, {"error": "Forbidden: invalid Origin"})
             return False
         return True

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -281,7 +281,7 @@ def playground_command(
     if not no_open:
         opened = webbrowser.open(frag_url)
     if not opened:
-        console.print(f"  [yellow]Open this URL in your browser:[/yellow]")
+        console.print("  [yellow]Open this URL in your browser:[/yellow]")
         console.print(f"  [cyan]{frag_url}[/cyan]")
         console.print()
 

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -114,10 +114,6 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             self._send_json(500, {"error": "Playground HTML not found"})
             return
         html = PLAYGROUND_HTML.read_text(encoding="utf-8")
-        html = html.replace(
-            "</title>",
-            f'</title>\n<meta name="moss-token" content="{self._token}" />',
-        )
         self._send_html(html)
 
     def _handle_list_indexes(self) -> None:
@@ -270,6 +266,7 @@ def playground_command(
 
     server = HTTPServer(server_addr, PlaygroundHandler)
     url = f"http://127.0.0.1:{final_port}"
+    frag_url = f"{url}/#{PlaygroundHandler._token}"
 
     console.print()
     console.print("  [bold]Moss Playground[/bold]")
@@ -279,7 +276,7 @@ def playground_command(
     console.print()
 
     if not no_open:
-        webbrowser.open(url)
+        webbrowser.open(frag_url)
 
     try:
         server.serve_forever()

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -270,13 +270,18 @@ def playground_command(
 
     console.print()
     console.print("  [bold]Moss Playground[/bold]")
-    console.print(f"  [dim]Server:[/dim]  [cyan]{url}[/cyan]")
+    console.print(f"  [dim]Server:[/dim]  [cyan]{frag_url}[/cyan]")
     console.print(f"  [dim]Project:[/dim] {pid[:8]}...")
     console.print("  [dim]Stop:[/dim]    Ctrl+C")
     console.print()
 
+    opened = False
     if not no_open:
-        webbrowser.open(frag_url)
+        opened = webbrowser.open(frag_url)
+    if not opened:
+        console.print(f"  [yellow]Open this URL in your browser:[/yellow]")
+        console.print(f"  [cyan]{frag_url}[/cyan]")
+        console.print()
 
     try:
         server.serve_forever()

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -12,7 +12,6 @@ import inspect
 import json
 import math
 import secrets
-import socket
 import threading
 import webbrowser
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
@@ -128,6 +127,7 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
     _worker: AsyncWorker | None = None
     _latest_request_ids: Dict[str, int] = {}
     _request_lock = threading.Lock()
+    _loaded_index: str | None = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=str(HERE / "playground"), **kwargs)
@@ -300,7 +300,18 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
         if name is None:
             return
         try:
-            worker.submit(lambda: client.load_index(name))
+            async def _call():
+                previous = PlaygroundHandler._loaded_index
+                if previous is not None and previous != name:
+                    unload = client.unload_index(previous)
+                    if inspect.isawaitable(unload):
+                        await unload
+                result = client.load_index(name)
+                if inspect.isawaitable(result):
+                    result = await result
+                PlaygroundHandler._loaded_index = name
+                return name
+            worker.submit(_call)
             self._send_json(200, {"name": name})
         except Exception as e:
             self._send_error(e)
@@ -342,7 +353,11 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             if isinstance(raw_alpha, bool) or not isinstance(raw_alpha, (int, float)):
                 self._send_json(400, {"error": "'alpha' must be a number"})
                 return
-            alpha = float(raw_alpha)
+            try:
+                alpha = float(raw_alpha)
+            except OverflowError:
+                self._send_json(400, {"error": "'alpha' must be a finite number"})
+                return
             if not math.isfinite(alpha):
                 self._send_json(400, {"error": "'alpha' must be a finite number"})
                 return
@@ -386,15 +401,27 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             self._send_error(e)
 
 
-def _find_free_port(start: int = 8765, max_attempts: int = 20) -> int:
+def _create_server(
+    handler: type,
+    start: int = 8765,
+    max_attempts: int = 20,
+) -> tuple[DaemonThreadingHTTPServer, int]:
+    """Construct the HTTP server on the first free port in the candidate range.
+
+    Binding happens inside ``DaemonThreadingHTTPServer``, so a port that is
+    probed free and then taken by another process is retried instead of
+    crashing the command (unlike a separate check-then-bind probe).
+    """
+    last_error: OSError | None = None
     for port in range(start, start + max_attempts):
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            try:
-                s.bind(("127.0.0.1", port))
-                return port
-            except OSError:
-                continue
-    raise RuntimeError(f"Could not find a free port in range {start}-{start + max_attempts}")
+        try:
+            return DaemonThreadingHTTPServer(("127.0.0.1", port), handler), port
+        except OSError as e:
+            last_error = e
+            continue
+    raise RuntimeError(
+        f"Could not find a free port in range {start}-{start + max_attempts}"
+    ) from last_error
 
 
 def playground_command(
@@ -425,15 +452,16 @@ def playground_command(
     client = worker.submit(lambda: MossClient(pid, pkey))
     
     # Start server
-    final_port = port if port else _find_free_port()
-    server_addr = ("127.0.0.1", final_port)
+    if port:
+        server = DaemonThreadingHTTPServer(("127.0.0.1", port), PlaygroundHandler)
+        final_port = port
+    else:
+        server, final_port = _create_server(PlaygroundHandler)
 
     PlaygroundHandler.client = client
     PlaygroundHandler._worker = worker
     PlaygroundHandler._token = secrets.token_urlsafe(32)
     PlaygroundHandler._server_host = f"127.0.0.1:{final_port}"
-
-    server = DaemonThreadingHTTPServer(server_addr, PlaygroundHandler)
     url = f"http://127.0.0.1:{final_port}"
     frag_url = f"{url}/#{PlaygroundHandler._token}"
 

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import secrets
 import socket
+import threading
 import webbrowser
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -28,6 +29,32 @@ console = Console()
 HERE = Path(__file__).resolve().parent.parent
 
 PLAYGROUND_HTML = HERE / "playground" / "index.html"
+
+
+class AsyncWorker:
+    """Single background thread with one persistent event loop.
+
+    All MossClient calls are submitted here so they execute serially on
+    one loop/thread — safe even when multiple HTTP handler threads are
+    active (ThreadingHTTPServer).
+    """
+
+    def __init__(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def submit(self, coro) -> Any:
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result()
+
+    def stop(self) -> None:
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join()
 
 
 def _index_info_to_dict(info: Any) -> Dict[str, Any]:
@@ -53,6 +80,7 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
     client: MossClient | None = None
     _token: str = ""
     _server_host: str = ""
+    _worker: AsyncWorker | None = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=str(HERE / "playground"), **kwargs)
@@ -120,25 +148,27 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
 
     def _handle_list_indexes(self) -> None:
         client = self.client
-        if client is None:
+        worker = self._worker
+        if client is None or worker is None:
             self._send_json(500, {"error": "MossClient not initialized"})
             return
         try:
-            indexes = asyncio.run(client.list_indexes())
+            indexes = worker.submit(client.list_indexes())
             self._send_json(200, {"indexes": [_index_info_to_dict(i) for i in indexes]})
         except Exception as e:
             self._send_json(500, {"error": str(e)})
 
     def _handle_get_index(self, name: str | None) -> None:
         client = self.client
-        if client is None:
+        worker = self._worker
+        if client is None or worker is None:
             self._send_json(500, {"error": "MossClient not initialized"})
             return
         if not name:
             self._send_json(400, {"error": "Missing 'name' query parameter"})
             return
         try:
-            info = asyncio.run(client.get_index(name))
+            info = worker.submit(client.get_index(name))
             self._send_json(200, {"index": _index_info_to_dict(info)})
         except Exception as e:
             self._send_json(500, {"error": str(e)})
@@ -169,7 +199,8 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
 
     def _handle_post_load_index(self, data: dict) -> None:
         client = self.client
-        if client is None:
+        worker = self._worker
+        if client is None or worker is None:
             self._send_json(500, {"error": "MossClient not initialized"})
             return
         name = data.get("name", "")
@@ -177,14 +208,15 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             self._send_json(400, {"error": "Missing 'name' in request body"})
             return
         try:
-            asyncio.run(client.load_index(name))
+            worker.submit(client.load_index(name))
             self._send_json(200, {"name": name})
         except Exception as e:
             self._send_json(500, {"error": str(e)})
 
     def _handle_post_query(self, data: dict) -> None:
         client = self.client
-        if client is None:
+        worker = self._worker
+        if client is None or worker is None:
             self._send_json(500, {"error": "MossClient not initialized"})
             return
         name = data.get("name", "")
@@ -206,7 +238,7 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
                 return
         try:
             opts = QueryOptions(top_k=top_k, alpha=alpha)
-            result = asyncio.run(client.query(name, query, opts))
+            result = worker.submit(client.query(name, query, opts))
             docs = []
             for d in result.docs:
                 docs.append({
@@ -267,12 +299,14 @@ def playground_command(
 
     # Initialize the SDK client for API endpoints
     client = MossClient(pid, pkey)
+    worker = AsyncWorker()
 
     # Start server
     final_port = port if port else _find_free_port()
     server_addr = ("127.0.0.1", final_port)
 
     PlaygroundHandler.client = client
+    PlaygroundHandler._worker = worker
     PlaygroundHandler._token = secrets.token_urlsafe(32)
     PlaygroundHandler._server_host = f"127.0.0.1:{final_port}"
 
@@ -300,3 +334,4 @@ def playground_command(
     except KeyboardInterrupt:
         console.print("\n[yellow]Shutting down...[/yellow]")
         server.server_close()
+        worker.stop()

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -15,7 +15,7 @@ import threading
 import webbrowser
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 from urllib.parse import urlparse, parse_qs
 
 import typer
@@ -37,6 +37,13 @@ class AsyncWorker:
     All MossClient calls are submitted here so they execute serially on
     one loop/thread — safe even when multiple HTTP handler threads are
     active (ThreadingHTTPServer).
+
+    `submit` takes a zero-arg callable rather than an already-constructed
+    coroutine. This ensures the coroutine object itself is *constructed*
+    on the worker's event loop (inside `runner`), not on the calling
+    (HTTP handler) thread. Some async SDK/PyO3 objects bind to "the
+    currently running loop" at construction time, so constructing them
+    off-thread and only awaiting them here would still be unsafe.
     """
 
     def __init__(self) -> None:
@@ -48,8 +55,20 @@ class AsyncWorker:
         asyncio.set_event_loop(self._loop)
         self._loop.run_forever()
 
-    def submit(self, coro) -> Any:
-        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+    def submit(self, coro_fn: Callable[[], Any]) -> Any:
+        """Run coro_fn() entirely on the worker loop/thread and return its result.
+
+        coro_fn must be a zero-arg callable. It may return an awaitable
+        (coroutine/Future) or a plain value — either is handled.
+        """
+
+        async def runner():
+            result = coro_fn()
+            if asyncio.iscoroutine(result) or asyncio.isfuture(result):
+                return await result
+            return result
+
+        future = asyncio.run_coroutine_threadsafe(runner(), self._loop)
         return future.result()
 
     def stop(self) -> None:
@@ -153,7 +172,7 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             self._send_json(500, {"error": "MossClient not initialized"})
             return
         try:
-            indexes = worker.submit(client.list_indexes())
+            indexes = worker.submit(lambda: client.list_indexes())
             self._send_json(200, {"indexes": [_index_info_to_dict(i) for i in indexes]})
         except Exception as e:
             self._send_json(500, {"error": str(e)})
@@ -168,7 +187,7 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             self._send_json(400, {"error": "Missing 'name' query parameter"})
             return
         try:
-            info = worker.submit(client.get_index(name))
+            info = worker.submit(lambda: client.get_index(name))
             self._send_json(200, {"index": _index_info_to_dict(info)})
         except Exception as e:
             self._send_json(500, {"error": str(e)})
@@ -187,8 +206,17 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
         parsed = urlparse(self.path)
         path = parsed.path
         length = int(self.headers.get("Content-Length", 0))
-        body = self.rfile.read(length).decode("utf-8") if length else "{}"
-        data = json.loads(body)
+        raw_body = self.rfile.read(length) if length else b"{}"
+
+        try:
+            data = json.loads(raw_body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            self._send_json(400, {"error": "Invalid JSON body"})
+            return
+
+        if not isinstance(data, dict):
+            self._send_json(400, {"error": "Request body must be a JSON object"})
+            return
 
         if path == "/api/load-index":
             self._handle_post_load_index(data)
@@ -208,7 +236,7 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             self._send_json(400, {"error": "Missing 'name' in request body"})
             return
         try:
-            worker.submit(client.load_index(name))
+            worker.submit(lambda: client.load_index(name))
             self._send_json(200, {"name": name})
         except Exception as e:
             self._send_json(500, {"error": str(e)})
@@ -224,21 +252,26 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
         if not name or not query:
             self._send_json(400, {"error": "Missing 'name' or 'query' in request body"})
             return
-        top_k = data.get("topK")
-        alpha = data.get("alpha")
-        if top_k is not None:
-            top_k = int(top_k)
-            if top_k < 1 or top_k > 50:
-                self._send_json(400, {"error": "topK must be between 1 and 50"})
-                return
-        if alpha is not None:
-            alpha = float(alpha)
-            if alpha < 0 or alpha > 1:
-                self._send_json(400, {"error": "alpha must be between 0 and 1"})
-                return
+
+        try:
+            raw_top_k = data.get("topK")
+            raw_alpha = data.get("alpha")
+            top_k = int(raw_top_k) if raw_top_k is not None else None
+            alpha = float(raw_alpha) if raw_alpha is not None else None
+        except (TypeError, ValueError):
+            self._send_json(400, {"error": "'topK' must be an integer and 'alpha' must be a number"})
+            return
+
+        if top_k is not None and (top_k < 1 or top_k > 50):
+            self._send_json(400, {"error": "topK must be between 1 and 50"})
+            return
+        if alpha is not None and (alpha < 0 or alpha > 1):
+            self._send_json(400, {"error": "alpha must be between 0 and 1"})
+            return
+
         try:
             opts = QueryOptions(top_k=top_k, alpha=alpha)
-            result = worker.submit(client.query(name, query, opts))
+            result = worker.submit(lambda: client.query(name, query, opts))
             docs = []
             for d in result.docs:
                 docs.append({

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -306,6 +306,7 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
                     unload = client.unload_index(previous)
                     if inspect.isawaitable(unload):
                         await unload
+                    PlaygroundHandler._loaded_index = None
                 result = client.load_index(name)
                 if inspect.isawaitable(result):
                     result = await result

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -189,8 +189,8 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             self._send_json(500, {"error": "MossClient not initialized"})
             return
         try:
-            indexes = worker.submit(lambda: client.list_indexes())
-            self._send_json(200, {"indexes": [_index_info_to_dict(i) for i in indexes]})
+            indexes = worker.submit(lambda: [_index_info_to_dict(i) for i in client.list_indexes()])
+            self._send_json(200, {"indexes": indexes})
         except Exception as e:
             self._send_json(500, {"error": str(e)})
 
@@ -204,8 +204,8 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             self._send_json(400, {"error": "Missing 'name' query parameter"})
             return
         try:
-            info = worker.submit(lambda: client.get_index(name))
-            self._send_json(200, {"index": _index_info_to_dict(info)})
+            info = worker.submit(lambda: _index_info_to_dict(client.get_index(name)))
+            self._send_json(200, {"index": info})
         except Exception as e:
             self._send_json(500, {"error": str(e)})
 
@@ -287,20 +287,17 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             return
 
         try:
-            result = worker.submit(lambda: client.query(name, query, QueryOptions(top_k=top_k, alpha=alpha)))
-            docs = []
-            for d in result.docs:
-                docs.append({
-                    "id": d.id,
-                    "text": d.text,
-                    "score": d.score,
-                    "metadata": d.metadata,
-                })
-            self._send_json(200, {
-                "docs": docs,
-                "timeTakenMs": result.time_taken_ms,
-                "query": result.query,
-            })
+            def _build_result(r):
+                return {
+                    "docs": [
+                        {"id": d.id, "text": d.text, "score": d.score, "metadata": d.metadata}
+                        for d in r.docs
+                    ],
+                    "timeTakenMs": r.time_taken_ms,
+                    "query": r.query,
+                }
+            payload = worker.submit(lambda: _build_result(client.query(name, query, QueryOptions(top_k=top_k, alpha=alpha))))
+            self._send_json(200, payload)
         except Exception as e:
             self._send_json(500, {"error": str(e)})
 

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -1,29 +1,28 @@
 """moss playground — local web UI for querying Moss indexes interactively.
 
-Starts a local HTTP server that serves a browser-based playground.
-Index and query operations are proxied through the server's credentialed
-MossClient — the project key never reaches the browser.
+Starts a local HTTP server that serves a browser-based playground. The UI
+loads ``@moss-dev/moss-web`` (the WASM browser SDK) via an import map from the
+unpkg CDN and executes index loading and queries entirely in the browser.
+
+The server only serves the static UI and, when credentials are available,
+injects them through a token-protected ``/api/config`` endpoint so the WASM
+client can talk to the Moss cloud directly. When no credentials are configured,
+the UI falls back to a manual connection form.
 """
 
 from __future__ import annotations
 
-import asyncio
-import inspect
 import json
-import math
 import secrets
-import threading
 import webbrowser
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional
-from urllib.parse import urlparse, parse_qs
+from typing import Optional
+from urllib.parse import urlparse
 
 import typer
 from rich.console import Console
 from rich.markup import escape as rich_escape
-
-from moss import MossClient, QueryOptions
 
 from ..config import resolve_credentials
 
@@ -32,102 +31,28 @@ HERE = Path(__file__).resolve().parent.parent
 
 PLAYGROUND_HTML = HERE / "playground" / "index.html"
 
-MAX_REQUEST_BODY_SIZE = 1 << 20
-
-
-class AsyncWorker:
-    """Single background thread with one persistent event loop.
-
-    All MossClient calls are submitted here so they execute serially on
-    one loop/thread — safe even when multiple HTTP handler threads are
-    active (ThreadingHTTPServer).
-
-    `submit` takes a zero-arg callable rather than an already-constructed
-    coroutine. This ensures the coroutine object itself is *constructed*
-    on the worker's event loop (inside `runner`), not on the calling
-    (HTTP handler) thread. Some async SDK/PyO3 objects bind to "the
-    currently running loop" at construction time, so constructing them
-    off-thread and only awaiting them here would still be unsafe.
-    """
-
-    def __init__(self) -> None:
-        self._loop = asyncio.new_event_loop()
-        self._thread = threading.Thread(target=self._run, daemon=True)
-        self._thread.start()
-        self._lock = asyncio.run_coroutine_threadsafe(self._make_lock(), self._loop).result()
-
-    async def _make_lock(self) -> asyncio.Lock:
-        return asyncio.Lock()
-
-    def _run(self) -> None:
-        asyncio.set_event_loop(self._loop)
-        self._loop.run_forever()
-
-    def submit(self, coro_fn: Callable[[], Any]) -> Any:
-        """Run coro_fn() entirely on the worker loop/thread and return its result.
-
-        coro_fn must be a zero-arg callable. It may return any awaitable
-        object (coroutine, Future, or a custom __await__-based object)
-        or a plain value — either is handled.
-        """
-
-        async def runner():
-            async with self._lock:
-                result = coro_fn()
-                if inspect.isawaitable(result):
-                    return await result
-                return result
-
-        future = asyncio.run_coroutine_threadsafe(runner(), self._loop)
-        return future.result()
-
-    def stop(self, timeout: float | None = 5.0) -> bool:
-        self._loop.call_soon_threadsafe(self._loop.stop)
-        self._thread.join(timeout)
-        return not self._thread.is_alive()
-
-
-def _index_info_to_dict(info: Any) -> Dict[str, Any]:
-    """Serialize an IndexInfo (Rust/PyO3 type) to a JSON-safe dict."""
-    model = getattr(info, "model", None)
-    model_dict = {"id": getattr(model, "id", None), "version": getattr(model, "version", None)} if model else None
-    return {
-        "id": getattr(info, "id", ""),
-        "name": getattr(info, "name", ""),
-        "version": getattr(info, "version", ""),
-        "status": getattr(info, "status", ""),
-        "docCount": getattr(info, "doc_count", 0),
-        "createdAt": getattr(info, "created_at", ""),
-        "updatedAt": getattr(info, "updated_at", ""),
-        "model": model_dict,
-    }
-
 
 class DaemonThreadingHTTPServer(ThreadingHTTPServer):
     """ThreadingHTTPServer whose per-request threads are daemons.
 
     By default ThreadingHTTPServer's request threads are non-daemon, so
     server_close() blocks waiting for any in-flight request thread to
-    finish. If a handler is parked in worker.submit(...) (e.g. a slow
-    /api/query) when the user hits Ctrl+C, shutdown would hang before
-    worker.stop() ever runs. Daemonizing request threads lets process
-    exit proceed without waiting on them.
+    finish. Daemonizing request threads lets process exit proceed without
+    waiting on them.
     """
 
     daemon_threads = True
 
 
 class PlaygroundHandler(SimpleHTTPRequestHandler):
-    """HTTP handler — serves the playground UI and proxies SDK calls server-side
-    so the project key is never exposed to the browser."""
+    """HTTP handler — serves the playground UI and injects credentials into the
+    browser when the server has them, so the WASM client runs entirely in the
+    browser."""
 
-    client: MossClient | None = None
     _token: str = ""
     _server_host: str = ""
-    _worker: AsyncWorker | None = None
-    _latest_request_ids: Dict[str, int] = {}
-    _request_lock = threading.Lock()
-    _loaded_index: str | None = None
+    _project_id: str | None = None
+    _project_key: str | None = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=str(HERE / "playground"), **kwargs)
@@ -165,36 +90,17 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
-    def _require_string_field(self, data: dict, key: str, message: str) -> str | None:
-        value = data.get(key)
-        if not isinstance(value, str) or not value.strip():
-            self._send_json(400, {"error": message})
-            return None
-        return value
-
-    def _send_error(self, exc: Exception) -> None:
-        console.print(f"[red]Playground error:[/red] {rich_escape(f'{type(exc).__name__}: {exc}')}")
-        self._send_json(500, {"error": "Internal server error"})
-
     def do_GET(self) -> None:
-        parsed = urlparse(self.path)
-        path = parsed.path
-        params = parse_qs(parsed.query)
-
+        path = urlparse(self.path).path
         if path == "/":
             self._serve_index()
         elif path == "/favicon.ico":
             self.send_response(204)
             self.end_headers()
-        elif path == "/api/indexes":
+        elif path == "/api/config":
             if not self._check_api_request():
                 return
-            self._handle_list_indexes()
-        elif path == "/api/index":
-            if not self._check_api_request():
-                return
-            names = params.get("name", [])
-            self._handle_get_index(names[0] if names else None)
+            self._handle_get_config()
         else:
             super().do_GET()
 
@@ -205,42 +111,14 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
         html = PLAYGROUND_HTML.read_text(encoding="utf-8")
         self._send_html(html)
 
-    def _handle_list_indexes(self) -> None:
-        client = self.client
-        worker = self._worker
-        if client is None or worker is None:
-            self._send_json(500, {"error": "MossClient not initialized"})
-            return
-        try:
-            async def _call():
-                indexes = client.list_indexes()
-                if inspect.isawaitable(indexes):
-                    indexes = await indexes
-                return [_index_info_to_dict(i) for i in indexes]
-            indexes = worker.submit(_call)
-            self._send_json(200, {"indexes": indexes})
-        except Exception as e:
-            self._send_error(e)
-
-    def _handle_get_index(self, name: str | None) -> None:
-        client = self.client
-        worker = self._worker
-        if client is None or worker is None:
-            self._send_json(500, {"error": "MossClient not initialized"})
-            return
-        if not name:
-            self._send_json(400, {"error": "Missing 'name' query parameter"})
-            return
-        try:
-            async def _call():
-                result = client.get_index(name)
-                if inspect.isawaitable(result):
-                    result = await result
-                return _index_info_to_dict(result)
-            info = worker.submit(_call)
-            self._send_json(200, {"index": info})
-        except Exception as e:
-            self._send_error(e)
+    def _handle_get_config(self) -> None:
+        self._send_json(
+            200,
+            {
+                "projectId": self._project_id,
+                "projectKey": self._project_key,
+            },
+        )
 
     def log_message(self, format, *args):
         safe = [rich_escape(str(a)) for a in args]
@@ -250,156 +128,6 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             console.print(f"  [dim]{safe[0]} {safe[1]}[/dim]")
         elif len(safe) >= 1:
             console.print(f"  [dim]{safe[0]}[/dim]")
-
-    def do_POST(self) -> None:
-        if not self._check_api_request():
-            return
-        parsed = urlparse(self.path)
-        path = parsed.path
-        length_header = self.headers.get("Content-Length")
-        if length_header is None:
-            length = 0
-        else:
-            try:
-                length = int(length_header)
-            except ValueError:
-                self._send_json(400, {"error": "Invalid Content-Length header"})
-                return
-            if length < 0:
-                self._send_json(400, {"error": "Invalid Content-Length header"})
-                return
-            if length > MAX_REQUEST_BODY_SIZE:
-                self._send_json(413, {"error": "Request body too large"})
-                return
-        raw_body = self.rfile.read(length) if length else b"{}"
-
-        try:
-            data = json.loads(raw_body.decode("utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError):
-            self._send_json(400, {"error": "Invalid JSON body"})
-            return
-
-        if not isinstance(data, dict):
-            self._send_json(400, {"error": "Request body must be a JSON object"})
-            return
-
-        if path == "/api/load-index":
-            self._handle_post_load_index(data)
-        elif path == "/api/query":
-            self._handle_post_query(data)
-        else:
-            self._send_json(404, {"error": "Not found"})
-
-    def _handle_post_load_index(self, data: dict) -> None:
-        client = self.client
-        worker = self._worker
-        if client is None or worker is None:
-            self._send_json(500, {"error": "MossClient not initialized"})
-            return
-        name = self._require_string_field(data, "name", "Missing 'name' in request body")
-        if name is None:
-            return
-        try:
-            async def _call():
-                previous = PlaygroundHandler._loaded_index
-                if previous is not None and previous != name:
-                    unload = client.unload_index(previous)
-                    if inspect.isawaitable(unload):
-                        await unload
-                    PlaygroundHandler._loaded_index = None
-                result = client.load_index(name)
-                if inspect.isawaitable(result):
-                    result = await result
-                PlaygroundHandler._loaded_index = name
-                return name
-            worker.submit(_call)
-            self._send_json(200, {"name": name})
-        except Exception as e:
-            self._send_error(e)
-
-    def _handle_post_query(self, data: dict) -> None:
-        client = self.client
-        worker = self._worker
-        if client is None or worker is None:
-            self._send_json(500, {"error": "MossClient not initialized"})
-            return
-        name = self._require_string_field(data, "name", "Missing 'name' or 'query' in request body")
-        if name is None:
-            return
-        query = self._require_string_field(data, "query", "Missing 'name' or 'query' in request body")
-        if query is None:
-            return
-
-        session_id = data.get("sessionId")
-        if not isinstance(session_id, str) or not session_id:
-            self._send_json(400, {"error": "Missing or invalid 'sessionId'"})
-            return
-
-        raw_request_id = data.get("requestId")
-        if isinstance(raw_request_id, bool) or not isinstance(raw_request_id, int):
-            self._send_json(400, {"error": "Missing or invalid 'requestId'"})
-            return
-
-        raw_top_k = data.get("topK")
-        if raw_top_k is not None:
-            if isinstance(raw_top_k, bool) or not isinstance(raw_top_k, int):
-                self._send_json(400, {"error": "'topK' must be an integer"})
-                return
-            top_k = raw_top_k
-        else:
-            top_k = None
-
-        raw_alpha = data.get("alpha")
-        if raw_alpha is not None:
-            if isinstance(raw_alpha, bool) or not isinstance(raw_alpha, (int, float)):
-                self._send_json(400, {"error": "'alpha' must be a number"})
-                return
-            try:
-                alpha = float(raw_alpha)
-            except OverflowError:
-                self._send_json(400, {"error": "'alpha' must be a finite number"})
-                return
-            if not math.isfinite(alpha):
-                self._send_json(400, {"error": "'alpha' must be a finite number"})
-                return
-        else:
-            alpha = None
-
-        if top_k is not None and (top_k < 1 or top_k > 50):
-            self._send_json(400, {"error": "topK must be between 1 and 50"})
-            return
-        if alpha is not None and (alpha < 0 or alpha > 1):
-            self._send_json(400, {"error": "alpha must be between 0 and 1"})
-            return
-
-        with PlaygroundHandler._request_lock:
-            latest = PlaygroundHandler._latest_request_ids.get(session_id, 0)
-            if raw_request_id < latest:
-                self._send_json(200, {"docs": [], "timeTakenMs": 0, "query": query, "superseded": True})
-                return
-            PlaygroundHandler._latest_request_ids[session_id] = raw_request_id
-
-        try:
-            def _build_result(r):
-                return {
-                    "docs": [
-                        {"id": d.id, "text": d.text, "score": d.score, "metadata": d.metadata}
-                        for d in r.docs
-                    ],
-                    "timeTakenMs": r.time_taken_ms,
-                    "query": r.query,
-                }
-            async def _call():
-                if raw_request_id < PlaygroundHandler._latest_request_ids.get(session_id, 0):
-                    return {"docs": [], "timeTakenMs": 0, "query": query, "superseded": True}
-                result = client.query(name, query, QueryOptions(top_k=top_k, alpha=alpha))
-                if inspect.isawaitable(result):
-                    result = await result
-                return _build_result(result)
-            payload = worker.submit(_call)
-            self._send_json(200, payload)
-        except Exception as e:
-            self._send_error(e)
 
 
 def _create_server(
@@ -435,23 +163,26 @@ def playground_command(
         False, "--no-open", help="Do not open the browser automatically",
     ),
 ) -> None:
-    """Start the Moss Playground — a local web UI for interactive search.
+    """Start the Moss Playground — a browser-based UI for interactive search.
 
-    Launches a browser-based playground where you can list cloud indexes,
-    load one into server memory, and run queries against it.
+    Launches a browser-based playground that loads the Moss WASM SDK
+    (@moss-dev/moss-web) and runs index loading and queries entirely in the
+    browser. Credentials from CLI flags, env vars, or a config profile are
+    injected through a token-protected endpoint; without them the UI shows a
+    manual connection form.
     """
     if profile:
         ctx.obj["profile"] = profile
 
-    # Resolve credentials
-    pid, pkey = resolve_credentials(
-        ctx.obj.get("project_id"), ctx.obj.get("project_key"), ctx.obj.get("profile")
-    )
+    # Resolve credentials if available — the playground still works without
+    # them by asking the user to connect manually in the browser.
+    try:
+        pid, pkey = resolve_credentials(
+            ctx.obj.get("project_id"), ctx.obj.get("project_key"), ctx.obj.get("profile")
+        )
+    except typer.BadParameter:
+        pid, pkey = None, None
 
-    # Initialize the SDK client for API endpoints
-    worker = AsyncWorker()
-    client = worker.submit(lambda: MossClient(pid, pkey))
-    
     # Start server
     if port:
         server = DaemonThreadingHTTPServer(("127.0.0.1", port), PlaygroundHandler)
@@ -459,17 +190,23 @@ def playground_command(
     else:
         server, final_port = _create_server(PlaygroundHandler)
 
-    PlaygroundHandler.client = client
-    PlaygroundHandler._worker = worker
     PlaygroundHandler._token = secrets.token_urlsafe(32)
     PlaygroundHandler._server_host = f"127.0.0.1:{final_port}"
+    PlaygroundHandler._project_id = pid
+    PlaygroundHandler._project_key = pkey
+
     url = f"http://127.0.0.1:{final_port}"
     frag_url = f"{url}/#{PlaygroundHandler._token}"
 
     console.print()
     console.print("  [bold]Moss Playground[/bold]")
     console.print(f"  [dim]Server:[/dim]  [cyan]{frag_url}[/cyan]")
-    console.print(f"  [dim]Project:[/dim] {pid[:8]}...")
+    if pid:
+        console.print(f"  [dim]Project:[/dim] {pid[:8]}...")
+    else:
+        console.print(
+            "  [yellow]No credentials found — enter them in the browser connection form.[/yellow]"
+        )
     console.print("  [dim]Stop:[/dim]    Ctrl+C")
     console.print()
 
@@ -487,5 +224,3 @@ def playground_command(
         console.print("\n[yellow]Shutting down...[/yellow]")
     finally:
         server.server_close()
-        if not worker.stop():
-            console.print("[yellow]Worker thread did not shut down gracefully within timeout[/yellow]")

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -1,9 +1,8 @@
 """moss playground — local web UI for querying Moss indexes interactively.
 
 Starts a local HTTP server that serves a browser-based playground.
-Users can list cloud indexes, load one into browser memory via
-@moss-dev/moss-web (WASM), and run queries with adjustable
-Top-K and Alpha — all with sub-10ms latency after the initial load.
+Index and query operations are proxied through the server's credentialed
+MossClient — the project key never reaches the browser.
 """
 
 from __future__ import annotations
@@ -20,7 +19,7 @@ from urllib.parse import urlparse, parse_qs
 import typer
 from rich.console import Console
 
-from moss import MossClient
+from moss import MossClient, QueryOptions
 
 from ..config import resolve_credentials
 
@@ -47,12 +46,10 @@ def _index_info_to_dict(info: Any) -> Dict[str, Any]:
 
 
 class PlaygroundHandler(SimpleHTTPRequestHandler):
-    """HTTP handler that serves the playground HTML with injected credentials
-    and provides /api/ endpoints backed by the Moss Python SDK."""
+    """HTTP handler — serves the playground UI and proxies SDK calls server-side
+    so the project key is never exposed to the browser."""
 
     client: MossClient | None = None
-    project_id: str = ""
-    project_key: str = ""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=str(HERE / "playground"), **kwargs)
@@ -131,6 +128,66 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
         elif len(args) >= 1:
             console.print(f"  [dim]{args[0]}[/dim]")
 
+    def do_POST(self) -> None:
+        parsed = urlparse(self.path)
+        path = parsed.path
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length).decode("utf-8") if length else "{}"
+        data = json.loads(body)
+
+        if path == "/api/load-index":
+            self._handle_post_load_index(data)
+        elif path == "/api/query":
+            self._handle_post_query(data)
+        else:
+            self._send_json(404, {"error": "Not found"})
+
+    def _handle_post_load_index(self, data: dict) -> None:
+        client = self.client
+        if client is None:
+            self._send_json(500, {"error": "MossClient not initialized"})
+            return
+        name = data.get("name", "")
+        if not name:
+            self._send_json(400, {"error": "Missing 'name' in request body"})
+            return
+        try:
+            asyncio.run(client.load_index(name))
+            self._send_json(200, {"name": name})
+        except Exception as e:
+            self._send_json(500, {"error": str(e)})
+
+    def _handle_post_query(self, data: dict) -> None:
+        client = self.client
+        if client is None:
+            self._send_json(500, {"error": "MossClient not initialized"})
+            return
+        name = data.get("name", "")
+        query = data.get("query", "")
+        if not name or not query:
+            self._send_json(400, {"error": "Missing 'name' or 'query' in request body"})
+            return
+        top_k = data.get("topK")
+        alpha = data.get("alpha")
+        try:
+            opts = QueryOptions(top_k=top_k, alpha=alpha)
+            result = asyncio.run(client.query(name, query, opts))
+            docs = []
+            for d in result.docs:
+                docs.append({
+                    "id": d.id,
+                    "text": d.text,
+                    "score": d.score,
+                    "metadata": d.metadata,
+                })
+            self._send_json(200, {
+                "docs": docs,
+                "timeTakenMs": result.time_taken_ms,
+                "query": result.query,
+            })
+        except Exception as e:
+            self._send_json(500, {"error": str(e)})
+
 
 def _find_free_port(start: int = 8765, max_attempts: int = 20) -> int:
     for port in range(start, start + max_attempts):
@@ -146,10 +203,6 @@ def _find_free_port(start: int = 8765, max_attempts: int = 20) -> int:
 def playground_command(
     ctx: typer.Context,
     port: int = typer.Option(0, "--port", "-p", help="Port for the HTTP server (0 = auto)"),
-    index_dir: Optional[str] = typer.Option(
-        None, "--index-dir", "-d",
-        help="Directory with local .moss index files (experimental)",
-    ),
     profile: Optional[str] = typer.Option(
         None, "--profile", help="Credential profile name",
     ),
@@ -160,18 +213,10 @@ def playground_command(
     """Start the Moss Playground — a local web UI for interactive search.
 
     Launches a browser-based playground where you can list cloud indexes,
-    load one into browser memory via WASM, and run queries with adjustable
-    Top-K and Alpha controls — all with sub-10ms local latency.
+    load one into server memory, and run queries against it.
     """
     if profile:
         ctx.obj["profile"] = profile
-
-    if index_dir:
-        idx_path = Path(index_dir).resolve()
-        if not idx_path.is_dir():
-            console.print(f"[red]Index directory not found: {idx_path}[/red]")
-            raise typer.Exit(1)
-        console.print(f"[dim]Index directory: {idx_path}[/dim]")
 
     # Resolve credentials
     pid, pkey = resolve_credentials(
@@ -193,8 +238,6 @@ def playground_command(
     server_addr = ("127.0.0.1", final_port)
 
     PlaygroundHandler.client = client
-    PlaygroundHandler.project_id = pid
-    PlaygroundHandler.project_key = pkey
 
     server = HTTPServer(server_addr, PlaygroundHandler)
     url = f"http://127.0.0.1:{final_port}"

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -189,7 +189,12 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             self._send_json(500, {"error": "MossClient not initialized"})
             return
         try:
-            indexes = worker.submit(lambda: [_index_info_to_dict(i) for i in client.list_indexes()])
+            async def _call():
+                indexes = client.list_indexes()
+                if inspect.isawaitable(indexes):
+                    indexes = await indexes
+                return [_index_info_to_dict(i) for i in indexes]
+            indexes = worker.submit(_call)
             self._send_json(200, {"indexes": indexes})
         except Exception as e:
             self._send_json(500, {"error": str(e)})
@@ -204,7 +209,12 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             self._send_json(400, {"error": "Missing 'name' query parameter"})
             return
         try:
-            info = worker.submit(lambda: _index_info_to_dict(client.get_index(name)))
+            async def _call():
+                result = client.get_index(name)
+                if inspect.isawaitable(result):
+                    result = await result
+                return _index_info_to_dict(result)
+            info = worker.submit(_call)
             self._send_json(200, {"index": info})
         except Exception as e:
             self._send_json(500, {"error": str(e)})
@@ -296,7 +306,12 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
                     "timeTakenMs": r.time_taken_ms,
                     "query": r.query,
                 }
-            payload = worker.submit(lambda: _build_result(client.query(name, query, QueryOptions(top_k=top_k, alpha=alpha))))
+            async def _call():
+                result = client.query(name, query, QueryOptions(top_k=top_k, alpha=alpha))
+                if inspect.isawaitable(result):
+                    result = await result
+                return _build_result(result)
+            payload = worker.submit(_call)
             self._send_json(200, payload)
         except Exception as e:
             self._send_json(500, {"error": str(e)})

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -49,6 +49,9 @@ class AsyncWorker:
 
     def __init__(self) -> None:
         self._loop = asyncio.new_event_loop()
+        self._lock = asyncio.run_coroutine_threadsafe(
+            asyncio.Lock(), self._loop
+        ).result()
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
 
@@ -65,10 +68,11 @@ class AsyncWorker:
         """
 
         async def runner():
-            result = coro_fn()
-            if inspect.isawaitable(result):
-                return await result
-            return result
+            async with self._lock:
+                result = coro_fn()
+                if inspect.isawaitable(result):
+                    return await result
+                return result
 
         future = asyncio.run_coroutine_threadsafe(runner(), self._loop)
         return future.result()

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import secrets
 import socket
 import webbrowser
 from http.server import HTTPServer, SimpleHTTPRequestHandler
@@ -50,9 +51,25 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
     so the project key is never exposed to the browser."""
 
     client: MossClient | None = None
+    _token: str = ""
+    _server_host: str = ""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=str(HERE / "playground"), **kwargs)
+
+    def _check_api_request(self) -> bool:
+        if self.headers.get("X-Moss-Token") != self._token:
+            self._send_json(403, {"error": "Forbidden: invalid or missing token"})
+            return False
+        host = self.headers.get("Host", "")
+        if host and host != self._server_host and host != self._server_host.replace("127.0.0.1", "localhost"):
+            self._send_json(403, {"error": "Forbidden: invalid Host header"})
+            return False
+        origin = self.headers.get("Origin", "")
+        if origin and origin != f"http://{self._server_host}":
+            self._send_json(403, {"error": "Forbidden: invalid Origin"})
+            return False
+        return True
 
     def _send_json(self, status: int, data: dict) -> None:
         body = json.dumps(data).encode("utf-8")
@@ -81,8 +98,12 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             self.send_response(204)
             self.end_headers()
         elif path == "/api/indexes":
+            if not self._check_api_request():
+                return
             self._handle_list_indexes()
         elif path == "/api/index":
+            if not self._check_api_request():
+                return
             names = params.get("name", [])
             self._handle_get_index(names[0] if names else None)
         else:
@@ -93,6 +114,10 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             self._send_json(500, {"error": "Playground HTML not found"})
             return
         html = PLAYGROUND_HTML.read_text(encoding="utf-8")
+        html = html.replace(
+            "</title>",
+            f'</title>\n<meta name="moss-token" content="{self._token}" />',
+        )
         self._send_html(html)
 
     def _handle_list_indexes(self) -> None:
@@ -129,6 +154,8 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             console.print(f"  [dim]{args[0]}[/dim]")
 
     def do_POST(self) -> None:
+        if not self._check_api_request():
+            return
         parsed = urlparse(self.path)
         path = parsed.path
         length = int(self.headers.get("Content-Length", 0))
@@ -238,6 +265,8 @@ def playground_command(
     server_addr = ("127.0.0.1", final_port)
 
     PlaygroundHandler.client = client
+    PlaygroundHandler._token = secrets.token_urlsafe(32)
+    PlaygroundHandler._server_host = f"127.0.0.1:{final_port}"
 
     server = HTTPServer(server_addr, PlaygroundHandler)
     url = f"http://127.0.0.1:{final_port}"

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
+import math
 import secrets
 import socket
 import threading
@@ -122,6 +123,8 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
     _token: str = ""
     _server_host: str = ""
     _worker: AsyncWorker | None = None
+    _latest_request_id: int = 0
+    _request_lock = threading.Lock()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=str(HERE / "playground"), **kwargs)
@@ -285,14 +288,31 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             self._send_json(400, {"error": "Missing 'name' or 'query' in request body"})
             return
 
-        try:
-            raw_top_k = data.get("topK")
-            raw_alpha = data.get("alpha")
-            top_k = int(raw_top_k) if raw_top_k is not None else None
-            alpha = float(raw_alpha) if raw_alpha is not None else None
-        except (TypeError, ValueError):
-            self._send_json(400, {"error": "'topK' must be an integer and 'alpha' must be a number"})
+        raw_request_id = data.get("requestId")
+        if isinstance(raw_request_id, bool) or not isinstance(raw_request_id, int):
+            self._send_json(400, {"error": "Missing or invalid 'requestId'"})
             return
+
+        raw_top_k = data.get("topK")
+        if raw_top_k is not None:
+            if isinstance(raw_top_k, bool) or not isinstance(raw_top_k, int):
+                self._send_json(400, {"error": "'topK' must be an integer"})
+                return
+            top_k = raw_top_k
+        else:
+            top_k = None
+
+        raw_alpha = data.get("alpha")
+        if raw_alpha is not None:
+            if isinstance(raw_alpha, bool) or not isinstance(raw_alpha, (int, float)):
+                self._send_json(400, {"error": "'alpha' must be a number"})
+                return
+            alpha = float(raw_alpha)
+            if not math.isfinite(alpha):
+                self._send_json(400, {"error": "'alpha' must be a finite number"})
+                return
+        else:
+            alpha = None
 
         if top_k is not None and (top_k < 1 or top_k > 50):
             self._send_json(400, {"error": "topK must be between 1 and 50"})
@@ -300,6 +320,12 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
         if alpha is not None and (alpha < 0 or alpha > 1):
             self._send_json(400, {"error": "alpha must be between 0 and 1"})
             return
+
+        with PlaygroundHandler._request_lock:
+            if raw_request_id < PlaygroundHandler._latest_request_id:
+                self._send_json(200, {"docs": [], "timeTakenMs": 0, "query": query, "superseded": True})
+                return
+            PlaygroundHandler._latest_request_id = raw_request_id
 
         try:
             def _build_result(r):
@@ -312,6 +338,8 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
                     "query": r.query,
                 }
             async def _call():
+                if raw_request_id < PlaygroundHandler._latest_request_id:
+                    return {"docs": [], "timeTakenMs": 0, "query": query, "superseded": True}
                 result = client.query(name, query, QueryOptions(top_k=top_k, alpha=alpha))
                 if inspect.isawaitable(result):
                     result = await result

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -1,0 +1,217 @@
+"""moss playground — local web UI for querying Moss indexes interactively.
+
+Starts a local HTTP server that serves a browser-based playground.
+Users can list cloud indexes, load one into browser memory via
+@moss-dev/moss-web (WASM), and run queries with adjustable
+Top-K and Alpha — all with sub-10ms latency after the initial load.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import webbrowser
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse, parse_qs
+
+import typer
+from rich.console import Console
+
+from moss import MossClient
+
+from ..config import resolve_credentials
+
+console = Console()
+HERE = Path(__file__).resolve().parent.parent
+
+PLAYGROUND_HTML = HERE / "playground" / "index.html"
+
+
+def _index_info_to_dict(info: Any) -> Dict[str, Any]:
+    """Serialize an IndexInfo (Rust/PyO3 type) to a JSON-safe dict."""
+    model = getattr(info, "model", None)
+    model_dict = {"id": getattr(model, "id", None), "version": getattr(model, "version", None)} if model else None
+    return {
+        "id": getattr(info, "id", ""),
+        "name": getattr(info, "name", ""),
+        "version": getattr(info, "version", ""),
+        "status": getattr(info, "status", ""),
+        "docCount": getattr(info, "doc_count", 0),
+        "createdAt": getattr(info, "created_at", ""),
+        "updatedAt": getattr(info, "updated_at", ""),
+        "model": model_dict,
+    }
+
+
+class PlaygroundHandler(SimpleHTTPRequestHandler):
+    """HTTP handler that serves the playground HTML with injected credentials
+    and provides /api/ endpoints backed by the Moss Python SDK."""
+
+    client: MossClient | None = None
+    project_id: str = ""
+    project_key: str = ""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=str(HERE / "playground"), **kwargs)
+
+    def _send_json(self, status: int, data: dict) -> None:
+        body = json.dumps(data).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_html(self, html: str) -> None:
+        body = html.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        path = parsed.path
+        params = parse_qs(parsed.query)
+
+        if path == "/":
+            self._serve_index()
+        elif path == "/favicon.ico":
+            self.send_response(204)
+            self.end_headers()
+        elif path == "/api/indexes":
+            self._handle_list_indexes()
+        elif path == "/api/index":
+            names = params.get("name", [])
+            self._handle_get_index(names[0] if names else None)
+        else:
+            super().do_GET()
+
+    def _serve_index(self) -> None:
+        if not PLAYGROUND_HTML.exists():
+            self._send_json(500, {"error": "Playground HTML not found"})
+            return
+        html = PLAYGROUND_HTML.read_text(encoding="utf-8")
+        self._send_html(html)
+
+    def _handle_list_indexes(self) -> None:
+        client = self.client
+        if client is None:
+            self._send_json(500, {"error": "MossClient not initialized"})
+            return
+        try:
+            indexes = asyncio.run(client.list_indexes())
+            self._send_json(200, {"indexes": [_index_info_to_dict(i) for i in indexes]})
+        except Exception as e:
+            self._send_json(500, {"error": str(e)})
+
+    def _handle_get_index(self, name: str | None) -> None:
+        client = self.client
+        if client is None:
+            self._send_json(500, {"error": "MossClient not initialized"})
+            return
+        if not name:
+            self._send_json(400, {"error": "Missing 'name' query parameter"})
+            return
+        try:
+            info = asyncio.run(client.get_index(name))
+            self._send_json(200, {"index": _index_info_to_dict(info)})
+        except Exception as e:
+            self._send_json(500, {"error": str(e)})
+
+    def log_message(self, format, *args):
+        if len(args) >= 3:
+            console.print(f"  [dim]{args[0]} {args[1]} {args[2]}[/dim]")
+        elif len(args) >= 2:
+            console.print(f"  [dim]{args[0]} {args[1]}[/dim]")
+        elif len(args) >= 1:
+            console.print(f"  [dim]{args[0]}[/dim]")
+
+
+def _find_free_port(start: int = 8765, max_attempts: int = 20) -> int:
+    for port in range(start, start + max_attempts):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("127.0.0.1", port))
+                return port
+            except OSError:
+                continue
+    raise RuntimeError(f"Could not find a free port in range {start}-{start + max_attempts}")
+
+
+def playground_command(
+    ctx: typer.Context,
+    port: int = typer.Option(0, "--port", "-p", help="Port for the HTTP server (0 = auto)"),
+    index_dir: Optional[str] = typer.Option(
+        None, "--index-dir", "-d",
+        help="Directory with local .moss index files (experimental)",
+    ),
+    profile: Optional[str] = typer.Option(
+        None, "--profile", help="Credential profile name",
+    ),
+    no_open: bool = typer.Option(
+        False, "--no-open", help="Do not open the browser automatically",
+    ),
+) -> None:
+    """Start the Moss Playground — a local web UI for interactive search.
+
+    Launches a browser-based playground where you can list cloud indexes,
+    load one into browser memory via WASM, and run queries with adjustable
+    Top-K and Alpha controls — all with sub-10ms local latency.
+    """
+    if profile:
+        ctx.obj["profile"] = profile
+
+    if index_dir:
+        idx_path = Path(index_dir).resolve()
+        if not idx_path.is_dir():
+            console.print(f"[red]Index directory not found: {idx_path}[/red]")
+            raise typer.Exit(1)
+        console.print(f"[dim]Index directory: {idx_path}[/dim]")
+
+    # Resolve credentials
+    pid, pkey = resolve_credentials(
+        ctx.obj.get("project_id"), ctx.obj.get("project_key"), ctx.obj.get("profile")
+    )
+
+    if not pid or not pkey:
+        console.print(
+            "[red]No credentials found.[/red] Run [bold]moss init[/bold] first "
+            "or set MOSS_PROJECT_ID and MOSS_PROJECT_KEY."
+        )
+        raise typer.Exit(1)
+
+    # Initialize the SDK client for API endpoints
+    client = MossClient(pid, pkey)
+
+    # Start server
+    final_port = port if port else _find_free_port()
+    server_addr = ("127.0.0.1", final_port)
+
+    PlaygroundHandler.client = client
+    PlaygroundHandler.project_id = pid
+    PlaygroundHandler.project_key = pkey
+
+    server = HTTPServer(server_addr, PlaygroundHandler)
+    url = f"http://127.0.0.1:{final_port}"
+
+    console.print()
+    console.print("  [bold]Moss Playground[/bold]")
+    console.print(f"  [dim]Server:[/dim]  [cyan]{url}[/cyan]")
+    console.print(f"  [dim]Project:[/dim] {pid[:8]}...")
+    console.print("  [dim]Stop:[/dim]    Ctrl+C")
+    console.print()
+
+    if not no_open:
+        webbrowser.open(url)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Shutting down...[/yellow]")
+        server.server_close()

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -49,11 +49,12 @@ class AsyncWorker:
 
     def __init__(self) -> None:
         self._loop = asyncio.new_event_loop()
-        self._lock = asyncio.run_coroutine_threadsafe(
-            asyncio.Lock(), self._loop
-        ).result()
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
+        self._lock = asyncio.run_coroutine_threadsafe(self._make_lock(), self._loop).result()
+
+    async def _make_lock(self) -> asyncio.Lock:
+        return asyncio.Lock()
 
     def _run(self) -> None:
         asyncio.set_event_loop(self._loop)

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -73,9 +73,10 @@ class AsyncWorker:
         future = asyncio.run_coroutine_threadsafe(runner(), self._loop)
         return future.result()
 
-    def stop(self) -> None:
+    def stop(self, timeout: float | None = 5.0) -> bool:
         self._loop.call_soon_threadsafe(self._loop.stop)
-        self._thread.join()
+        self._thread.join(timeout)
+        return self._thread.is_alive()
 
 
 def _index_info_to_dict(info: Any) -> Dict[str, Any]:
@@ -286,8 +287,7 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             return
 
         try:
-            opts = QueryOptions(top_k=top_k, alpha=alpha)
-            result = worker.submit(lambda: client.query(name, query, opts))
+            result = worker.submit(lambda: client.query(name, query, QueryOptions(top_k=top_k, alpha=alpha)))
             docs = []
             for d in result.docs:
                 docs.append({
@@ -347,9 +347,9 @@ def playground_command(
         raise typer.Exit(1)
 
     # Initialize the SDK client for API endpoints
-    client = MossClient(pid, pkey)
     worker = AsyncWorker()
-
+    client = worker.submit(lambda: MossClient(pid, pkey))
+    
     # Start server
     final_port = port if port else _find_free_port()
     server_addr = ("127.0.0.1", final_port)
@@ -384,4 +384,5 @@ def playground_command(
         console.print("\n[yellow]Shutting down...[/yellow]")
     finally:
         server.server_close()
-        worker.stop()
+        if worker.stop():
+            console.print("[yellow]Worker thread did not shut down gracefully within timeout[/yellow]")

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -12,7 +12,7 @@ import json
 import secrets
 import socket
 import webbrowser
-from http.server import HTTPServer, SimpleHTTPRequestHandler
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse, parse_qs
@@ -194,6 +194,16 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             return
         top_k = data.get("topK")
         alpha = data.get("alpha")
+        if top_k is not None:
+            top_k = int(top_k)
+            if top_k < 1 or top_k > 50:
+                self._send_json(400, {"error": "topK must be between 1 and 50"})
+                return
+        if alpha is not None:
+            alpha = float(alpha)
+            if alpha < 0 or alpha > 1:
+                self._send_json(400, {"error": "alpha must be between 0 and 1"})
+                return
         try:
             opts = QueryOptions(top_k=top_k, alpha=alpha)
             result = asyncio.run(client.query(name, query, opts))
@@ -266,7 +276,7 @@ def playground_command(
     PlaygroundHandler._token = secrets.token_urlsafe(32)
     PlaygroundHandler._server_host = f"127.0.0.1:{final_port}"
 
-    server = HTTPServer(server_addr, PlaygroundHandler)
+    server = ThreadingHTTPServer(server_addr, PlaygroundHandler)
     url = f"http://127.0.0.1:{final_port}"
     frag_url = f"{url}/#{PlaygroundHandler._token}"
 

--- a/packages/moss-cli/src/moss_cli/commands/playground.py
+++ b/packages/moss-cli/src/moss_cli/commands/playground.py
@@ -22,6 +22,7 @@ from urllib.parse import urlparse, parse_qs
 
 import typer
 from rich.console import Console
+from rich.markup import escape as rich_escape
 
 from moss import MossClient, QueryOptions
 
@@ -31,6 +32,8 @@ console = Console()
 HERE = Path(__file__).resolve().parent.parent
 
 PLAYGROUND_HTML = HERE / "playground" / "index.html"
+
+MAX_REQUEST_BODY_SIZE = 1 << 20
 
 
 class AsyncWorker:
@@ -82,7 +85,7 @@ class AsyncWorker:
     def stop(self, timeout: float | None = 5.0) -> bool:
         self._loop.call_soon_threadsafe(self._loop.stop)
         self._thread.join(timeout)
-        return self._thread.is_alive()
+        return not self._thread.is_alive()
 
 
 def _index_info_to_dict(info: Any) -> Dict[str, Any]:
@@ -123,14 +126,15 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
     _token: str = ""
     _server_host: str = ""
     _worker: AsyncWorker | None = None
-    _latest_request_id: int = 0
+    _latest_request_ids: Dict[str, int] = {}
     _request_lock = threading.Lock()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=str(HERE / "playground"), **kwargs)
 
     def _check_api_request(self) -> bool:
-        if self.headers.get("X-Moss-Token") != self._token:
+        token = self.headers.get("X-Moss-Token")
+        if token is None or not secrets.compare_digest(token, self._token):
             self._send_json(403, {"error": "Forbidden: invalid or missing token"})
             return False
         host = self.headers.get("Host", "")
@@ -160,6 +164,17 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
+
+    def _require_string_field(self, data: dict, key: str, message: str) -> str | None:
+        value = data.get(key)
+        if not isinstance(value, str) or not value.strip():
+            self._send_json(400, {"error": message})
+            return None
+        return value
+
+    def _send_error(self, exc: Exception) -> None:
+        console.print(f"[red]Playground error:[/red] {rich_escape(f'{type(exc).__name__}: {exc}')}")
+        self._send_json(500, {"error": "Internal server error"})
 
     def do_GET(self) -> None:
         parsed = urlparse(self.path)
@@ -205,7 +220,7 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             indexes = worker.submit(_call)
             self._send_json(200, {"indexes": indexes})
         except Exception as e:
-            self._send_json(500, {"error": str(e)})
+            self._send_error(e)
 
     def _handle_get_index(self, name: str | None) -> None:
         client = self.client
@@ -225,22 +240,37 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             info = worker.submit(_call)
             self._send_json(200, {"index": info})
         except Exception as e:
-            self._send_json(500, {"error": str(e)})
+            self._send_error(e)
 
     def log_message(self, format, *args):
-        if len(args) >= 3:
-            console.print(f"  [dim]{args[0]} {args[1]} {args[2]}[/dim]")
-        elif len(args) >= 2:
-            console.print(f"  [dim]{args[0]} {args[1]}[/dim]")
-        elif len(args) >= 1:
-            console.print(f"  [dim]{args[0]}[/dim]")
+        safe = [rich_escape(str(a)) for a in args]
+        if len(safe) >= 3:
+            console.print(f"  [dim]{safe[0]} {safe[1]} {safe[2]}[/dim]")
+        elif len(safe) >= 2:
+            console.print(f"  [dim]{safe[0]} {safe[1]}[/dim]")
+        elif len(safe) >= 1:
+            console.print(f"  [dim]{safe[0]}[/dim]")
 
     def do_POST(self) -> None:
         if not self._check_api_request():
             return
         parsed = urlparse(self.path)
         path = parsed.path
-        length = int(self.headers.get("Content-Length", 0))
+        length_header = self.headers.get("Content-Length")
+        if length_header is None:
+            length = 0
+        else:
+            try:
+                length = int(length_header)
+            except ValueError:
+                self._send_json(400, {"error": "Invalid Content-Length header"})
+                return
+            if length < 0:
+                self._send_json(400, {"error": "Invalid Content-Length header"})
+                return
+            if length > MAX_REQUEST_BODY_SIZE:
+                self._send_json(413, {"error": "Request body too large"})
+                return
         raw_body = self.rfile.read(length) if length else b"{}"
 
         try:
@@ -266,15 +296,14 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
         if client is None or worker is None:
             self._send_json(500, {"error": "MossClient not initialized"})
             return
-        name = data.get("name", "")
-        if not name:
-            self._send_json(400, {"error": "Missing 'name' in request body"})
+        name = self._require_string_field(data, "name", "Missing 'name' in request body")
+        if name is None:
             return
         try:
             worker.submit(lambda: client.load_index(name))
             self._send_json(200, {"name": name})
         except Exception as e:
-            self._send_json(500, {"error": str(e)})
+            self._send_error(e)
 
     def _handle_post_query(self, data: dict) -> None:
         client = self.client
@@ -282,10 +311,16 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
         if client is None or worker is None:
             self._send_json(500, {"error": "MossClient not initialized"})
             return
-        name = data.get("name", "")
-        query = data.get("query", "")
-        if not name or not query:
-            self._send_json(400, {"error": "Missing 'name' or 'query' in request body"})
+        name = self._require_string_field(data, "name", "Missing 'name' or 'query' in request body")
+        if name is None:
+            return
+        query = self._require_string_field(data, "query", "Missing 'name' or 'query' in request body")
+        if query is None:
+            return
+
+        session_id = data.get("sessionId")
+        if not isinstance(session_id, str) or not session_id:
+            self._send_json(400, {"error": "Missing or invalid 'sessionId'"})
             return
 
         raw_request_id = data.get("requestId")
@@ -322,10 +357,11 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             return
 
         with PlaygroundHandler._request_lock:
-            if raw_request_id < PlaygroundHandler._latest_request_id:
+            latest = PlaygroundHandler._latest_request_ids.get(session_id, 0)
+            if raw_request_id < latest:
                 self._send_json(200, {"docs": [], "timeTakenMs": 0, "query": query, "superseded": True})
                 return
-            PlaygroundHandler._latest_request_id = raw_request_id
+            PlaygroundHandler._latest_request_ids[session_id] = raw_request_id
 
         try:
             def _build_result(r):
@@ -338,7 +374,7 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
                     "query": r.query,
                 }
             async def _call():
-                if raw_request_id < PlaygroundHandler._latest_request_id:
+                if raw_request_id < PlaygroundHandler._latest_request_ids.get(session_id, 0):
                     return {"docs": [], "timeTakenMs": 0, "query": query, "superseded": True}
                 result = client.query(name, query, QueryOptions(top_k=top_k, alpha=alpha))
                 if inspect.isawaitable(result):
@@ -347,7 +383,7 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
             payload = worker.submit(_call)
             self._send_json(200, payload)
         except Exception as e:
-            self._send_json(500, {"error": str(e)})
+            self._send_error(e)
 
 
 def _find_free_port(start: int = 8765, max_attempts: int = 20) -> int:
@@ -383,13 +419,6 @@ def playground_command(
     pid, pkey = resolve_credentials(
         ctx.obj.get("project_id"), ctx.obj.get("project_key"), ctx.obj.get("profile")
     )
-
-    if not pid or not pkey:
-        console.print(
-            "[red]No credentials found.[/red] Run [bold]moss init[/bold] first "
-            "or set MOSS_PROJECT_ID and MOSS_PROJECT_KEY."
-        )
-        raise typer.Exit(1)
 
     # Initialize the SDK client for API endpoints
     worker = AsyncWorker()
@@ -429,5 +458,5 @@ def playground_command(
         console.print("\n[yellow]Shutting down...[/yellow]")
     finally:
         server.server_close()
-        if worker.stop():
+        if not worker.stop():
             console.print("[yellow]Worker thread did not shut down gracefully within timeout[/yellow]")

--- a/packages/moss-cli/src/moss_cli/main.py
+++ b/packages/moss-cli/src/moss_cli/main.py
@@ -12,6 +12,7 @@ from .commands.doc import doc_app
 from .commands.index import index_app
 from .commands.init_cmd import init_command
 from .commands.job import job_app
+from .commands.playground import playground_command
 from .commands.profile import profile_app
 from .commands.search import query_command
 from .commands.sync import sync_command
@@ -39,6 +40,7 @@ app.command(name="version")(version_command)
 app.command(name="validate")(validate_command)
 app.command(name="sync")(sync_command)
 app.command(name="completions")(completions_command)
+app.command(name="playground")(playground_command)
 
 
 @app.callback()

--- a/packages/moss-cli/src/moss_cli/playground/index.html
+++ b/packages/moss-cli/src/moss_cli/playground/index.html
@@ -158,22 +158,29 @@ const alphaDisplay = $('alpha-display');
 const results = $('results');
 const searchForm = $('search-form');
 
-async function fetchIndexes() {
-  try {
-    const res = await apiFetch('/api/indexes');
-    if (!res.ok) throw new Error('Failed to fetch indexes');
-    const data = await res.json();
-    indexes = data.indexes || [];
-    return indexes;
-  } catch (e) {
-    console.error('fetchIndexes failed:', e);
-    return [];
-  }
-}
-
 async function refreshIndexList() {
   select.innerHTML = '<option value="">Loading...</option>';
-  const idxs = await fetchIndexes();
+  let idxs;
+  try {
+    const res = await apiFetch('/api/indexes');
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(err.error || 'Failed to fetch indexes');
+    }
+    const data = await res.json();
+    idxs = data.indexes || [];
+  } catch (e) {
+    console.error('fetchIndexes failed:', e);
+    select.innerHTML = '<option value="">Error loading indexes</option>';
+    loadBtn.disabled = true;
+    const status = document.createElement('div');
+    status.className = 'status-box status-error';
+    status.textContent = `Failed to list indexes: ${e.message || e}`;
+    const existing = select.parentElement.querySelector('.status-error');
+    if (existing) existing.remove();
+    select.parentElement.appendChild(status);
+    return;
+  }
   select.innerHTML = '';
   if (idxs.length === 0) {
     select.innerHTML = '<option value="">No indexes found</option>';
@@ -262,11 +269,8 @@ async function loadIndex() {
   } catch (e) {
     if (loadReqId !== requestId) return;
     console.error('loadIndex failed:', e);
-    currentIndex = null;
     updateLoadBtn();
     loadStatus.classList.remove('hidden');
-    loadStatus.className = 'status-box status-error';
-    loadStatus.textContent = `Failed: ${e.message || e}`;
     loadStatus.className = 'status-box status-error';
     loadStatus.textContent = `Failed: ${e.message || e}`;
   } finally {

--- a/packages/moss-cli/src/moss_cli/playground/index.html
+++ b/packages/moss-cli/src/moss_cli/playground/index.html
@@ -351,7 +351,7 @@ function renderResults(searchResults) {
     item.innerHTML = `
       <div class="result-meta">
         <span class="${scoreClass}">${scorePct}%</span>
-        <span class="result-id">${doc.id}</span>
+        <span class="result-id">${escapeHtml(doc.id)}</span>
       </div>
       <div class="result-text">${escapeHtml(doc.text)}</div>
     `;

--- a/packages/moss-cli/src/moss_cli/playground/index.html
+++ b/packages/moss-cli/src/moss_cli/playground/index.html
@@ -168,7 +168,7 @@ async function refreshIndexList() {
       throw new Error(err.error || 'Failed to fetch indexes');
     }
     const data = await res.json();
-    idxs = data.indexes || [];
+    indexes = data.indexes || [];
   } catch (e) {
     console.error('fetchIndexes failed:', e);
     select.innerHTML = '<option value="">Error loading indexes</option>';
@@ -182,12 +182,12 @@ async function refreshIndexList() {
     return;
   }
   select.innerHTML = '';
-  if (idxs.length === 0) {
+  if (indexes.length === 0) {
     select.innerHTML = '<option value="">No indexes found</option>';
     loadBtn.disabled = true;
     return;
   }
-  idxs.forEach(idx => {
+  indexes.forEach(idx => {
     const opt = document.createElement('option');
     opt.value = idx.name;
     const status = idx.status === 'Ready' ? '' : ` (${idx.status})`;
@@ -264,6 +264,11 @@ async function loadIndex() {
     }
     if (loadReqId !== requestId || select.value !== name) return;
     currentIndex = name;
+    results.innerHTML = '';
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.innerHTML = '<p>Type a query to search</p>';
+    results.appendChild(empty);
     updateLoadBtn();
     searchInput.focus();
   } catch (e) {
@@ -387,6 +392,11 @@ function handleSearch(e) {
 select.addEventListener('change', () => {
   ++requestId;
   if (searchTimeout) clearTimeout(searchTimeout);
+  results.innerHTML = '';
+  const empty = document.createElement('div');
+  empty.className = 'empty-state';
+  empty.innerHTML = '<p>Load this index and type a query to search</p>';
+  results.appendChild(empty);
   updateLoadBtn();
   const name = select.value;
   const idx = indexes.find(i => i.name === name);

--- a/packages/moss-cli/src/moss_cli/playground/index.html
+++ b/packages/moss-cli/src/moss_cli/playground/index.html
@@ -193,11 +193,19 @@ async function refreshIndexList() {
 
 function updateLoadBtn() {
   const name = select.value;
-  loadBtn.disabled = !name || name === currentIndex;
-  if (name !== currentIndex && currentIndex) {
-    searchInput.disabled = true;
-    topkInput.disabled = true;
-    alphaSlider.disabled = true;
+  const isLoaded = name === currentIndex;
+  loadBtn.disabled = !name || isLoaded;
+  loadBtn.innerHTML = isLoaded ? '&#10003; Loaded' : 'Load Index';
+  loadBtn.className = isLoaded ? 'btn btn-success' : 'btn btn-primary';
+  searchInput.disabled = !isLoaded;
+  topkInput.disabled = !isLoaded;
+  alphaSlider.disabled = !isLoaded;
+  if (isLoaded) {
+    loadStatus.className = 'status-box status-success';
+    loadStatus.textContent = 'Index loaded into server memory';
+    loadStatus.classList.remove('hidden');
+  } else {
+    loadStatus.classList.add('hidden');
   }
 }
 
@@ -249,22 +257,16 @@ async function loadIndex() {
     }
     if (loadReqId !== requestId || select.value !== name) return;
     currentIndex = name;
-    loadBtn.innerHTML = '&#10003; Loaded';
-    loadBtn.className = 'btn btn-success';
-    loadBtn.disabled = false;
-    loadStatus.className = 'status-box status-success';
-    loadStatus.textContent = 'Index loaded into server memory';
-    searchInput.disabled = false;
+    updateLoadBtn();
     searchInput.focus();
-    topkInput.disabled = false;
-    alphaSlider.disabled = false;
   } catch (e) {
     if (loadReqId !== requestId) return;
     console.error('loadIndex failed:', e);
     currentIndex = null;
-    loadBtn.innerHTML = 'Load Index';
-    loadBtn.className = 'btn btn-primary';
-    loadBtn.disabled = false;
+    updateLoadBtn();
+    loadStatus.classList.remove('hidden');
+    loadStatus.className = 'status-box status-error';
+    loadStatus.textContent = `Failed: ${e.message || e}`;
     loadStatus.className = 'status-box status-error';
     loadStatus.textContent = `Failed: ${e.message || e}`;
   } finally {

--- a/packages/moss-cli/src/moss_cli/playground/index.html
+++ b/packages/moss-cli/src/moss_cli/playground/index.html
@@ -135,7 +135,7 @@ input[type=range]{width:100%;accent-color:var(--primary);height:4px;cursor:point
 </div>
 
 <script type="module">
-const mossToken = document.querySelector('meta[name="moss-token"]')?.getAttribute('content') || '';
+const mossToken = location.hash.replace(/^#/, '') || '';
 
 function apiFetch(path, options = {}) {
   const headers = { ...options.headers, 'X-Moss-Token': mossToken };
@@ -226,6 +226,9 @@ function showIndexInfo(idx) {
 async function loadIndex() {
   const name = select.value;
   if (!name) return;
+
+  ++requestId;
+  if (searchTimeout) clearTimeout(searchTimeout);
 
   loadBtn.disabled = true;
   loadBtn.innerHTML = '<span class="spinner">&#9696;</span> Loading...';
@@ -344,6 +347,7 @@ function handleSearch(e) {
 
   if (searchTimeout) clearTimeout(searchTimeout);
   const thisRequestId = ++requestId;
+  const idx = currentIndex;
   searchTimeout = setTimeout(async () => {
     const placeholder = results.querySelector('.empty-state');
     if (placeholder) placeholder.innerHTML = '<p>Searching...</p>';
@@ -352,7 +356,7 @@ function handleSearch(e) {
       const res = await apiFetch('/api/query', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: currentIndex, query, topK, alpha }),
+        body: JSON.stringify({ name: idx, query, topK, alpha }),
       });
       if (!res.ok) {
         const err = await res.json();
@@ -370,6 +374,8 @@ function handleSearch(e) {
 }
 
 select.addEventListener('change', () => {
+  ++requestId;
+  if (searchTimeout) clearTimeout(searchTimeout);
   updateLoadBtn();
   const name = select.value;
   const idx = indexes.find(i => i.name === name);

--- a/packages/moss-cli/src/moss_cli/playground/index.html
+++ b/packages/moss-cli/src/moss_cli/playground/index.html
@@ -1,0 +1,472 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Moss Playground</title>
+<script type="importmap">
+{
+  "imports": {
+    "@moss-dev/moss-web": "https://unpkg.com/@moss-dev/moss-web@1.0.0/dist/index.js",
+    "@moss-dev/moss-wasm": "https://unpkg.com/@moss-dev/moss-wasm@0.10.0/moss_wasm.js",
+    "onnxruntime-web": "https://unpkg.com/onnxruntime-web@1.27.0/dist/ort.bundle.min.mjs"
+  }
+}
+</script>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{--bg:#0f0f13;--surface:#1a1a23;--surface2:#22222e;--border:#2e2e3a;--text:#e8e8ef;--text2:#8888a0;--primary:#6366f1;--primary-hover:#5558e6;--success:#22c55e;--error:#ef4444;--warning:#f59e0b;--radius:8px;--font:system-ui,-apple-system,sans-serif;--mono:'SF Mono','Fira Code','Cascadia Code',monospace}
+body{background:var(--bg);color:var(--text);font-family:var(--font);font-size:14px;line-height:1.5;min-height:100vh}
+.container{max-width:1200px;margin:0 auto;padding:24px}
+header{text-align:center;margin-bottom:32px}
+header h1{font-size:24px;font-weight:700;letter-spacing:-0.5px}
+header h1 span{color:var(--primary)}
+header p{color:var(--text2);font-size:13px;margin-top:4px}
+.grid{display:grid;grid-template-columns:320px 1fr;gap:24px}
+@media(max-width:768px){.grid{grid-template-columns:1fr}}
+.panel{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:20px}
+.panel-title{font-size:15px;font-weight:600;margin-bottom:16px;display:flex;align-items:center;gap:8px}
+label{display:block;font-size:12px;font-weight:500;color:var(--text2);margin-bottom:4px}
+select,input[type=text],input[type=number]{width:100%;padding:8px 10px;background:var(--surface2);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:13px;font-family:var(--font);outline:none;transition:border-color .15s}
+select:focus,input:focus{border-color:var(--primary)}
+select option{background:var(--surface2);color:var(--text)}
+input[type=number]{width:72px}
+input[type=range]{width:100%;accent-color:var(--primary);height:4px;cursor:pointer;background:transparent}
+.btn{padding:8px 16px;border:none;border-radius:6px;font-size:13px;font-weight:500;cursor:pointer;display:inline-flex;align-items:center;gap:6px;transition:all .15s;font-family:var(--font)}
+.btn-primary{background:var(--primary);color:#fff}
+.btn-primary:hover{background:var(--primary-hover)}
+.btn-primary:disabled{opacity:.4;cursor:not-allowed}
+.btn-secondary{background:var(--surface2);color:var(--text);border:1px solid var(--border)}
+.btn-secondary:hover{background:var(--border)}
+.btn-secondary:disabled{opacity:.4;cursor:not-allowed}
+.btn-success{background:var(--success);color:#fff}
+.btn-success:disabled{opacity:.4;cursor:not-allowed}
+.spinner{animation:spin .8s linear infinite}
+@keyframes spin{to{transform:rotate(360deg)}}
+.controls{margin-bottom:16px}
+.control-row{display:flex;align-items:center;gap:12px;margin-bottom:12px}
+.control-row label{display:flex;align-items:center;gap:6px;margin:0;white-space:nowrap}
+.control-row .range-wrap{flex:1;display:flex;align-items:center;gap:8px}
+.control-row .range-wrap span{font-size:11px;color:var(--text2);white-space:nowrap}
+.alpha-value{font-family:var(--mono);font-size:12px;color:var(--text2);min-width:48px;text-align:right}
+.status-box{padding:10px 12px;border-radius:6px;font-size:12px;display:flex;align-items:center;gap:8px;margin-top:12px}
+.status-success{background:color-mix(in srgb,var(--success) 15%,transparent);color:var(--success);border:1px solid color-mix(in srgb,var(--success) 30%,transparent)}
+.status-error{background:color-mix(in srgb,var(--error) 15%,transparent);color:var(--error);border:1px solid color-mix(in srgb,var(--error) 30%,transparent)}
+.search-form{margin-bottom:12px}
+.search-group{display:flex;align-items:center;background:var(--surface2);border:1px solid var(--border);border-radius:8px;padding:2px;transition:border-color .15s}
+.search-group:focus-within{border-color:var(--primary)}
+.search-group input{flex:1;background:transparent;border:none;padding:10px 8px;color:var(--text);font-size:14px;outline:none}
+.search-group input::placeholder{color:var(--text2)}
+.search-group input:disabled{opacity:.5}
+.search-icon{padding:0 4px 0 10px;color:var(--text2);display:flex}
+.index-select{display:flex;gap:8px;margin-bottom:16px}
+.index-select select{flex:1}
+.index-info{font-size:12px;color:var(--text2);margin-bottom:12px;padding:8px 10px;background:var(--surface2);border-radius:6px;font-family:var(--mono);word-break:break-all;line-height:1.6}
+.index-info strong{color:var(--text)}
+.results-summary{font-size:12px;color:var(--text2);margin-bottom:12px;display:flex;justify-content:space-between;align-items:center}
+.result-item{padding:12px;border:1px solid var(--border);border-radius:6px;margin-bottom:8px;transition:border-color .15s}
+.result-item:hover{border-color:var(--primary)}
+.result-meta{display:flex;align-items:center;gap:8px;margin-bottom:6px}
+.result-score{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;font-family:var(--mono);background:color-mix(in srgb,var(--success) 20%,transparent);color:var(--success)}
+.result-score.low{background:color-mix(in srgb,var(--warning) 20%,transparent);color:var(--warning)}
+.result-id{font-size:11px;color:var(--text2);font-family:var(--mono)}
+.result-text{font-size:13px;color:var(--text);line-height:1.5;word-break:break-word}
+.empty-state{text-align:center;padding:48px 24px;color:var(--text2)}
+.empty-state svg{width:48px;height:48px;margin-bottom:12px;opacity:.3}
+.empty-state p{font-size:13px}
+.creds-form{display:flex;flex-direction:column;gap:12px;max-width:400px;margin:48px auto}
+.creds-form h2{text-align:center;font-size:18px;margin-bottom:8px}
+.creds-form p{text-align:center;font-size:12px;color:var(--text2)}
+.creds-form input{padding:10px 12px}
+.creds-form .btn{width:100%;justify-content:center;padding:10px}
+.hidden{display:none!important}
+.result-timestamp{font-size:10px;color:var(--text2);opacity:.5}
+</style>
+</head>
+<body>
+<div class="container" id="app">
+  <header>
+    <h1>Moss <span>Playground</span></h1>
+    <p>Load an index, run queries, and inspect results &mdash; all in your browser via WASM</p>
+  </header>
+
+  <div id="creds-panel" class="creds-form hidden">
+    <h2>Connect to Moss</h2>
+    <p>Enter your Project ID and Project Key to get started.</p>
+    <input id="pid-input" type="text" placeholder="Project ID" />
+    <input id="pkey-input" type="password" placeholder="Project Key" />
+    <button class="btn btn-primary" id="connect-btn">Connect</button>
+  </div>
+
+  <div id="main-panel" class="hidden">
+    <div class="grid">
+      <!-- Left: Index Selection -->
+      <div>
+        <div class="panel">
+          <div class="panel-title">Index</div>
+          <div class="index-select">
+            <select id="index-select">
+              <option value="">Loading indexes...</option>
+            </select>
+          </div>
+          <div id="index-info" class="index-info hidden"></div>
+          <button class="btn btn-primary" id="load-btn" disabled style="width:100%;justify-content:center">
+            Load Index
+          </button>
+          <div id="load-status" class="hidden"></div>
+        </div>
+      </div>
+
+      <!-- Right: Search -->
+      <div>
+        <div class="panel">
+          <div class="panel-title">Search</div>
+          <div class="search-form">
+            <form id="search-form" autocomplete="off">
+              <div class="search-group">
+                <span class="search-icon">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+                </span>
+                <input type="text" id="search-input" placeholder="Type to search..." disabled />
+              </div>
+            </form>
+          </div>
+
+          <div class="controls">
+            <div class="control-row">
+              <label>Top K <input type="number" id="topk-input" min="1" max="50" value="5" disabled /></label>
+              <div class="range-wrap">
+                <span>Keyword</span>
+                <input type="range" id="alpha-slider" min="0" max="1" step="0.05" value="0.5" disabled />
+                <span>Semantic</span>
+                <span class="alpha-value" id="alpha-display">&alpha; 0.50</span>
+              </div>
+            </div>
+          </div>
+
+          <div id="results">
+            <div class="empty-state" id="results-placeholder">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+              <p>Load an index and type a query to search</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script type="module">
+let MossClientClass = null;
+let client = null;
+let indexes = [];
+let currentIndex = null;
+let isIndexLoaded = false;
+
+const $ = id => document.getElementById(id);
+const select = $('index-select');
+const loadBtn = $('load-btn');
+const loadStatus = $('load-status');
+const indexInfo = $('index-info');
+const searchInput = $('search-input');
+const topkInput = $('topk-input');
+const alphaSlider = $('alpha-slider');
+const alphaDisplay = $('alpha-display');
+const results = $('results');
+const resultsPlaceholder = $('results-placeholder');
+const searchForm = $('search-form');
+const pidInput = $('pid-input');
+const pkeyInput = $('pkey-input');
+const connectBtn = $('connect-btn');
+const credsPanel = $('creds-panel');
+const mainPanel = $('main-panel');
+
+let projectId = '';
+let projectKey = '';
+
+function resolveCssVar(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+async function loadMossClient() {
+  try {
+    const mod = await import("@moss-dev/moss-web");
+    MossClientClass = mod.MossClient;
+    return true;
+  } catch (e) {
+    console.error('Failed to load @moss-dev/moss-web:', e);
+    return false;
+  }
+}
+
+function showCredsForm(message) {
+  credsPanel.classList.remove('hidden');
+  mainPanel.classList.add('hidden');
+  if (message) {
+    const existing = credsPanel.querySelector('.status-error');
+    if (existing) existing.remove();
+    const err = document.createElement('div');
+    err.className = 'status-box status-error';
+    err.textContent = message;
+    credsPanel.appendChild(err);
+  }
+}
+
+function initClient(id, key) {
+  if (!MossClientClass) return false;
+  if (client) client.dispose();
+  client = new MossClientClass(id, key);
+  projectId = id;
+  projectKey = key;
+  return true;
+}
+
+async function fetchIndexes() {
+  try {
+    const res = await fetch('/api/indexes');
+    if (!res.ok) throw new Error('Failed to fetch indexes');
+    const data = await res.json();
+    indexes = data.indexes || [];
+    return indexes;
+  } catch {
+    // fallback: list via cloud API using client
+    if (!client) return [];
+    try {
+      indexes = await client.listIndexes();
+      return indexes;
+    } catch (e) {
+      console.error('listIndexes failed:', e);
+      return [];
+    }
+  }
+}
+
+async function refreshIndexList() {
+  select.innerHTML = '<option value="">Loading...</option>';
+  const idxs = await fetchIndexes();
+  select.innerHTML = '';
+  if (idxs.length === 0) {
+    select.innerHTML = '<option value="">No indexes found</option>';
+    loadBtn.disabled = true;
+    return;
+  }
+  idxs.forEach(idx => {
+    const opt = document.createElement('option');
+    opt.value = idx.name;
+    const status = idx.status === 'Ready' ? '' : ` (${idx.status})`;
+    opt.textContent = `${idx.name}${status} — ${idx.docCount || 0} docs`;
+    select.appendChild(opt);
+  });
+  select.value = '';
+  updateLoadBtn();
+}
+
+function updateLoadBtn() {
+  const name = select.value;
+  loadBtn.disabled = !name || isIndexLoaded;
+}
+
+function showIndexInfo(idx) {
+  if (!idx) {
+    indexInfo.classList.add('hidden');
+    return;
+  }
+  indexInfo.classList.remove('hidden');
+  indexInfo.innerHTML = '';
+  const rows = [
+    ['Name', idx.name],
+    ['Status', idx.status],
+    ['Documents', String(idx.docCount ?? 0)],
+    ['Model', idx.model?.id ?? 'unknown'],
+    ['Created', idx.createdAt ?? 'unknown'],
+  ];
+  for (const [label, value] of rows) {
+    const strong = document.createElement('strong');
+    strong.textContent = label + ':';
+    indexInfo.appendChild(strong);
+    indexInfo.appendChild(document.createTextNode(' ' + value + '\n'));
+  }
+}
+
+async function loadIndex() {
+  const name = select.value;
+  if (!name || !client) return;
+
+  loadBtn.disabled = true;
+  loadBtn.innerHTML = '<span class="spinner">&#9696;</span> Loading...';
+  loadStatus.classList.remove('hidden');
+  loadStatus.className = 'status-box';
+  loadStatus.textContent = 'Connecting to cloud...';
+
+  try {
+    await client.loadIndex(name);
+    isIndexLoaded = true;
+    currentIndex = name;
+    loadBtn.innerHTML = '&#10003; Loaded';
+    loadBtn.className = 'btn btn-success';
+    loadStatus.className = 'status-box status-success';
+    loadStatus.textContent = 'Index loaded into browser memory';
+    searchInput.disabled = false;
+    searchInput.focus();
+    topkInput.disabled = false;
+    alphaSlider.disabled = false;
+  } catch (e) {
+    console.error('loadIndex failed:', e);
+    isIndexLoaded = false;
+    loadBtn.innerHTML = 'Load Index';
+    loadBtn.className = 'btn btn-primary';
+    loadBtn.disabled = false;
+    loadStatus.className = 'status-box status-error';
+    loadStatus.textContent = `Failed: ${e.message || e}`;
+  }
+}
+
+function renderResults(searchResults) {
+  results.innerHTML = '';
+
+  if (!searchResults || !searchResults.docs || searchResults.docs.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.innerHTML = '<p>No matching results. Try a different query.</p>';
+    results.appendChild(empty);
+    return;
+  }
+
+  const summary = document.createElement('div');
+  summary.className = 'results-summary';
+  const timeMs = searchResults.timeTakenMs || searchResults.timeTakenInMs;
+  summary.innerHTML = `
+    <span>${searchResults.docs.length} result(s)</span>
+    ${timeMs != null ? `<span>${timeMs.toFixed(1)} ms</span>` : ''}
+  `;
+  results.appendChild(summary);
+
+  searchResults.docs.forEach(doc => {
+    const item = document.createElement('div');
+    item.className = 'result-item';
+    const score = doc.score || 0;
+    const scorePct = (score * 100).toFixed(0);
+    const scoreClass = score < 0.75 ? 'result-score low' : 'result-score';
+
+    item.innerHTML = `
+      <div class="result-meta">
+        <span class="${scoreClass}">${scorePct}%</span>
+        <span class="result-id">${doc.id}</span>
+      </div>
+      <div class="result-text">${escapeHtml(doc.text)}</div>
+    `;
+    results.appendChild(item);
+  });
+}
+
+function escapeHtml(text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+let searchTimeout = null;
+
+function handleSearch(e) {
+  if (e) e.preventDefault();
+  if (!isIndexLoaded || !client || !currentIndex) return;
+
+  const query = searchInput.value.trim();
+  if (!query) {
+    results.innerHTML = '';
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.innerHTML = '<p>Type a query to search</p>';
+    results.appendChild(empty);
+    return;
+  }
+
+  const topK = parseInt(topkInput.value) || 5;
+  const alpha = parseFloat(alphaSlider.value) || 0.5;
+
+  if (searchTimeout) clearTimeout(searchTimeout);
+  searchTimeout = setTimeout(async () => {
+    const placeholder = results.querySelector('.empty-state');
+    if (placeholder) placeholder.innerHTML = '<p>Searching...</p>';
+
+    try {
+      console.log('Querying with topK:', topK, 'alpha:', alpha);
+      const searchResults = await client.query(currentIndex, query, { topK, alpha });
+      console.log('Results count:', searchResults.docs?.length);
+      renderResults(searchResults);
+    } catch (e) {
+      console.error('Query failed:', e);
+      results.innerHTML = `<div class="status-box status-error">Query failed: ${escapeHtml(e.message || e)}</div>`;
+    }
+  }, 150);
+}
+
+// ── Event listeners ──
+select.addEventListener('change', () => {
+  updateLoadBtn();
+  const name = select.value;
+  const idx = indexes.find(i => i.name === name);
+  showIndexInfo(idx);
+});
+
+loadBtn.addEventListener('click', loadIndex);
+
+searchForm.addEventListener('submit', handleSearch);
+searchInput.addEventListener('input', handleSearch);
+
+topkInput.addEventListener('input', () => {
+  if (isIndexLoaded && searchInput.value.trim()) handleSearch();
+});
+
+alphaSlider.addEventListener('input', () => {
+  const val = parseFloat(alphaSlider.value);
+  alphaDisplay.textContent = `\u03B1 ${val.toFixed(2)}`;
+  if (isIndexLoaded && searchInput.value.trim()) handleSearch();
+});
+
+connectBtn.addEventListener('click', () => {
+  const pid = pidInput.value.trim();
+  const pkey = pkeyInput.value.trim();
+  if (!pid || !pkey) return;
+  if (!initClient(pid, pkey)) {
+    showCredsForm('Failed to initialize MossClient. SDK may not be loaded yet.');
+    return;
+  }
+  startApp();
+});
+
+// ── Init ──
+async function startApp() {
+  credsPanel.classList.add('hidden');
+  mainPanel.classList.remove('hidden');
+  await refreshIndexList();
+  // Auto-load first index if available
+  if (select.options.length > 0 && select.options[0].value) {
+    select.value = select.options[0].value;
+    const idx = indexes.find(i => i.name === select.value);
+    showIndexInfo(idx);
+    updateLoadBtn();
+  }
+}
+
+async function init() {
+  const loaded = await loadMossClient();
+  if (!loaded) {
+    showCredsForm('Failed to load @moss-dev/moss-web SDK from CDN. Check your internet connection.');
+    return;
+  }
+
+  showCredsForm();
+}
+
+// Re-run search when index state changes (trigger a reload effect)
+const origLoadIndex = loadIndex;
+loadIndex = async function() {
+  await origLoadIndex();
+  if (searchInput.value.trim()) handleSearch();
+};
+
+init();
+</script>
+</body>
+</html>

--- a/packages/moss-cli/src/moss_cli/playground/index.html
+++ b/packages/moss-cli/src/moss_cli/playground/index.html
@@ -138,8 +138,12 @@ input[type=range]{width:100%;accent-color:var(--primary);height:4px;cursor:point
 </div>
 
 <script type="module">
-const mossToken = location.hash.replace(/^#/, '') || '';
-if (mossToken) history.replaceState(null, '', location.pathname + location.search);
+const tokenFromHash = location.hash.replace(/^#/, '');
+const mossToken = tokenFromHash || sessionStorage.getItem('mossToken') || '';
+if (tokenFromHash) {
+  sessionStorage.setItem('mossToken', tokenFromHash);
+  history.replaceState(null, '', location.pathname + location.search);
+}
 
 const sessionId = (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function')
   ? crypto.randomUUID()

--- a/packages/moss-cli/src/moss_cli/playground/index.html
+++ b/packages/moss-cli/src/moss_cli/playground/index.html
@@ -135,6 +135,13 @@ input[type=range]{width:100%;accent-color:var(--primary);height:4px;cursor:point
 </div>
 
 <script type="module">
+const mossToken = document.querySelector('meta[name="moss-token"]')?.getAttribute('content') || '';
+
+function apiFetch(path, options = {}) {
+  const headers = { ...options.headers, 'X-Moss-Token': mossToken };
+  return fetch(path, { ...options, headers });
+}
+
 let indexes = [];
 let currentIndex = null;
 let requestId = 0;
@@ -153,7 +160,7 @@ const searchForm = $('search-form');
 
 async function fetchIndexes() {
   try {
-    const res = await fetch('/api/indexes');
+    const res = await apiFetch('/api/indexes');
     if (!res.ok) throw new Error('Failed to fetch indexes');
     const data = await res.json();
     indexes = data.indexes || [];
@@ -227,7 +234,7 @@ async function loadIndex() {
   loadStatus.textContent = 'Connecting to cloud...';
 
   try {
-    const res = await fetch('/api/load-index', {
+    const res = await apiFetch('/api/load-index', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name }),
@@ -342,7 +349,7 @@ function handleSearch(e) {
     if (placeholder) placeholder.innerHTML = '<p>Searching...</p>';
 
     try {
-      const res = await fetch('/api/query', {
+      const res = await apiFetch('/api/query', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: currentIndex, query, topK, alpha }),

--- a/packages/moss-cli/src/moss_cli/playground/index.html
+++ b/packages/moss-cli/src/moss_cli/playground/index.html
@@ -227,8 +227,9 @@ async function loadIndex() {
   const name = select.value;
   if (!name) return;
 
-  ++requestId;
+  const loadReqId = ++requestId;
   if (searchTimeout) clearTimeout(searchTimeout);
+  select.disabled = true;
 
   loadBtn.disabled = true;
   loadBtn.innerHTML = '<span class="spinner">&#9696;</span> Loading...';
@@ -246,6 +247,7 @@ async function loadIndex() {
       const err = await res.json();
       throw new Error(err.error || 'Failed to load index');
     }
+    if (loadReqId !== requestId || select.value !== name) return;
     currentIndex = name;
     loadBtn.innerHTML = '&#10003; Loaded';
     loadBtn.className = 'btn btn-success';
@@ -257,6 +259,7 @@ async function loadIndex() {
     topkInput.disabled = false;
     alphaSlider.disabled = false;
   } catch (e) {
+    if (loadReqId !== requestId) return;
     console.error('loadIndex failed:', e);
     currentIndex = null;
     loadBtn.innerHTML = 'Load Index';
@@ -264,6 +267,8 @@ async function loadIndex() {
     loadBtn.disabled = false;
     loadStatus.className = 'status-box status-error';
     loadStatus.textContent = `Failed: ${e.message || e}`;
+  } finally {
+    select.disabled = false;
   }
 }
 

--- a/packages/moss-cli/src/moss_cli/playground/index.html
+++ b/packages/moss-cli/src/moss_cli/playground/index.html
@@ -67,6 +67,9 @@ input[type=range]{width:100%;accent-color:var(--primary);height:4px;cursor:point
 .empty-state p{font-size:13px}
 .hidden{display:none!important}
 .result-timestamp{font-size:10px;color:var(--text2);opacity:.5}
+.result-metadata{margin-top:8px;border-top:1px solid var(--border);padding-top:8px}
+.result-metadata summary{font-size:11px;color:var(--text2);cursor:pointer;user-select:none}
+.result-metadata pre{margin-top:6px;font-size:11px;color:var(--text2);background:var(--surface2);padding:8px;border-radius:6px;overflow-x:auto;font-family:var(--mono);line-height:1.5;white-space:pre-wrap;word-break:break-word}
 </style>
 </head>
 <body>
@@ -145,6 +148,7 @@ function apiFetch(path, options = {}) {
 let indexes = [];
 let currentIndex = null;
 let requestId = 0;
+let searchAbort = null;
 
 const $ = id => document.getElementById(id);
 const select = $('index-select');
@@ -244,6 +248,8 @@ async function loadIndex() {
 
   const loadReqId = ++requestId;
   if (searchTimeout) clearTimeout(searchTimeout);
+  if (searchAbort) searchAbort.abort();
+  searchAbort = null;
   select.disabled = true;
 
   loadBtn.disabled = true;
@@ -337,6 +343,18 @@ function renderResults(searchResults) {
     textDiv.textContent = doc.text;
     item.appendChild(textDiv);
 
+    if (doc.metadata && typeof doc.metadata === 'object' && Object.keys(doc.metadata).length > 0) {
+      const details = document.createElement('details');
+      details.className = 'result-metadata';
+      const summary = document.createElement('summary');
+      summary.textContent = 'Metadata';
+      details.appendChild(summary);
+      const pre = document.createElement('pre');
+      pre.textContent = JSON.stringify(doc.metadata, null, 2);
+      details.appendChild(pre);
+      item.appendChild(details);
+    }
+
     results.appendChild(item);
   });
 }
@@ -355,6 +373,10 @@ function handleSearch(e) {
 
   const query = searchInput.value.trim();
   if (!query) {
+    if (searchTimeout) clearTimeout(searchTimeout);
+    if (searchAbort) searchAbort.abort();
+    searchAbort = null;
+    ++requestId;
     results.innerHTML = '';
     const empty = document.createElement('div');
     empty.className = 'empty-state';
@@ -363,13 +385,17 @@ function handleSearch(e) {
     return;
   }
 
-  const parsedTopK = parseInt(topkInput.value, 10);
-  const topK = Number.isNaN(parsedTopK) ? 5 : parsedTopK;
+  const rawTopK = topkInput.value.trim();
+  const parsedTopK = Number(rawTopK);
+  const topK = rawTopK === '' || Number.isNaN(parsedTopK) ? 5 : parsedTopK;
   const parsedAlpha = parseFloat(alphaSlider.value);
   const alpha = Number.isNaN(parsedAlpha) ? 0.5 : parsedAlpha;
 
   if (searchTimeout) clearTimeout(searchTimeout);
   const thisRequestId = ++requestId;
+  if (searchAbort) searchAbort.abort();
+  searchAbort = new AbortController();
+  const thisAbort = searchAbort;
   const idx = currentIndex;
   searchTimeout = setTimeout(async () => {
     const placeholder = results.querySelector('.empty-state');
@@ -379,17 +405,18 @@ function handleSearch(e) {
       const res = await apiFetch('/api/query', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: idx, query, topK, alpha }),
+        signal: thisAbort.signal,
+        body: JSON.stringify({ name: idx, query, topK, alpha, requestId: thisRequestId }),
       });
       if (!res.ok) {
         const err = await res.json();
         throw new Error(err.error || 'Query failed');
       }
       const searchResults = await res.json();
-      if (thisRequestId !== requestId) return;
+      if (thisRequestId !== requestId || thisAbort.signal.aborted) return;
       renderResults(searchResults);
     } catch (e) {
-      if (thisRequestId !== requestId) return;
+      if (thisRequestId !== requestId || thisAbort.signal.aborted) return;
       console.error('Query failed:', e);
       results.innerHTML = `<div class="status-box status-error">Query failed: ${escapeHtml(e.message || e)}</div>`;
     }
@@ -399,6 +426,8 @@ function handleSearch(e) {
 select.addEventListener('change', () => {
   ++requestId;
   if (searchTimeout) clearTimeout(searchTimeout);
+  if (searchAbort) searchAbort.abort();
+  searchAbort = null;
   results.innerHTML = '';
   const empty = document.createElement('div');
   empty.className = 'empty-state';

--- a/packages/moss-cli/src/moss_cli/playground/index.html
+++ b/packages/moss-cli/src/moss_cli/playground/index.html
@@ -52,7 +52,7 @@ input[type=range]{width:100%;accent-color:var(--primary);height:4px;cursor:point
 .search-icon{padding:0 4px 0 10px;color:var(--text2);display:flex}
 .index-select{display:flex;gap:8px;margin-bottom:16px}
 .index-select select{flex:1}
-.index-info{font-size:12px;color:var(--text2);margin-bottom:12px;padding:8px 10px;background:var(--surface2);border-radius:6px;font-family:var(--mono);word-break:break-all;line-height:1.6}
+.index-info{font-size:12px;color:var(--text2);margin-bottom:12px;padding:8px 10px;background:var(--surface2);border-radius:6px;font-family:var(--mono);word-break:break-all;line-height:1.6;white-space:pre-wrap}
 .index-info strong{color:var(--text)}
 .results-summary{font-size:12px;color:var(--text2);margin-bottom:12px;display:flex;justify-content:space-between;align-items:center}
 .result-item{padding:12px;border:1px solid var(--border);border-radius:6px;margin-bottom:8px;transition:border-color .15s}
@@ -86,7 +86,7 @@ input[type=range]{width:100%;accent-color:var(--primary);height:4px;cursor:point
         <div class="panel">
           <div class="panel-title">Index</div>
           <div class="index-select">
-            <select id="index-select">
+            <select id="index-select" aria-label="Select an index">
               <option value="">Loading indexes...</option>
             </select>
           </div>
@@ -108,7 +108,7 @@ input[type=range]{width:100%;accent-color:var(--primary);height:4px;cursor:point
                 <span class="search-icon">
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
                 </span>
-                <input type="text" id="search-input" placeholder="Type to search..." disabled />
+                <input type="text" id="search-input" placeholder="Type to search..." disabled aria-label="Search query" />
               </div>
             </form>
           </div>
@@ -118,7 +118,7 @@ input[type=range]{width:100%;accent-color:var(--primary);height:4px;cursor:point
               <label>Top K <input type="number" id="topk-input" min="1" max="50" value="5" disabled /></label>
               <div class="range-wrap">
                 <span>Keyword</span>
-                <input type="range" id="alpha-slider" min="0" max="1" step="0.05" value="0.5" disabled />
+                <input type="range" id="alpha-slider" min="0" max="1" step="0.05" value="0.5" disabled aria-label="Keyword vs semantic balance" />
                 <span>Semantic</span>
                 <span class="alpha-value" id="alpha-display">&alpha; 0.50</span>
               </div>
@@ -139,16 +139,34 @@ input[type=range]{width:100%;accent-color:var(--primary);height:4px;cursor:point
 
 <script type="module">
 const mossToken = location.hash.replace(/^#/, '') || '';
+if (mossToken) history.replaceState(null, '', location.pathname + location.search);
+
+const sessionId = (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function')
+  ? crypto.randomUUID()
+  : `session-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
 function apiFetch(path, options = {}) {
   const headers = { ...options.headers, 'X-Moss-Token': mossToken };
   return fetch(path, { ...options, headers });
 }
 
+async function errorFromResponse(res, fallback) {
+  let message = fallback;
+  try {
+    const text = await res.text();
+    const parsed = text ? JSON.parse(text) : null;
+    if (parsed && typeof parsed.error === 'string' && parsed.error) {
+      message = parsed.error;
+    }
+  } catch (_) {}
+  return new Error(`${message} (HTTP ${res.status})`);
+}
+
 let indexes = [];
 let currentIndex = null;
 let requestId = 0;
 let searchAbort = null;
+let searchTimeout = null;
 
 const $ = id => document.getElementById(id);
 const select = $('index-select');
@@ -168,8 +186,7 @@ async function refreshIndexList() {
   try {
     const res = await apiFetch('/api/indexes');
     if (!res.ok) {
-      const err = await res.json();
-      throw new Error(err.error || 'Failed to fetch indexes');
+      throw await errorFromResponse(res, 'Failed to fetch indexes');
     }
     const data = await res.json();
     indexes = data.indexes || [];
@@ -265,8 +282,7 @@ async function loadIndex() {
       body: JSON.stringify({ name }),
     });
     if (!res.ok) {
-      const err = await res.json();
-      throw new Error(err.error || 'Failed to load index');
+      throw await errorFromResponse(res, 'Failed to load index');
     }
     if (loadReqId !== requestId || select.value !== name) return;
     currentIndex = name;
@@ -359,14 +375,6 @@ function renderResults(searchResults) {
   });
 }
 
-function escapeHtml(text) {
-  const div = document.createElement('div');
-  div.textContent = text;
-  return div.innerHTML;
-}
-
-let searchTimeout = null;
-
 function handleSearch(e) {
   if (e) e.preventDefault();
   if (!currentIndex) return;
@@ -386,8 +394,10 @@ function handleSearch(e) {
   }
 
   const rawTopK = topkInput.value.trim();
-  const parsedTopK = Number(rawTopK);
-  const topK = rawTopK === '' || Number.isNaN(parsedTopK) ? 5 : parsedTopK;
+  const parsedTopK = Math.round(Number(rawTopK));
+  const topK = rawTopK === '' || Number.isNaN(parsedTopK)
+    ? 5
+    : Math.min(50, Math.max(1, parsedTopK));
   const parsedAlpha = parseFloat(alphaSlider.value);
   const alpha = Number.isNaN(parsedAlpha) ? 0.5 : parsedAlpha;
 
@@ -406,11 +416,10 @@ function handleSearch(e) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         signal: thisAbort.signal,
-        body: JSON.stringify({ name: idx, query, topK, alpha, requestId: thisRequestId }),
+        body: JSON.stringify({ name: idx, query, topK, alpha, requestId: thisRequestId, sessionId }),
       });
       if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.error || 'Query failed');
+        throw await errorFromResponse(res, 'Query failed');
       }
       const searchResults = await res.json();
       if (thisRequestId !== requestId || thisAbort.signal.aborted) return;
@@ -418,7 +427,11 @@ function handleSearch(e) {
     } catch (e) {
       if (thisRequestId !== requestId || thisAbort.signal.aborted) return;
       console.error('Query failed:', e);
-      results.innerHTML = `<div class="status-box status-error">Query failed: ${escapeHtml(e.message || e)}</div>`;
+      results.innerHTML = '';
+      const status = document.createElement('div');
+      status.className = 'status-box status-error';
+      status.textContent = `Query failed: ${e.message || e}`;
+      results.appendChild(status);
     }
   }, 150);
 }
@@ -454,7 +467,16 @@ alphaSlider.addEventListener('input', () => {
   if (currentIndex && searchInput.value.trim()) handleSearch();
 });
 
-refreshIndexList();
+if (!mossToken) {
+  select.innerHTML = '<option value="">Missing token</option>';
+  loadBtn.disabled = true;
+  const status = document.createElement('div');
+  status.className = 'status-box status-error';
+  status.textContent = 'No token found in the URL. Re-open the playground from the address printed by `moss playground`.';
+  select.parentElement.appendChild(status);
+} else {
+  refreshIndexList();
+}
 </script>
 </body>
 </html>

--- a/packages/moss-cli/src/moss_cli/playground/index.html
+++ b/packages/moss-cli/src/moss_cli/playground/index.html
@@ -18,7 +18,7 @@ header p{color:var(--text2);font-size:13px;margin-top:4px}
 .panel{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:20px}
 .panel-title{font-size:15px;font-weight:600;margin-bottom:16px;display:flex;align-items:center;gap:8px}
 label{display:block;font-size:12px;font-weight:500;color:var(--text2);margin-bottom:4px}
-select,input[type=text],input[type=number]{width:100%;padding:8px 10px;background:var(--surface2);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:13px;font-family:var(--font);outline:none;transition:border-color .15s}
+select,input[type=text],input[type=password],input[type=number]{width:100%;padding:8px 10px;background:var(--surface2);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:13px;font-family:var(--font);outline:none;transition:border-color .15s}
 select:focus,input:focus{border-color:var(--primary)}
 select option{background:var(--surface2);color:var(--text)}
 input[type=number]{width:72px}
@@ -32,6 +32,8 @@ input[type=range]{width:100%;accent-color:var(--primary);height:4px;cursor:point
 .btn-secondary:disabled{opacity:.4;cursor:not-allowed}
 .btn-success{background:var(--success);color:#fff}
 .btn-success:disabled{opacity:.4;cursor:not-allowed}
+.link-btn{background:none;border:none;color:var(--text2);font-size:12px;cursor:pointer;text-decoration:underline;padding:0;font-family:var(--font)}
+.link-btn:hover{color:var(--primary)}
 .spinner{animation:spin .8s linear infinite}
 @keyframes spin{to{transform:rotate(360deg)}}
 .controls{margin-bottom:16px}
@@ -70,21 +72,50 @@ input[type=range]{width:100%;accent-color:var(--primary);height:4px;cursor:point
 .result-metadata{margin-top:8px;border-top:1px solid var(--border);padding-top:8px}
 .result-metadata summary{font-size:11px;color:var(--text2);cursor:pointer;user-select:none}
 .result-metadata pre{margin-top:6px;font-size:11px;color:var(--text2);background:var(--surface2);padding:8px;border-radius:6px;overflow-x:auto;font-family:var(--mono);line-height:1.5;white-space:pre-wrap;word-break:break-word}
+.connect-panel{max-width:460px;margin:0 auto}
+.connect-panel .field{margin-bottom:14px}
+.connect-panel p.hint{font-size:12px;color:var(--text2);margin-bottom:16px}
 </style>
 </head>
 <body>
 <div class="container" id="app">
   <header>
     <h1>Moss <span>Playground</span></h1>
-    <p>Load an index, run queries, and inspect results &mdash; all proxied through your local server</p>
+    <p>Load an index and run searches entirely in your browser via <code>@moss-dev/moss-web</code> (WASM)</p>
   </header>
 
-  <div id="main-panel">
+  <!-- Connection (manual fallback when the server has no credentials) -->
+  <div id="connect-panel" class="panel connect-panel">
+    <div class="panel-title">Connect to Moss</div>
+    <p class="hint">
+      The server did not provide credentials. Enter your Project ID and Project Key to connect
+      directly to the Moss cloud. They are kept in this browser tab only.
+    </p>
+    <form id="connect-form" autocomplete="off">
+      <div class="field">
+        <label for="pid-input">Project ID</label>
+        <input type="text" id="pid-input" placeholder="moss-project-id" autocomplete="off" />
+      </div>
+      <div class="field">
+        <label for="pkey-input">Project Key</label>
+        <input type="password" id="pkey-input" placeholder="moss-project-key" autocomplete="off" />
+      </div>
+      <button type="submit" id="connect-btn" class="btn btn-primary" style="width:100%;justify-content:center">
+        Connect
+      </button>
+    </form>
+    <div id="connect-status" class="hidden"></div>
+  </div>
+
+  <div id="main-panel" class="hidden">
     <div class="grid">
       <!-- Left: Index Selection -->
       <div>
         <div class="panel">
-          <div class="panel-title">Index</div>
+          <div class="panel-title" style="display:flex;justify-content:space-between;align-items:center">
+            <span>Index</span>
+            <button class="link-btn" id="change-conn-btn" type="button">Change connection</button>
+          </div>
           <div class="index-select">
             <select id="index-select" aria-label="Select an index">
               <option value="">Loading indexes...</option>
@@ -137,6 +168,16 @@ input[type=range]{width:100%;accent-color:var(--primary);height:4px;cursor:point
   </div>
 </div>
 
+<script type="importmap">
+{
+  "imports": {
+    "@moss-dev/moss-web": "https://unpkg.com/@moss-dev/moss-web@1.0.0/dist/index.js",
+    "@moss-dev/moss-wasm": "https://unpkg.com/@moss-dev/moss-wasm@0.10.0/moss_wasm.js",
+    "onnxruntime-web": "https://unpkg.com/onnxruntime-web@1.21.0/dist/ort.bundle.min.mjs"
+  }
+}
+</script>
+
 <script type="module">
 const tokenFromHash = location.hash.replace(/^#/, '');
 const mossToken = tokenFromHash || sessionStorage.getItem('mossToken') || '';
@@ -145,9 +186,32 @@ if (tokenFromHash) {
   history.replaceState(null, '', location.pathname + location.search);
 }
 
-const sessionId = (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function')
-  ? crypto.randomUUID()
-  : `session-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+let MossClient = null;
+let client = null;
+let indexes = [];
+let currentIndex = null;
+let requestId = 0;
+let searchTimeout = null;
+
+const $ = id => document.getElementById(id);
+const select = $('index-select');
+const loadBtn = $('load-btn');
+const loadStatus = $('load-status');
+const indexInfo = $('index-info');
+const searchInput = $('search-input');
+const topkInput = $('topk-input');
+const alphaSlider = $('alpha-slider');
+const alphaDisplay = $('alpha-display');
+const results = $('results');
+const searchForm = $('search-form');
+const connectPanel = $('connect-panel');
+const mainPanel = $('main-panel');
+const connectForm = $('connect-form');
+const pidInput = $('pid-input');
+const pkeyInput = $('pkey-input');
+const connectBtn = $('connect-btn');
+const connectStatus = $('connect-status');
+const changeConnBtn = $('change-conn-btn');
 
 function apiFetch(path, options = {}) {
   const headers = { ...options.headers, 'X-Moss-Token': mossToken };
@@ -166,36 +230,92 @@ async function errorFromResponse(res, fallback) {
   return new Error(`${message} (HTTP ${res.status})`);
 }
 
-let indexes = [];
-let currentIndex = null;
-let requestId = 0;
-let searchAbort = null;
-let searchTimeout = null;
+function showStatus(el, kind, text) {
+  el.classList.remove('hidden');
+  el.className = kind ? `status-box status-${kind}` : 'status-box';
+  el.textContent = text;
+}
 
-const $ = id => document.getElementById(id);
-const select = $('index-select');
-const loadBtn = $('load-btn');
-const loadStatus = $('load-status');
-const indexInfo = $('index-info');
-const searchInput = $('search-input');
-const topkInput = $('topk-input');
-const alphaSlider = $('alpha-slider');
-const alphaDisplay = $('alpha-display');
-const results = $('results');
-const searchForm = $('search-form');
+function hideStatus(el) {
+  el.classList.add('hidden');
+  el.textContent = '';
+}
+
+// Load the WASM SDK (dynamic import so a CDN failure can be reported).
+async function loadSdk() {
+  if (MossClient) return;
+  const mod = await import('@moss-dev/moss-web');
+  MossClient = mod.MossClient;
+}
+
+async function init() {
+  if (!mossToken) {
+    connectPanel.classList.remove('hidden');
+    showStatus(connectStatus, 'error',
+      'No token found in the URL. Re-open the playground from the address printed by `moss playground`.');
+    return;
+  }
+  let injected;
+  try {
+    const res = await apiFetch('/api/config');
+    if (!res.ok) throw await errorFromResponse(res, 'Failed to reach the playground server');
+    injected = await res.json();
+  } catch (e) {
+    connectPanel.classList.remove('hidden');
+    showStatus(connectStatus, 'error', e.message);
+    return;
+  }
+  if (injected && injected.projectId && injected.projectKey) {
+    await connect(injected.projectId, injected.projectKey);
+  } else {
+    connectPanel.classList.remove('hidden');
+  }
+}
+
+async function connect(pid, pkey) {
+  connectPanel.classList.remove('hidden');
+  mainPanel.classList.add('hidden');
+  showStatus(connectStatus, '',
+    'Loading the Moss WASM engine (first load downloads the embedding model)...');
+  connectBtn.disabled = true;
+  try {
+    await loadSdk();
+    client = await MossClient.create(pid, pkey);
+    connectPanel.classList.add('hidden');
+    mainPanel.classList.remove('hidden');
+    await refreshIndexList();
+  } catch (e) {
+    console.error('Connection failed:', e);
+    showStatus(connectStatus, 'error', `Connection failed: ${e.message}`);
+    connectBtn.disabled = false;
+  }
+}
+
+connectForm.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const pid = pidInput.value.trim();
+  const pkey = pkeyInput.value.trim();
+  if (!pid || !pkey) {
+    showStatus(connectStatus, 'error', 'Enter both Project ID and Project Key.');
+    return;
+  }
+  connect(pid, pkey);
+});
+
+changeConnBtn.addEventListener('click', () => {
+  mainPanel.classList.add('hidden');
+  connectPanel.classList.remove('hidden');
+  hideStatus(connectStatus);
+  connectBtn.disabled = false;
+});
 
 async function refreshIndexList() {
   select.innerHTML = '<option value="">Loading...</option>';
   let idxs;
   try {
-    const res = await apiFetch('/api/indexes');
-    if (!res.ok) {
-      throw await errorFromResponse(res, 'Failed to fetch indexes');
-    }
-    const data = await res.json();
-    indexes = data.indexes || [];
+    idxs = await client.listIndexes();
   } catch (e) {
-    console.error('fetchIndexes failed:', e);
+    console.error('listIndexes failed:', e);
     select.innerHTML = '<option value="">Error loading indexes</option>';
     loadBtn.disabled = true;
     const status = document.createElement('div');
@@ -206,6 +326,7 @@ async function refreshIndexList() {
     select.parentElement.appendChild(status);
     return;
   }
+  indexes = idxs || [];
   select.innerHTML = '';
   if (indexes.length === 0) {
     select.innerHTML = '<option value="">No indexes found</option>';
@@ -234,7 +355,7 @@ function updateLoadBtn() {
   alphaSlider.disabled = !isLoaded;
   if (isLoaded) {
     loadStatus.className = 'status-box status-success';
-    loadStatus.textContent = 'Index loaded into server memory';
+    loadStatus.textContent = 'Index loaded into browser memory';
     loadStatus.classList.remove('hidden');
   } else {
     loadStatus.classList.add('hidden');
@@ -265,30 +386,17 @@ function showIndexInfo(idx) {
 
 async function loadIndex() {
   const name = select.value;
-  if (!name) return;
-
-  const loadReqId = ++requestId;
-  if (searchTimeout) clearTimeout(searchTimeout);
-  if (searchAbort) searchAbort.abort();
-  searchAbort = null;
-  select.disabled = true;
+  if (!name || !client) return;
 
   loadBtn.disabled = true;
   loadBtn.innerHTML = '<span class="spinner">&#9696;</span> Loading...';
   loadStatus.classList.remove('hidden');
   loadStatus.className = 'status-box';
-  loadStatus.textContent = 'Connecting to cloud...';
+  loadStatus.textContent = 'Downloading index into the browser...';
+  select.disabled = true;
 
   try {
-    const res = await apiFetch('/api/load-index', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name }),
-    });
-    if (!res.ok) {
-      throw await errorFromResponse(res, 'Failed to load index');
-    }
-    if (loadReqId !== requestId || select.value !== name) return;
+    await client.loadIndex(name);
     currentIndex = name;
     results.innerHTML = '';
     const empty = document.createElement('div');
@@ -298,7 +406,6 @@ async function loadIndex() {
     updateLoadBtn();
     searchInput.focus();
   } catch (e) {
-    if (loadReqId !== requestId) return;
     console.error('loadIndex failed:', e);
     updateLoadBtn();
     loadStatus.classList.remove('hidden');
@@ -332,7 +439,7 @@ function renderResults(searchResults) {
     const timeSpan = document.createElement('span');
     timeSpan.textContent = `${timeMs} ms`;
     summary.appendChild(timeSpan);
-}
+  }
 
   results.appendChild(summary);
 
@@ -381,13 +488,11 @@ function renderResults(searchResults) {
 
 function handleSearch(e) {
   if (e) e.preventDefault();
-  if (!currentIndex) return;
+  if (!currentIndex || !client) return;
 
   const query = searchInput.value.trim();
   if (!query) {
     if (searchTimeout) clearTimeout(searchTimeout);
-    if (searchAbort) searchAbort.abort();
-    searchAbort = null;
     ++requestId;
     results.innerHTML = '';
     const empty = document.createElement('div');
@@ -407,34 +512,22 @@ function handleSearch(e) {
 
   if (searchTimeout) clearTimeout(searchTimeout);
   const thisRequestId = ++requestId;
-  if (searchAbort) searchAbort.abort();
-  searchAbort = new AbortController();
-  const thisAbort = searchAbort;
   const idx = currentIndex;
   searchTimeout = setTimeout(async () => {
     const placeholder = results.querySelector('.empty-state');
     if (placeholder) placeholder.innerHTML = '<p>Searching...</p>';
 
     try {
-      const res = await apiFetch('/api/query', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        signal: thisAbort.signal,
-        body: JSON.stringify({ name: idx, query, topK, alpha, requestId: thisRequestId, sessionId }),
-      });
-      if (!res.ok) {
-        throw await errorFromResponse(res, 'Query failed');
-      }
-      const searchResults = await res.json();
-      if (thisRequestId !== requestId || thisAbort.signal.aborted) return;
+      const searchResults = await client.query(idx, query, { topK, alpha });
+      if (thisRequestId !== requestId) return;
       renderResults(searchResults);
-    } catch (e) {
-      if (thisRequestId !== requestId || thisAbort.signal.aborted) return;
-      console.error('Query failed:', e);
+    } catch (err) {
+      if (thisRequestId !== requestId) return;
+      console.error('Query failed:', err);
       results.innerHTML = '';
       const status = document.createElement('div');
       status.className = 'status-box status-error';
-      status.textContent = `Query failed: ${e.message || e}`;
+      status.textContent = `Query failed: ${err.message || err}`;
       results.appendChild(status);
     }
   }, 150);
@@ -443,8 +536,6 @@ function handleSearch(e) {
 select.addEventListener('change', () => {
   ++requestId;
   if (searchTimeout) clearTimeout(searchTimeout);
-  if (searchAbort) searchAbort.abort();
-  searchAbort = null;
   results.innerHTML = '';
   const empty = document.createElement('div');
   empty.className = 'empty-state';
@@ -471,16 +562,7 @@ alphaSlider.addEventListener('input', () => {
   if (currentIndex && searchInput.value.trim()) handleSearch();
 });
 
-if (!mossToken) {
-  select.innerHTML = '<option value="">Missing token</option>';
-  loadBtn.disabled = true;
-  const status = document.createElement('div');
-  status.className = 'status-box status-error';
-  status.textContent = 'No token found in the URL. Re-open the playground from the address printed by `moss playground`.';
-  select.parentElement.appendChild(status);
-} else {
-  refreshIndexList();
-}
+init();
 </script>
 </body>
 </html>

--- a/packages/moss-cli/src/moss_cli/playground/index.html
+++ b/packages/moss-cli/src/moss_cli/playground/index.html
@@ -296,11 +296,18 @@ function renderResults(searchResults) {
 
   const summary = document.createElement('div');
   summary.className = 'results-summary';
+
+  const countSpan = document.createElement('span');
+  countSpan.textContent = `${searchResults.docs.length} result(s)`;
+  summary.appendChild(countSpan);
+
   const timeMs = searchResults.timeTakenMs;
-  summary.innerHTML = `
-    <span>${searchResults.docs.length} result(s)</span>
-    ${timeMs != null ? `<span>${timeMs} ms</span>` : ''}
-  `;
+  if (typeof timeMs === 'number' && Number.isFinite(timeMs)) {
+    const timeSpan = document.createElement('span');
+    timeSpan.textContent = `${timeMs} ms`;
+    summary.appendChild(timeSpan);
+}
+
   results.appendChild(summary);
 
   searchResults.docs.forEach(doc => {

--- a/packages/moss-cli/src/moss_cli/playground/index.html
+++ b/packages/moss-cli/src/moss_cli/playground/index.html
@@ -4,15 +4,6 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Moss Playground</title>
-<script type="importmap">
-{
-  "imports": {
-    "@moss-dev/moss-web": "https://unpkg.com/@moss-dev/moss-web@1.0.0/dist/index.js",
-    "@moss-dev/moss-wasm": "https://unpkg.com/@moss-dev/moss-wasm@0.10.0/moss_wasm.js",
-    "onnxruntime-web": "https://unpkg.com/onnxruntime-web@1.27.0/dist/ort.bundle.min.mjs"
-  }
-}
-</script>
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 :root{--bg:#0f0f13;--surface:#1a1a23;--surface2:#22222e;--border:#2e2e3a;--text:#e8e8ef;--text2:#8888a0;--primary:#6366f1;--primary-hover:#5558e6;--success:#22c55e;--error:#ef4444;--warning:#f59e0b;--radius:8px;--font:system-ui,-apple-system,sans-serif;--mono:'SF Mono','Fira Code','Cascadia Code',monospace}
@@ -74,11 +65,6 @@ input[type=range]{width:100%;accent-color:var(--primary);height:4px;cursor:point
 .empty-state{text-align:center;padding:48px 24px;color:var(--text2)}
 .empty-state svg{width:48px;height:48px;margin-bottom:12px;opacity:.3}
 .empty-state p{font-size:13px}
-.creds-form{display:flex;flex-direction:column;gap:12px;max-width:400px;margin:48px auto}
-.creds-form h2{text-align:center;font-size:18px;margin-bottom:8px}
-.creds-form p{text-align:center;font-size:12px;color:var(--text2)}
-.creds-form input{padding:10px 12px}
-.creds-form .btn{width:100%;justify-content:center;padding:10px}
 .hidden{display:none!important}
 .result-timestamp{font-size:10px;color:var(--text2);opacity:.5}
 </style>
@@ -87,18 +73,10 @@ input[type=range]{width:100%;accent-color:var(--primary);height:4px;cursor:point
 <div class="container" id="app">
   <header>
     <h1>Moss <span>Playground</span></h1>
-    <p>Load an index, run queries, and inspect results &mdash; all in your browser via WASM</p>
+    <p>Load an index, run queries, and inspect results &mdash; all proxied through your local server</p>
   </header>
 
-  <div id="creds-panel" class="creds-form hidden">
-    <h2>Connect to Moss</h2>
-    <p>Enter your Project ID and Project Key to get started.</p>
-    <input id="pid-input" type="text" placeholder="Project ID" />
-    <input id="pkey-input" type="password" placeholder="Project Key" />
-    <button class="btn btn-primary" id="connect-btn">Connect</button>
-  </div>
-
-  <div id="main-panel" class="hidden">
+  <div id="main-panel">
     <div class="grid">
       <!-- Left: Index Selection -->
       <div>
@@ -145,7 +123,7 @@ input[type=range]{width:100%;accent-color:var(--primary);height:4px;cursor:point
           </div>
 
           <div id="results">
-            <div class="empty-state" id="results-placeholder">
+            <div class="empty-state">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
               <p>Load an index and type a query to search</p>
             </div>
@@ -157,11 +135,9 @@ input[type=range]{width:100%;accent-color:var(--primary);height:4px;cursor:point
 </div>
 
 <script type="module">
-let MossClientClass = null;
-let client = null;
 let indexes = [];
 let currentIndex = null;
-let isIndexLoaded = false;
+let requestId = 0;
 
 const $ = id => document.getElementById(id);
 const select = $('index-select');
@@ -173,53 +149,7 @@ const topkInput = $('topk-input');
 const alphaSlider = $('alpha-slider');
 const alphaDisplay = $('alpha-display');
 const results = $('results');
-const resultsPlaceholder = $('results-placeholder');
 const searchForm = $('search-form');
-const pidInput = $('pid-input');
-const pkeyInput = $('pkey-input');
-const connectBtn = $('connect-btn');
-const credsPanel = $('creds-panel');
-const mainPanel = $('main-panel');
-
-let projectId = '';
-let projectKey = '';
-
-function resolveCssVar(name) {
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-}
-
-async function loadMossClient() {
-  try {
-    const mod = await import("@moss-dev/moss-web");
-    MossClientClass = mod.MossClient;
-    return true;
-  } catch (e) {
-    console.error('Failed to load @moss-dev/moss-web:', e);
-    return false;
-  }
-}
-
-function showCredsForm(message) {
-  credsPanel.classList.remove('hidden');
-  mainPanel.classList.add('hidden');
-  if (message) {
-    const existing = credsPanel.querySelector('.status-error');
-    if (existing) existing.remove();
-    const err = document.createElement('div');
-    err.className = 'status-box status-error';
-    err.textContent = message;
-    credsPanel.appendChild(err);
-  }
-}
-
-function initClient(id, key) {
-  if (!MossClientClass) return false;
-  if (client) client.dispose();
-  client = new MossClientClass(id, key);
-  projectId = id;
-  projectKey = key;
-  return true;
-}
 
 async function fetchIndexes() {
   try {
@@ -228,16 +158,9 @@ async function fetchIndexes() {
     const data = await res.json();
     indexes = data.indexes || [];
     return indexes;
-  } catch {
-    // fallback: list via cloud API using client
-    if (!client) return [];
-    try {
-      indexes = await client.listIndexes();
-      return indexes;
-    } catch (e) {
-      console.error('listIndexes failed:', e);
-      return [];
-    }
+  } catch (e) {
+    console.error('fetchIndexes failed:', e);
+    return [];
   }
 }
 
@@ -263,7 +186,12 @@ async function refreshIndexList() {
 
 function updateLoadBtn() {
   const name = select.value;
-  loadBtn.disabled = !name || isIndexLoaded;
+  loadBtn.disabled = !name || name === currentIndex;
+  if (name !== currentIndex && currentIndex) {
+    searchInput.disabled = true;
+    topkInput.disabled = true;
+    alphaSlider.disabled = true;
+  }
 }
 
 function showIndexInfo(idx) {
@@ -290,7 +218,7 @@ function showIndexInfo(idx) {
 
 async function loadIndex() {
   const name = select.value;
-  if (!name || !client) return;
+  if (!name) return;
 
   loadBtn.disabled = true;
   loadBtn.innerHTML = '<span class="spinner">&#9696;</span> Loading...';
@@ -299,20 +227,28 @@ async function loadIndex() {
   loadStatus.textContent = 'Connecting to cloud...';
 
   try {
-    await client.loadIndex(name);
-    isIndexLoaded = true;
+    const res = await fetch('/api/load-index', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(err.error || 'Failed to load index');
+    }
     currentIndex = name;
     loadBtn.innerHTML = '&#10003; Loaded';
     loadBtn.className = 'btn btn-success';
+    loadBtn.disabled = false;
     loadStatus.className = 'status-box status-success';
-    loadStatus.textContent = 'Index loaded into browser memory';
+    loadStatus.textContent = 'Index loaded into server memory';
     searchInput.disabled = false;
     searchInput.focus();
     topkInput.disabled = false;
     alphaSlider.disabled = false;
   } catch (e) {
     console.error('loadIndex failed:', e);
-    isIndexLoaded = false;
+    currentIndex = null;
     loadBtn.innerHTML = 'Load Index';
     loadBtn.className = 'btn btn-primary';
     loadBtn.disabled = false;
@@ -334,10 +270,10 @@ function renderResults(searchResults) {
 
   const summary = document.createElement('div');
   summary.className = 'results-summary';
-  const timeMs = searchResults.timeTakenMs || searchResults.timeTakenInMs;
+  const timeMs = searchResults.timeTakenMs;
   summary.innerHTML = `
     <span>${searchResults.docs.length} result(s)</span>
-    ${timeMs != null ? `<span>${timeMs.toFixed(1)} ms</span>` : ''}
+    ${timeMs != null ? `<span>${timeMs} ms</span>` : ''}
   `;
   results.appendChild(summary);
 
@@ -348,13 +284,26 @@ function renderResults(searchResults) {
     const scorePct = (score * 100).toFixed(0);
     const scoreClass = score < 0.75 ? 'result-score low' : 'result-score';
 
-    item.innerHTML = `
-      <div class="result-meta">
-        <span class="${scoreClass}">${scorePct}%</span>
-        <span class="result-id">${escapeHtml(doc.id)}</span>
-      </div>
-      <div class="result-text">${escapeHtml(doc.text)}</div>
-    `;
+    const meta = document.createElement('div');
+    meta.className = 'result-meta';
+
+    const scoreSpan = document.createElement('span');
+    scoreSpan.className = scoreClass;
+    scoreSpan.textContent = `${scorePct}%`;
+    meta.appendChild(scoreSpan);
+
+    const idSpan = document.createElement('span');
+    idSpan.className = 'result-id';
+    idSpan.textContent = doc.id;
+    meta.appendChild(idSpan);
+
+    item.appendChild(meta);
+
+    const textDiv = document.createElement('div');
+    textDiv.className = 'result-text';
+    textDiv.textContent = doc.text;
+    item.appendChild(textDiv);
+
     results.appendChild(item);
   });
 }
@@ -369,7 +318,7 @@ let searchTimeout = null;
 
 function handleSearch(e) {
   if (e) e.preventDefault();
-  if (!isIndexLoaded || !client || !currentIndex) return;
+  if (!currentIndex) return;
 
   const query = searchInput.value.trim();
   if (!query) {
@@ -381,27 +330,38 @@ function handleSearch(e) {
     return;
   }
 
-  const topK = parseInt(topkInput.value) || 5;
-  const alpha = parseFloat(alphaSlider.value) || 0.5;
+  const parsedTopK = parseInt(topkInput.value, 10);
+  const topK = Number.isNaN(parsedTopK) ? 5 : parsedTopK;
+  const parsedAlpha = parseFloat(alphaSlider.value);
+  const alpha = Number.isNaN(parsedAlpha) ? 0.5 : parsedAlpha;
 
   if (searchTimeout) clearTimeout(searchTimeout);
+  const thisRequestId = ++requestId;
   searchTimeout = setTimeout(async () => {
     const placeholder = results.querySelector('.empty-state');
     if (placeholder) placeholder.innerHTML = '<p>Searching...</p>';
 
     try {
-      console.log('Querying with topK:', topK, 'alpha:', alpha);
-      const searchResults = await client.query(currentIndex, query, { topK, alpha });
-      console.log('Results count:', searchResults.docs?.length);
+      const res = await fetch('/api/query', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: currentIndex, query, topK, alpha }),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error || 'Query failed');
+      }
+      const searchResults = await res.json();
+      if (thisRequestId !== requestId) return;
       renderResults(searchResults);
     } catch (e) {
+      if (thisRequestId !== requestId) return;
       console.error('Query failed:', e);
       results.innerHTML = `<div class="status-box status-error">Query failed: ${escapeHtml(e.message || e)}</div>`;
     }
   }, 150);
 }
 
-// ── Event listeners ──
 select.addEventListener('change', () => {
   updateLoadBtn();
   const name = select.value;
@@ -415,58 +375,16 @@ searchForm.addEventListener('submit', handleSearch);
 searchInput.addEventListener('input', handleSearch);
 
 topkInput.addEventListener('input', () => {
-  if (isIndexLoaded && searchInput.value.trim()) handleSearch();
+  if (currentIndex && searchInput.value.trim()) handleSearch();
 });
 
 alphaSlider.addEventListener('input', () => {
   const val = parseFloat(alphaSlider.value);
-  alphaDisplay.textContent = `\u03B1 ${val.toFixed(2)}`;
-  if (isIndexLoaded && searchInput.value.trim()) handleSearch();
+  alphaDisplay.textContent = `\u03B1 ${Number.isNaN(val) ? '0.50' : val.toFixed(2)}`;
+  if (currentIndex && searchInput.value.trim()) handleSearch();
 });
 
-connectBtn.addEventListener('click', () => {
-  const pid = pidInput.value.trim();
-  const pkey = pkeyInput.value.trim();
-  if (!pid || !pkey) return;
-  if (!initClient(pid, pkey)) {
-    showCredsForm('Failed to initialize MossClient. SDK may not be loaded yet.');
-    return;
-  }
-  startApp();
-});
-
-// ── Init ──
-async function startApp() {
-  credsPanel.classList.add('hidden');
-  mainPanel.classList.remove('hidden');
-  await refreshIndexList();
-  // Auto-load first index if available
-  if (select.options.length > 0 && select.options[0].value) {
-    select.value = select.options[0].value;
-    const idx = indexes.find(i => i.name === select.value);
-    showIndexInfo(idx);
-    updateLoadBtn();
-  }
-}
-
-async function init() {
-  const loaded = await loadMossClient();
-  if (!loaded) {
-    showCredsForm('Failed to load @moss-dev/moss-web SDK from CDN. Check your internet connection.');
-    return;
-  }
-
-  showCredsForm();
-}
-
-// Re-run search when index state changes (trigger a reload effect)
-const origLoadIndex = loadIndex;
-loadIndex = async function() {
-  await origLoadIndex();
-  if (searchInput.value.trim()) handleSearch();
-};
-
-init();
+refreshIndexList();
 </script>
 </body>
 </html>

--- a/packages/moss-cli/tests/test_playground.py
+++ b/packages/moss-cli/tests/test_playground.py
@@ -1,64 +1,7 @@
-import asyncio
-import inspect
-import io
-from types import SimpleNamespace
-
-from moss_cli.commands.playground import (
-    MAX_REQUEST_BODY_SIZE,
-    PLAYGROUND_HTML,
-    PlaygroundHandler,
-)
+from moss_cli.commands.playground import PLAYGROUND_HTML, PlaygroundHandler
 
 
-class FakeClient:
-    def __init__(self):
-        self.query_calls = []
-
-    def query(self, name, query, options):
-        self.query_calls.append((name, query, options))
-        doc = SimpleNamespace(id="d1", text="hello", score=0.9, metadata={"k": "v"})
-        return SimpleNamespace(docs=[doc], time_taken_ms=12, query=query)
-
-
-class FakeLoadClient:
-    def __init__(self):
-        self.loaded = []
-        self.unloaded = []
-
-    def load_index(self, name):
-        self.loaded.append(name)
-        return name
-
-    def unload_index(self, name):
-        self.unloaded.append(name)
-
-
-class FakeWorker:
-    def __init__(self, client):
-        self.client = client
-
-    def submit(self, coro_fn):
-        result = coro_fn()
-        if inspect.isawaitable(result):
-            return asyncio.run(result)
-        return result
-
-
-class SupersedingWorker:
-    """Simulates a newer query arriving while an older one is queued."""
-
-    def __init__(self, client):
-        self.client = client
-
-    def submit(self, coro_fn):
-        PlaygroundHandler._latest_request_ids["sess"] = 99
-        result = coro_fn()
-        if inspect.isawaitable(result):
-            return asyncio.run(result)
-        return result
-
-
-def _make_handler(monkeypatch, client=None, worker=None):
+def _make_config_handler(monkeypatch, pid=None, pkey=None):
     handler = PlaygroundHandler.__new__(PlaygroundHandler)
     captured = {}
 
@@ -67,10 +10,8 @@ def _make_handler(monkeypatch, client=None, worker=None):
         captured["data"] = data
 
     monkeypatch.setattr(handler, "_send_json", fake_send_json)
-    monkeypatch.setattr(PlaygroundHandler, "client", client)
-    monkeypatch.setattr(PlaygroundHandler, "_worker", worker)
-    monkeypatch.setattr(PlaygroundHandler, "_latest_request_ids", {})
-    monkeypatch.setattr(PlaygroundHandler, "_loaded_index", None)
+    monkeypatch.setattr(PlaygroundHandler, "_project_id", pid)
+    monkeypatch.setattr(PlaygroundHandler, "_project_key", pkey)
     return handler, captured
 
 
@@ -86,17 +27,6 @@ def _make_token_handler(monkeypatch):
     monkeypatch.setattr(PlaygroundHandler, "_token", "secret-token")
     monkeypatch.setattr(PlaygroundHandler, "_server_host", "127.0.0.1:8765")
     return handler, captured
-
-
-def _valid_body():
-    return {
-        "name": "idx",
-        "query": "hello",
-        "sessionId": "sess",
-        "requestId": 1,
-        "topK": 5,
-        "alpha": 0.5,
-    }
 
 
 def _auth_headers(**extra):
@@ -116,6 +46,35 @@ def test_playground_html_asset_exists():
     )
 
 
+def test_html_includes_wasm_importmap():
+    html = PLAYGROUND_HTML.read_text(encoding="utf-8")
+    assert '<script type="importmap">' in html
+    assert "https://unpkg.com/@moss-dev/moss-web@" in html
+    assert "https://unpkg.com/@moss-dev/moss-wasm@" in html
+    assert "https://unpkg.com/onnxruntime-web@" in html
+
+
+def test_html_loads_moss_web_in_browser():
+    html = PLAYGROUND_HTML.read_text(encoding="utf-8")
+    assert "import('@moss-dev/moss-web')" in html
+    assert "MossClient.create" in html
+
+
+def test_html_has_manual_connection_form():
+    html = PLAYGROUND_HTML.read_text(encoding="utf-8")
+    assert 'id="connect-form"' in html
+    assert 'id="pid-input"' in html
+    assert 'id="pkey-input"' in html
+
+
+def test_html_queries_in_browser_not_via_server():
+    html = PLAYGROUND_HTML.read_text(encoding="utf-8")
+    assert "client.query(" in html
+    assert "client.loadIndex(" in html
+    assert "/api/query" not in html
+    assert "/api/load-index" not in html
+
+
 def test_html_renders_metadata_safely():
     html = PLAYGROUND_HTML.read_text(encoding="utf-8")
     assert "result-metadata" in html
@@ -123,168 +82,35 @@ def test_html_renders_metadata_safely():
     assert "textContent" in html
 
 
-def test_html_aborts_stale_queries():
-    html = PLAYGROUND_HTML.read_text(encoding="utf-8")
-    assert "AbortController" in html
-    assert "signal: thisAbort.signal" in html
-    assert "requestId: thisRequestId" in html
-
-
-def test_query_accepts_valid_params(monkeypatch):
-    client = FakeClient()
-    worker = FakeWorker(client)
-    handler, captured = _make_handler(monkeypatch, client=client, worker=worker)
-    handler._handle_post_query(dict(_valid_body()))
+def test_config_returns_injected_credentials(monkeypatch):
+    handler, captured = _make_config_handler(monkeypatch, pid="proj-1", pkey="key-1")
+    handler._handle_get_config()
     assert captured["status"] == 200
-    assert len(client.query_calls) == 1
-    name, query, options = client.query_calls[0]
-    assert (name, query) == ("idx", "hello")
-    assert options.top_k == 5
-    assert options.alpha == 0.5
-    assert captured["data"]["docs"][0]["metadata"] == {"k": "v"}
+    assert captured["data"] == {"projectId": "proj-1", "projectKey": "key-1"}
 
 
-def test_query_rejects_bool_topk(monkeypatch):
-    client = FakeClient()
-    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
-    body = _valid_body()
-    body["topK"] = True
-    handler._handle_post_query(body)
-    assert captured["status"] == 400
-    assert client.query_calls == []
-
-
-def test_query_rejects_fractional_topk(monkeypatch):
-    client = FakeClient()
-    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
-    body = _valid_body()
-    body["topK"] = 1.9
-    handler._handle_post_query(body)
-    assert captured["status"] == 400
-    assert client.query_calls == []
-
-
-def test_query_rejects_string_topk(monkeypatch):
-    client = FakeClient()
-    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
-    body = _valid_body()
-    body["topK"] = "5"
-    handler._handle_post_query(body)
-    assert captured["status"] == 400
-    assert client.query_calls == []
-
-
-def test_query_rejects_out_of_range_topk(monkeypatch):
-    client = FakeClient()
-    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
-    for bad in (0, 51):
-        body = _valid_body()
-        body["topK"] = bad
-        handler._handle_post_query(body)
-        assert captured["status"] == 400, f"expected 400 for topK={bad}"
-        assert client.query_calls == []
-
-
-def test_query_rejects_bool_alpha(monkeypatch):
-    client = FakeClient()
-    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
-    body = _valid_body()
-    body["alpha"] = True
-    handler._handle_post_query(body)
-    assert captured["status"] == 400
-    assert client.query_calls == []
-
-
-def test_query_rejects_non_finite_alpha(monkeypatch):
-    client = FakeClient()
-    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
-    for bad in (float("nan"), float("inf"), float("-inf")):
-        body = _valid_body()
-        body["alpha"] = bad
-        handler._handle_post_query(body)
-        assert captured["status"] == 400, f"expected 400 for alpha={bad}"
-        assert client.query_calls == []
-
-
-def test_query_rejects_oversized_int_alpha(monkeypatch):
-    client = FakeClient()
-    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
-    body = _valid_body()
-    body["alpha"] = 10**400
-    handler._handle_post_query(body)
-    assert captured["status"] == 400
-    assert client.query_calls == []
-
-
-def test_query_rejects_out_of_range_alpha(monkeypatch):
-    client = FakeClient()
-    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
-    for bad in (-0.1, 1.1):
-        body = _valid_body()
-        body["alpha"] = bad
-        handler._handle_post_query(body)
-        assert captured["status"] == 400, f"expected 400 for alpha={bad}"
-        assert client.query_calls == []
-
-
-def test_query_requires_request_id(monkeypatch):
-    client = FakeClient()
-    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
-    body = _valid_body()
-    for bad in (None, True, "1"):
-        body["requestId"] = bad
-        handler._handle_post_query(body)
-        assert captured["status"] == 400, f"expected 400 for requestId={bad}"
-        assert client.query_calls == []
-
-
-def test_query_drops_already_superseded_request(monkeypatch):
-    client = FakeClient()
-    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
-    PlaygroundHandler._latest_request_ids["sess"] = 5
-    body = _valid_body()
-    body["requestId"] = 3
-    handler._handle_post_query(body)
+def test_config_returns_nulls_without_credentials(monkeypatch):
+    handler, captured = _make_config_handler(monkeypatch)
+    handler._handle_get_config()
     assert captured["status"] == 200
-    assert captured["data"].get("superseded") is True
-    assert client.query_calls == []
+    assert captured["data"] == {"projectId": None, "projectKey": None}
 
 
-def test_query_sessions_are_isolated(monkeypatch):
-    client = FakeClient()
-    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
-    body = _valid_body()
-    body["requestId"] = 1
-    body["sessionId"] = "sess-a"
-    handler._handle_post_query(body)
+def test_config_requires_token(monkeypatch):
+    handler, captured = _make_token_handler(monkeypatch)
+    handler.path = "/api/config"
+    handler.headers = {"Host": "127.0.0.1:8765"}
+    handler.do_GET()
+    assert captured["status"] == 403
+
+
+def test_config_allows_valid_token(monkeypatch):
+    handler, captured = _make_token_handler(monkeypatch)
+    handler.path = "/api/config"
+    handler.headers = _auth_headers()
+    handler.do_GET()
     assert captured["status"] == 200
-    body["sessionId"] = "sess-b"
-    handler._handle_post_query(body)
-    assert captured["status"] == 200
-    assert len(client.query_calls) == 2
-
-
-def test_query_requires_session_id(monkeypatch):
-    client = FakeClient()
-    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
-    for bad in (None, True, 123, ""):
-        body = _valid_body()
-        body["sessionId"] = bad
-        handler._handle_post_query(body)
-        assert captured["status"] == 400, f"expected 400 for sessionId={bad!r}"
-        assert client.query_calls == []
-
-
-def test_query_rejects_non_string_name_and_query(monkeypatch):
-    client = FakeClient()
-    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
-    for key in ("name", "query"):
-        for bad in (123, "   "):
-            body = _valid_body()
-            body[key] = bad
-            handler._handle_post_query(body)
-            assert captured["status"] == 400, f"expected 400 for {key}={bad!r}"
-            assert client.query_calls == []
+    assert captured["data"] == {"projectId": None, "projectKey": None}
 
 
 def test_check_api_request_missing_token(monkeypatch):
@@ -328,93 +154,3 @@ def test_check_api_request_allows_valid_request(monkeypatch):
     }
     assert handler._check_api_request() is True
     assert "status" not in captured
-
-
-def _make_authed_handler(monkeypatch, client=None, worker=None):
-    handler, captured = _make_handler(monkeypatch, client=client, worker=worker)
-    monkeypatch.setattr(PlaygroundHandler, "_token", "secret-token")
-    monkeypatch.setattr(PlaygroundHandler, "_server_host", "127.0.0.1:8765")
-    return handler, captured
-
-
-def test_post_rejects_malformed_content_length(monkeypatch):
-    handler, captured = _make_authed_handler(monkeypatch)
-    handler.path = "/api/query"
-    handler.headers = _auth_headers(**{"Content-Length": "abc"})
-    handler.rfile = io.BytesIO(b"{}")
-    handler.do_POST()
-    assert captured["status"] == 400
-
-
-def test_post_rejects_negative_content_length(monkeypatch):
-    handler, captured = _make_authed_handler(monkeypatch)
-    handler.path = "/api/query"
-    handler.headers = _auth_headers(**{"Content-Length": "-1"})
-    handler.rfile = io.BytesIO(b"{}")
-    handler.do_POST()
-    assert captured["status"] == 400
-
-
-def test_post_rejects_oversized_body(monkeypatch):
-    handler, captured = _make_authed_handler(monkeypatch)
-    handler.path = "/api/query"
-    handler.headers = _auth_headers(**{"Content-Length": str(MAX_REQUEST_BODY_SIZE + 1)})
-    handler.rfile = io.BytesIO(b"{}")
-    handler.do_POST()
-    assert captured["status"] == 413
-
-
-def test_post_accepts_empty_body_fallback(monkeypatch):
-    handler, captured = _make_authed_handler(
-        monkeypatch, client=FakeClient(), worker=FakeWorker(FakeClient())
-    )
-    handler.path = "/api/query"
-    handler.headers = _auth_headers()
-    handler.rfile = io.BytesIO(b"{}")
-    handler.do_POST()
-    assert captured["status"] == 400
-
-
-def test_load_index_unloads_previous(monkeypatch):
-    client = FakeLoadClient()
-    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
-    monkeypatch.setattr(PlaygroundHandler, "_loaded_index", "idx-a")
-
-    handler._handle_post_load_index({"name": "idx-b"})
-    assert captured["status"] == 200
-    assert client.unloaded == ["idx-a"]
-    assert client.loaded == ["idx-b"]
-    assert PlaygroundHandler._loaded_index == "idx-b"
-
-
-def test_load_index_reuses_current_index_without_unload(monkeypatch):
-    client = FakeLoadClient()
-    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
-    monkeypatch.setattr(PlaygroundHandler, "_loaded_index", "idx-a")
-
-    handler._handle_post_load_index({"name": "idx-a"})
-    assert captured["status"] == 200
-    assert client.unloaded == []
-    assert client.loaded == ["idx-a"]
-    assert PlaygroundHandler._loaded_index == "idx-a"
-
-
-def test_load_index_requires_name(monkeypatch):
-    client = FakeLoadClient()
-    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
-    for bad in (None, "", "   "):
-        handler._handle_post_load_index({"name": bad})
-        assert captured["status"] == 400, f"expected 400 for name={bad!r}"
-    assert client.loaded == []
-    assert client.unloaded == []
-
-
-def test_query_skips_stale_queued_job(monkeypatch):
-    client = FakeClient()
-    handler, captured = _make_handler(
-        monkeypatch, client=client, worker=SupersedingWorker(client)
-    )
-    handler._handle_post_query(dict(_valid_body()))
-    assert captured["status"] == 200
-    assert captured["data"].get("superseded") is True
-    assert client.query_calls == []

--- a/packages/moss-cli/tests/test_playground.py
+++ b/packages/moss-cli/tests/test_playground.py
@@ -1,4 +1,62 @@
-from moss_cli.commands.playground import PLAYGROUND_HTML
+import asyncio
+import inspect
+from types import SimpleNamespace
+
+from moss_cli.commands.playground import PLAYGROUND_HTML, PlaygroundHandler
+
+
+class FakeClient:
+    def __init__(self):
+        self.query_calls = []
+
+    def query(self, name, query, options):
+        self.query_calls.append((name, query, options))
+        doc = SimpleNamespace(id="d1", text="hello", score=0.9, metadata={"k": "v"})
+        return SimpleNamespace(docs=[doc], time_taken_ms=12, query=query)
+
+
+class FakeWorker:
+    def __init__(self, client):
+        self.client = client
+
+    def submit(self, coro_fn):
+        result = coro_fn()
+        if inspect.isawaitable(result):
+            return asyncio.run(result)
+        return result
+
+
+class SupersedingWorker:
+    """Simulates a newer query arriving while an older one is queued."""
+
+    def __init__(self, client):
+        self.client = client
+
+    def submit(self, coro_fn):
+        PlaygroundHandler._latest_request_id = 99
+        result = coro_fn()
+        if inspect.isawaitable(result):
+            return asyncio.run(result)
+        return result
+
+
+def _make_handler(monkeypatch, client=None, worker=None):
+    handler = PlaygroundHandler.__new__(PlaygroundHandler)
+    captured = {}
+
+    def fake_send_json(status, data):
+        captured["status"] = status
+        captured["data"] = data
+
+    monkeypatch.setattr(handler, "_send_json", fake_send_json)
+    monkeypatch.setattr(PlaygroundHandler, "client", client)
+    monkeypatch.setattr(PlaygroundHandler, "_worker", worker)
+    monkeypatch.setattr(PlaygroundHandler, "_latest_request_id", 0)
+    return handler, captured
+
+
+def _valid_body():
+    return {"name": "idx", "query": "hello", "requestId": 1, "topK": 5, "alpha": 0.5}
 
 
 def test_playground_html_asset_exists():
@@ -6,3 +64,138 @@ def test_playground_html_asset_exists():
         f"Playground HTML not found at {PLAYGROUND_HTML}. "
         "Check that the asset is included in the package data."
     )
+
+
+def test_html_renders_metadata_safely():
+    html = PLAYGROUND_HTML.read_text(encoding="utf-8")
+    assert "result-metadata" in html
+    assert "JSON.stringify(doc.metadata, null, 2)" in html
+    assert "textContent" in html
+
+
+def test_html_aborts_stale_queries():
+    html = PLAYGROUND_HTML.read_text(encoding="utf-8")
+    assert "AbortController" in html
+    assert "signal: thisAbort.signal" in html
+    assert "requestId: thisRequestId" in html
+
+
+def test_query_accepts_valid_params(monkeypatch):
+    client = FakeClient()
+    worker = FakeWorker(client)
+    handler, captured = _make_handler(monkeypatch, client=client, worker=worker)
+    handler._handle_post_query(dict(_valid_body()))
+    assert captured["status"] == 200
+    assert len(client.query_calls) == 1
+    name, query, options = client.query_calls[0]
+    assert (name, query) == ("idx", "hello")
+    assert options.top_k == 5
+    assert options.alpha == 0.5
+    assert captured["data"]["docs"][0]["metadata"] == {"k": "v"}
+
+
+def test_query_rejects_bool_topk(monkeypatch):
+    client = FakeClient()
+    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
+    body = _valid_body()
+    body["topK"] = True
+    handler._handle_post_query(body)
+    assert captured["status"] == 400
+    assert client.query_calls == []
+
+
+def test_query_rejects_fractional_topk(monkeypatch):
+    client = FakeClient()
+    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
+    body = _valid_body()
+    body["topK"] = 1.9
+    handler._handle_post_query(body)
+    assert captured["status"] == 400
+    assert client.query_calls == []
+
+
+def test_query_rejects_string_topk(monkeypatch):
+    client = FakeClient()
+    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
+    body = _valid_body()
+    body["topK"] = "5"
+    handler._handle_post_query(body)
+    assert captured["status"] == 400
+    assert client.query_calls == []
+
+
+def test_query_rejects_out_of_range_topk(monkeypatch):
+    client = FakeClient()
+    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
+    for bad in (0, 51):
+        body = _valid_body()
+        body["topK"] = bad
+        handler._handle_post_query(body)
+        assert captured["status"] == 400, f"expected 400 for topK={bad}"
+        assert client.query_calls == []
+
+
+def test_query_rejects_bool_alpha(monkeypatch):
+    client = FakeClient()
+    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
+    body = _valid_body()
+    body["alpha"] = True
+    handler._handle_post_query(body)
+    assert captured["status"] == 400
+    assert client.query_calls == []
+
+
+def test_query_rejects_non_finite_alpha(monkeypatch):
+    client = FakeClient()
+    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
+    for bad in (float("nan"), float("inf"), float("-inf")):
+        body = _valid_body()
+        body["alpha"] = bad
+        handler._handle_post_query(body)
+        assert captured["status"] == 400, f"expected 400 for alpha={bad}"
+        assert client.query_calls == []
+
+
+def test_query_rejects_out_of_range_alpha(monkeypatch):
+    client = FakeClient()
+    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
+    for bad in (-0.1, 1.1):
+        body = _valid_body()
+        body["alpha"] = bad
+        handler._handle_post_query(body)
+        assert captured["status"] == 400, f"expected 400 for alpha={bad}"
+        assert client.query_calls == []
+
+
+def test_query_requires_request_id(monkeypatch):
+    client = FakeClient()
+    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
+    body = _valid_body()
+    for bad in (None, True, "1"):
+        body["requestId"] = bad
+        handler._handle_post_query(body)
+        assert captured["status"] == 400, f"expected 400 for requestId={bad}"
+        assert client.query_calls == []
+
+
+def test_query_drops_already_superseded_request(monkeypatch):
+    client = FakeClient()
+    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
+    monkeypatch.setattr(PlaygroundHandler, "_latest_request_id", 5)
+    body = _valid_body()
+    body["requestId"] = 3
+    handler._handle_post_query(body)
+    assert captured["status"] == 200
+    assert captured["data"].get("superseded") is True
+    assert client.query_calls == []
+
+
+def test_query_skips_stale_queued_job(monkeypatch):
+    client = FakeClient()
+    handler, captured = _make_handler(
+        monkeypatch, client=client, worker=SupersedingWorker(client)
+    )
+    handler._handle_post_query(dict(_valid_body()))
+    assert captured["status"] == 200
+    assert captured["data"].get("superseded") is True
+    assert client.query_calls == []

--- a/packages/moss-cli/tests/test_playground.py
+++ b/packages/moss-cli/tests/test_playground.py
@@ -1,0 +1,8 @@
+from moss_cli.commands.playground import PLAYGROUND_HTML
+
+
+def test_playground_html_asset_exists():
+    assert PLAYGROUND_HTML.exists(), (
+        f"Playground HTML not found at {PLAYGROUND_HTML}. "
+        "Check that the asset is included in the package data."
+    )

--- a/packages/moss-cli/tests/test_playground.py
+++ b/packages/moss-cli/tests/test_playground.py
@@ -1,8 +1,13 @@
 import asyncio
 import inspect
+import io
 from types import SimpleNamespace
 
-from moss_cli.commands.playground import PLAYGROUND_HTML, PlaygroundHandler
+from moss_cli.commands.playground import (
+    MAX_REQUEST_BODY_SIZE,
+    PLAYGROUND_HTML,
+    PlaygroundHandler,
+)
 
 
 class FakeClient:
@@ -33,7 +38,7 @@ class SupersedingWorker:
         self.client = client
 
     def submit(self, coro_fn):
-        PlaygroundHandler._latest_request_id = 99
+        PlaygroundHandler._latest_request_ids["sess"] = 99
         result = coro_fn()
         if inspect.isawaitable(result):
             return asyncio.run(result)
@@ -51,12 +56,43 @@ def _make_handler(monkeypatch, client=None, worker=None):
     monkeypatch.setattr(handler, "_send_json", fake_send_json)
     monkeypatch.setattr(PlaygroundHandler, "client", client)
     monkeypatch.setattr(PlaygroundHandler, "_worker", worker)
-    monkeypatch.setattr(PlaygroundHandler, "_latest_request_id", 0)
+    monkeypatch.setattr(PlaygroundHandler, "_latest_request_ids", {})
+    return handler, captured
+
+
+def _make_token_handler(monkeypatch):
+    handler = PlaygroundHandler.__new__(PlaygroundHandler)
+    captured = {}
+
+    def fake_send_json(status, data):
+        captured["status"] = status
+        captured["data"] = data
+
+    monkeypatch.setattr(handler, "_send_json", fake_send_json)
+    monkeypatch.setattr(PlaygroundHandler, "_token", "secret-token")
+    monkeypatch.setattr(PlaygroundHandler, "_server_host", "127.0.0.1:8765")
     return handler, captured
 
 
 def _valid_body():
-    return {"name": "idx", "query": "hello", "requestId": 1, "topK": 5, "alpha": 0.5}
+    return {
+        "name": "idx",
+        "query": "hello",
+        "sessionId": "sess",
+        "requestId": 1,
+        "topK": 5,
+        "alpha": 0.5,
+    }
+
+
+def _auth_headers(**extra):
+    headers = {
+        "X-Moss-Token": "secret-token",
+        "Host": "127.0.0.1:8765",
+        "Origin": "http://127.0.0.1:8765",
+    }
+    headers.update(extra)
+    return headers
 
 
 def test_playground_html_asset_exists():
@@ -181,13 +217,138 @@ def test_query_requires_request_id(monkeypatch):
 def test_query_drops_already_superseded_request(monkeypatch):
     client = FakeClient()
     handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
-    monkeypatch.setattr(PlaygroundHandler, "_latest_request_id", 5)
+    PlaygroundHandler._latest_request_ids["sess"] = 5
     body = _valid_body()
     body["requestId"] = 3
     handler._handle_post_query(body)
     assert captured["status"] == 200
     assert captured["data"].get("superseded") is True
     assert client.query_calls == []
+
+
+def test_query_sessions_are_isolated(monkeypatch):
+    client = FakeClient()
+    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
+    body = _valid_body()
+    body["requestId"] = 1
+    body["sessionId"] = "sess-a"
+    handler._handle_post_query(body)
+    assert captured["status"] == 200
+    body["sessionId"] = "sess-b"
+    handler._handle_post_query(body)
+    assert captured["status"] == 200
+    assert len(client.query_calls) == 2
+
+
+def test_query_requires_session_id(monkeypatch):
+    client = FakeClient()
+    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
+    for bad in (None, True, 123, ""):
+        body = _valid_body()
+        body["sessionId"] = bad
+        handler._handle_post_query(body)
+        assert captured["status"] == 400, f"expected 400 for sessionId={bad!r}"
+        assert client.query_calls == []
+
+
+def test_query_rejects_non_string_name_and_query(monkeypatch):
+    client = FakeClient()
+    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
+    for key in ("name", "query"):
+        for bad in (123, "   "):
+            body = _valid_body()
+            body[key] = bad
+            handler._handle_post_query(body)
+            assert captured["status"] == 400, f"expected 400 for {key}={bad!r}"
+            assert client.query_calls == []
+
+
+def test_check_api_request_missing_token(monkeypatch):
+    handler, captured = _make_token_handler(monkeypatch)
+    handler.headers = {"Host": "127.0.0.1:8765"}
+    assert handler._check_api_request() is False
+    assert captured["status"] == 403
+
+
+def test_check_api_request_wrong_token(monkeypatch):
+    handler, captured = _make_token_handler(monkeypatch)
+    handler.headers = {"X-Moss-Token": "wrong", "Host": "127.0.0.1:8765"}
+    assert handler._check_api_request() is False
+    assert captured["status"] == 403
+
+
+def test_check_api_request_foreign_host(monkeypatch):
+    handler, captured = _make_token_handler(monkeypatch)
+    handler.headers = {"X-Moss-Token": "secret-token", "Host": "evil.example.com"}
+    assert handler._check_api_request() is False
+    assert captured["status"] == 403
+
+
+def test_check_api_request_foreign_origin(monkeypatch):
+    handler, captured = _make_token_handler(monkeypatch)
+    handler.headers = {
+        "X-Moss-Token": "secret-token",
+        "Host": "127.0.0.1:8765",
+        "Origin": "http://evil.example.com",
+    }
+    assert handler._check_api_request() is False
+    assert captured["status"] == 403
+
+
+def test_check_api_request_allows_valid_request(monkeypatch):
+    handler, captured = _make_token_handler(monkeypatch)
+    handler.headers = {
+        "X-Moss-Token": "secret-token",
+        "Host": "localhost:8765",
+        "Origin": "http://localhost:8765",
+    }
+    assert handler._check_api_request() is True
+    assert "status" not in captured
+
+
+def _make_authed_handler(monkeypatch, client=None, worker=None):
+    handler, captured = _make_handler(monkeypatch, client=client, worker=worker)
+    monkeypatch.setattr(PlaygroundHandler, "_token", "secret-token")
+    monkeypatch.setattr(PlaygroundHandler, "_server_host", "127.0.0.1:8765")
+    return handler, captured
+
+
+def test_post_rejects_malformed_content_length(monkeypatch):
+    handler, captured = _make_authed_handler(monkeypatch)
+    handler.path = "/api/query"
+    handler.headers = _auth_headers(**{"Content-Length": "abc"})
+    handler.rfile = io.BytesIO(b"{}")
+    handler.do_POST()
+    assert captured["status"] == 400
+
+
+def test_post_rejects_negative_content_length(monkeypatch):
+    handler, captured = _make_authed_handler(monkeypatch)
+    handler.path = "/api/query"
+    handler.headers = _auth_headers(**{"Content-Length": "-1"})
+    handler.rfile = io.BytesIO(b"{}")
+    handler.do_POST()
+    assert captured["status"] == 400
+
+
+def test_post_rejects_oversized_body(monkeypatch):
+    handler, captured = _make_authed_handler(monkeypatch)
+    handler.path = "/api/query"
+    handler.headers = _auth_headers(**{"Content-Length": str(MAX_REQUEST_BODY_SIZE + 1)})
+    handler.rfile = io.BytesIO(b"{}")
+    handler.do_POST()
+    assert captured["status"] == 413
+
+
+def test_post_accepts_empty_body_fallback(monkeypatch):
+    handler, captured = _make_authed_handler(
+        monkeypatch, client=FakeClient(), worker=FakeWorker(FakeClient())
+    )
+    handler.path = "/api/query"
+    handler.headers = _auth_headers()
+    handler.rfile = io.BytesIO(b"{}")
+    handler.do_POST()
+    assert captured["status"] == 400
 
 
 def test_query_skips_stale_queued_job(monkeypatch):

--- a/packages/moss-cli/tests/test_playground.py
+++ b/packages/moss-cli/tests/test_playground.py
@@ -20,6 +20,19 @@ class FakeClient:
         return SimpleNamespace(docs=[doc], time_taken_ms=12, query=query)
 
 
+class FakeLoadClient:
+    def __init__(self):
+        self.loaded = []
+        self.unloaded = []
+
+    def load_index(self, name):
+        self.loaded.append(name)
+        return name
+
+    def unload_index(self, name):
+        self.unloaded.append(name)
+
+
 class FakeWorker:
     def __init__(self, client):
         self.client = client
@@ -57,6 +70,7 @@ def _make_handler(monkeypatch, client=None, worker=None):
     monkeypatch.setattr(PlaygroundHandler, "client", client)
     monkeypatch.setattr(PlaygroundHandler, "_worker", worker)
     monkeypatch.setattr(PlaygroundHandler, "_latest_request_ids", {})
+    monkeypatch.setattr(PlaygroundHandler, "_loaded_index", None)
     return handler, captured
 
 
@@ -190,6 +204,16 @@ def test_query_rejects_non_finite_alpha(monkeypatch):
         handler._handle_post_query(body)
         assert captured["status"] == 400, f"expected 400 for alpha={bad}"
         assert client.query_calls == []
+
+
+def test_query_rejects_oversized_int_alpha(monkeypatch):
+    client = FakeClient()
+    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
+    body = _valid_body()
+    body["alpha"] = 10**400
+    handler._handle_post_query(body)
+    assert captured["status"] == 400
+    assert client.query_calls == []
 
 
 def test_query_rejects_out_of_range_alpha(monkeypatch):
@@ -349,6 +373,40 @@ def test_post_accepts_empty_body_fallback(monkeypatch):
     handler.rfile = io.BytesIO(b"{}")
     handler.do_POST()
     assert captured["status"] == 400
+
+
+def test_load_index_unloads_previous(monkeypatch):
+    client = FakeLoadClient()
+    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
+    monkeypatch.setattr(PlaygroundHandler, "_loaded_index", "idx-a")
+
+    handler._handle_post_load_index({"name": "idx-b"})
+    assert captured["status"] == 200
+    assert client.unloaded == ["idx-a"]
+    assert client.loaded == ["idx-b"]
+    assert PlaygroundHandler._loaded_index == "idx-b"
+
+
+def test_load_index_reuses_current_index_without_unload(monkeypatch):
+    client = FakeLoadClient()
+    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
+    monkeypatch.setattr(PlaygroundHandler, "_loaded_index", "idx-a")
+
+    handler._handle_post_load_index({"name": "idx-a"})
+    assert captured["status"] == 200
+    assert client.unloaded == []
+    assert client.loaded == ["idx-a"]
+    assert PlaygroundHandler._loaded_index == "idx-a"
+
+
+def test_load_index_requires_name(monkeypatch):
+    client = FakeLoadClient()
+    handler, captured = _make_handler(monkeypatch, client=client, worker=FakeWorker(client))
+    for bad in (None, "", "   "):
+        handler._handle_post_load_index({"name": bad})
+        assert captured["status"] == 400, f"expected 400 for name={bad!r}"
+    assert client.loaded == []
+    assert client.unloaded == []
 
 
 def test_query_skips_stale_queued_job(monkeypatch):


### PR DESCRIPTION
# Pull Request Checklist

Please ensure that your PR meets the following requirements:

* [X] I have read the [[CONTRIBUTING](https://chatgpt.com/c/CONTRIBUTING.md)](CONTRIBUTING.md) guide.
* [x] I have updated the documentation (if applicable).
* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have added tests that prove my fix is effective or that my feature works.
* [x] New and existing unit tests pass locally with my changes.

## Description

Adds a local playground for interactively exploring Moss indexes from the browser.

The new `moss playground` command starts a lightweight local HTTP server that serves a browser-based playground. The UI uses `@moss-dev/moss-web` (WASM) to execute searches entirely in the browser after an index is loaded.

**Usage**

```bash
moss playground
```

The server starts on `127.0.0.1:8765` (or the next available port if occupied).

### What's Included

* Added `playground.py` command to start a local HTTP server.
* Added a browser-based playground UI (`playground/index.html`).
* Added API endpoints:

  * `GET /api/indexes` – lists available cloud indexes.
  * `GET /api/index?name=...` – returns index metadata.
* Supports automatic credential resolution from CLI flags, environment variables, or configuration.
* Loads `@moss-dev/moss-web` via WASM using an `importmap` with the unpkg CDN.
* Allows users to:

  * Select and load an index.
  * Execute queries locally in the browser.
  * Adjust Top-K.
  * Adjust Alpha.
  * View score, document ID, text snippet, and query latency.
* Falls back to a manual connection form when credentials are not injected by the server.

Fixes #434

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/usemoss/moss/pull/496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local browser-based Playground for browsing indexes and running semantic searches.
  * Added the `moss playground` command with configurable ports, credential profiles, and optional automatic browser launch.
  * Added result metadata, scores, timing details, tokenized access, and clear loading, empty, and error states.
  * Added secure local access for loading indexes and querying results.

* **Documentation**
  * Documented Playground setup, controls, index browsing, searching, and API behavior.

* **Tests**
  * Added coverage for packaged Playground assets, authentication, validation, and request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->