### PR TITLE
chore(deps): upgrade form-data to latest version

### DIFF
--- a/packages/n8n-nodes-moss/package-lock.json
+++ b/packages/n8n-nodes-moss/package-lock.json
@@ -1609,17 +1609,17 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
 			},
 			"engines": {
 				"node": ">= 6"

--- a/packages/n8n-nodes-moss/package.json
+++ b/packages/n8n-nodes-moss/package.json
@@ -56,6 +56,7 @@
 		"n8n-workflow": "*"
 	},
 	"overrides": {
-		"lodash": "^4.18.1"
+		"lodash": "^4.18.1",
+		"form-data": "^4.0.6"
 	}
 }


### PR DESCRIPTION
Pull Request Checklist

Please ensure that your PR meets the following requirements:

- [x] I have read the CONTRIBUTING (CONTRIBUTING.md) guide.
- [ ] I have updated the documentation (if applicable). -- N/A
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works. -- N/A, this is a dependency bump
- [x] New and existing unit tests pass locally with my changes.

Description

form-data was outdated (4.0.4) in packages/n8n-nodes-moss/package-lock.json, pulled in transitively via n8n-workflow@2.16.0, which pins it to that exact version. Since n8n-workflow is declared as * (any version) and bumping the whole n8n-workflow package is out of scope here, I added "form-data": "^4.0.6" to the existing overrides block in package.json (the same mechanism already used there for lodash) and regenerated the lockfile with npm install.

Checked the other lockfile referencing form-data (apps/moss-vscode/package-lock.json) — it already resolves to the latest 4.0.6 via @vscode/vsce's ^4.0.0 range, so no change was needed there.

Verified npm run typecheck and npm test pass in packages/n8n-nodes-moss, and confirmed via npm ls form-data that only a single deduped 4.0.6 instance is installed (no duplicate/nested copies introduced).

Fixes #468

Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update -- No, N/A (dependency-only change)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/usemoss/moss/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

