### PR TITLE
feat(apps): add TEN tool-call and Agora custom-llm Moss samples with offline bench

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,3 +179,25 @@ jobs:
     - name: Run tests
       working-directory: packages/vitepress-plugin-moss
       run: pnpm test
+
+  agora-ten-samples-smoke:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Install smoke deps
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest pytest-asyncio fastapi httpx pydantic python-dotenv
+    - name: TEN graph + bench unit tests
+      run: |
+        pytest apps/ten-moss/tests apps/ten-moss/bench/test_run.py -v
+    - name: custom-llm mock/doctor tests
+      run: |
+        pytest apps/agora-custom-llm-moss/tests -v
+    - name: Echo-grounding table (no LLM keys)
+      run: |
+        python apps/ten-moss/bench/run.py --echo-grounding

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ examples/
     moss-cognee-daytona/ — Claude Code + Cognee + Moss on Daytona (shared memory)
 apps/
   agora-moss/      — Agora Conversational AI voice agent (MCP server demo)
+  agora-custom-llm-moss/ — Agora custom-llm middleware: ambient prepend + in-process tool loop
   docker/          — Dockerized Python + JS SDK examples (ECS/K8s pattern)
   elevenlabs-moss/ — ElevenLabs voice agent with Moss knowledge base
   livekit-moss-vercel/ — LiveKit voice agent + React frontend on Vercel
@@ -111,12 +112,13 @@ asks for an experimental landing spot.
 | Directory | Integration | What it demonstrates |
 | --------- | ----------- | -------------------- |
 | `agora-moss/` | Agora Conversational AI | Moss as an MCP tool (`search_knowledge_base`) mounted on an Agora voice agent |
+| `agora-custom-llm-moss/` | Agora custom-llm | OpenAI-compatible `/chat/completions` with Moss ambient + tool modes; Agora never sees the tool |
 | `elevenlabs-moss/` | ElevenLabs | Knowledge-base-backed ElevenLabs Conversational AI bot with live Moss retrieval |
 | `livekit-moss-vercel/` | LiveKit + Vercel | LiveKit voice agent with React frontend deployed to Vercel; Moss powers RAG |
 | `pipecat-moss/pipecat-quickstart/` | Pipecat Cloud | Minimal Pipecat bot — local dev → Pipecat Cloud deployment |
 | `pipecat-moss/ollama-local/` | Pipecat + Ollama | Full-stack local voice AI: Ollama LLM + Moss RAG + Pipecat audio, one `docker compose up` |
 | `pipecat-moss/hume-ollama-local/` | Pipecat + Ollama + Hume | Same as above with Hume AI (Octave) expressive TTS |
-| `ten-moss/` | TEN Framework | Voice agent that grounds each turn in a Moss session (`MossSessionManager`); TEN `voice-assistant` example + the Moss delta |
+| `ten-moss/` | TEN Framework | Voice agent that grounds each turn in a Moss session (`MossSessionManager`); graphs `voice_assistant` (ambient, default) and `voice_assistant_tools` (in-process `search_knowledge_base`) |
 | `vapi-moss/` | VAPI | Webhook server connecting VAPI Custom Tool calls to Moss search; LLM-directed retrieval |
 
 ### Other Apps
@@ -273,4 +275,12 @@ The `.github/workflows/ci.yml` pipeline runs on push to `main` and on PRs:
 - `python-lint` — ruff on examples and apps
 - `python-sdk-test` — matrix over Python 3.10–3.14
 - `javascript-lint` — eslint
+- `agora-ten-samples-smoke` — TEN graph contract + `bench/run.py --echo-grounding` + custom-llm mock/doctor (no Agora/LLM keys)
 - Separate release workflows publish to PyPI / npm on tagged releases
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ apps/
 ├── livekit-moss-vercel/     # LiveKit voice agent on Vercel
 ├── agora-moss/              # Agora Conversational AI MCP server with Moss retrieval
 ├── agora-custom-llm-moss/   # Agora custom-llm middleware (ambient + in-process tool loop)
+├── ten-moss/                # TEN voice agent (ambient default + tool-call graph)
 ├── moss-llamaindex/         # LlamaIndex RAG backend + frontend
 ├── moss-bun/                # Bun runtime example
 └── docker/                  # Dockerized examples (ECS/K8s pattern)
@@ -239,8 +240,8 @@ Full API reference: [docs.moss.dev](https://docs.moss.dev).
 | [LiveKit](https://github.com/livekit/livekit) | Available | [`apps/livekit-moss-vercel/`](apps/livekit-moss-vercel/) |
 | [Vapi](https://vapi.ai) | Available | [`apps/vapi-moss/`](apps/vapi-moss/) |
 | [ElevenLabs](https://elevenlabs.io) | Available | [`apps/elevenlabs-moss/`](apps/elevenlabs-moss/) |
-| [Agora](https://www.agora.io/) | Available | [`apps/agora-moss/`](apps/agora-moss/) (MCP) and [`apps/agora-custom-llm-moss/`](apps/agora-custom-llm-moss/) (custom-llm) |
-| [TEN Framework](https://github.com/ten-framework/ten-framework) | Available | [`apps/ten-moss/`](apps/ten-moss/) |
+| [Agora](https://www.agora.io/) | Available | [`apps/agora-moss/`](apps/agora-moss/) (MCP) and [`apps/agora-custom-llm-moss/`](apps/agora-custom-llm-moss/) (custom-llm: ambient + tool-call) |
+| [TEN Framework](https://github.com/ten-framework/ten-framework) | Available | [`apps/ten-moss/`](apps/ten-moss/) (ambient + tool-call) |
 | [Strands Agents](https://github.com/strands-agents/sdk-python) | Available | [`packages/strands-agents-moss/`](packages/strands-agents-moss/) |
 | [Langflow](https://github.com/langflow-ai/langflow) | Available | [`examples/cookbook/langflow/`](examples/cookbook/langflow/) |
 | [Next.js](https://nextjs.org) | Available | [`apps/next-js/`](apps/next-js/) |

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ apps/
 ├── elevenlabs-moss/         # ElevenLabs voice agent with Moss retrieval
 ├── livekit-moss-vercel/     # LiveKit voice agent on Vercel
 ├── agora-moss/              # Agora Conversational AI MCP server with Moss retrieval
+├── agora-custom-llm-moss/   # Agora custom-llm middleware (ambient + in-process tool loop)
 ├── moss-llamaindex/         # LlamaIndex RAG backend + frontend
 ├── moss-bun/                # Bun runtime example
 └── docker/                  # Dockerized examples (ECS/K8s pattern)
@@ -238,7 +239,7 @@ Full API reference: [docs.moss.dev](https://docs.moss.dev).
 | [LiveKit](https://github.com/livekit/livekit) | Available | [`apps/livekit-moss-vercel/`](apps/livekit-moss-vercel/) |
 | [Vapi](https://vapi.ai) | Available | [`apps/vapi-moss/`](apps/vapi-moss/) |
 | [ElevenLabs](https://elevenlabs.io) | Available | [`apps/elevenlabs-moss/`](apps/elevenlabs-moss/) |
-| [Agora](https://www.agora.io/) | Available | [`apps/agora-moss/`](apps/agora-moss/) |
+| [Agora](https://www.agora.io/) | Available | [`apps/agora-moss/`](apps/agora-moss/) (MCP) and [`apps/agora-custom-llm-moss/`](apps/agora-custom-llm-moss/) (custom-llm) |
 | [TEN Framework](https://github.com/ten-framework/ten-framework) | Available | [`apps/ten-moss/`](apps/ten-moss/) |
 | [Strands Agents](https://github.com/strands-agents/sdk-python) | Available | [`packages/strands-agents-moss/`](packages/strands-agents-moss/) |
 | [Langflow](https://github.com/langflow-ai/langflow) | Available | [`examples/cookbook/langflow/`](examples/cookbook/langflow/) |

--- a/apps/agora-custom-llm-moss/README.md
+++ b/apps/agora-custom-llm-moss/README.md
@@ -41,7 +41,7 @@ python server/src/server.py                      # /llm ambient, /llm-tools tool
 ## Run with a real index
 
 ```bash
-cp server/.env.example server/.env   # fill MOSS_* (and UPSTREAM_LLM_* if not mocking)
+cp server/.env.example server/.env   # fill MOSS_* and a unique CUSTOM_LLM_API_KEY
 python create_index.py
 python server/src/server.py
 ngrok http 8000
@@ -49,7 +49,7 @@ ngrok http 8000
 # tool URL:     https://<tunnel>/llm-tools/chat/completions
 ```
 
-Send `Authorization: Bearer $CUSTOM_LLM_API_KEY`. If Moss is unset or errors, the handler returns empty context and still streams.
+Set `CUSTOM_LLM_API_KEY` to a unique value before exposing the URL. If it is empty, every request is rejected, including any Bearer token. Send `Authorization: Bearer $CUSTOM_LLM_API_KEY`. If Moss is unset or errors, the handler returns empty context and still streams.
 
 Offline table: `python apps/ten-moss/bench/run.py --echo-grounding`
 

--- a/apps/agora-custom-llm-moss/README.md
+++ b/apps/agora-custom-llm-moss/README.md
@@ -1,0 +1,83 @@
+# Agora custom-llm + Moss
+
+A copy-paste custom LLM for [Agora Conversational AI](https://recipes.agora.io/recipes/custom-llm). Agora cloud owns STT/TTS. This process owns `/chat/completions` and runs Moss **in the middleware**.
+
+This is not `apps/agora-moss` (that demo is MCP: Agora calls `search_knowledge_base`). Here Agora only sees an OpenAI-compatible URL.
+
+Same 10 FAQs as `apps/ten-moss/data/knowledge.jsonl`.
+
+## What a stranger copies
+
+| File | Why |
+| --- | --- |
+| `README.md` | this page |
+| `server/src/llm.py` | the whole Moss story (ambient prepend vs tool loop) |
+| `create_index.py` + `data/knowledge.jsonl` | identical corpus as TEN |
+| `server/.env.example` | `MOSS_*`, `CUSTOM_LLM_*`, `UPSTREAM_LLM_*` |
+
+## Two entrypoints, one index
+
+| URL | Mode | What happens on a turn |
+| --- | --- | --- |
+| `/llm/chat/completions` | ambient (default) | extract last user text -> `query_context` -> prepend -> upstream LLM -> SSE |
+| `/llm-tools/chat/completions` | tool | advertise `search_knowledge_base` to the **upstream** LLM, run Moss in-process, stream only the final answer. Cap 2 Moss calls. Agora never sees the tool. |
+
+`MOSS_MODE=ambient|tool` selects the mode when you run `llm.py` alone.
+
+## Quick start (zero LLM keys)
+
+```bash
+cd apps/agora-custom-llm-moss
+python -m pip install -r server/requirements.txt
+python server/src/llm.py --mock --doctor
+```
+
+`--doctor` hits ambient + tool in-process and checks that a missing `Authorization: Bearer` is rejected when mock is off. No Moss keys, no OpenAI keys, no Agora.
+
+Mock server (Agora can call this through ngrok):
+
+```bash
+python server/src/llm.py --mock --mode ambient
+# http://127.0.0.1:8001/chat/completions
+```
+
+Both mounts on one port:
+
+```bash
+python server/src/server.py
+# /llm        ambient
+# /llm-tools  tool
+```
+
+## With a real index
+
+```bash
+cp server/.env.example server/.env
+# fill MOSS_PROJECT_ID / MOSS_PROJECT_KEY / MOSS_INDEX_NAME
+python create_index.py
+# optional: UPSTREAM_LLM_API_KEY for a real model (leave MOCK unset)
+python server/src/server.py
+ngrok http 8000
+# CUSTOM_LLM_URL=https://<tunnel>/llm/chat/completions
+# tool URL:     https://<tunnel>/llm-tools/chat/completions
+```
+
+Point Agora's custom-llm vendor at that public URL. Send `Authorization: Bearer $CUSTOM_LLM_API_KEY`.
+
+## Fail-open
+
+If Moss is unset, fails to import, times out, or raises, the handler returns empty context and still streams an answer. The SSE loop does not die.
+
+## Offline bench
+
+The published gold-phrase table lives next to the TEN app:
+
+```bash
+python apps/ten-moss/bench/run.py --echo-grounding
+```
+
+Same queries, same FAQ corpus.
+
+## License
+
+`server/src/llm.py` keeps the Agora recipe's request/SSE contract (MIT). Moss-authored code in this directory is BSD-2-Clause, same as the rest of this repo.

--- a/apps/agora-custom-llm-moss/README.md
+++ b/apps/agora-custom-llm-moss/README.md
@@ -1,30 +1,29 @@
 # Agora custom-llm + Moss
 
-A copy-paste custom LLM for [Agora Conversational AI](https://recipes.agora.io/recipes/custom-llm). Agora cloud owns STT/TTS. This process owns `/chat/completions` and runs Moss **in the middleware**.
+Agora cloud owns STT and TTS. This process owns `/chat/completions` and runs Moss next to the LLM.
 
-This is not `apps/agora-moss` (that demo is MCP: Agora calls `search_knowledge_base`). Here Agora only sees an OpenAI-compatible URL.
+This is not `apps/agora-moss`. That demo is MCP (Agora calls `search_knowledge_base`). Here Agora only sees an OpenAI-compatible URL.
 
 Same 10 FAQs as `apps/ten-moss/data/knowledge.jsonl`.
 
-## What a stranger copies
+## Copy these
 
 | File | Why |
 | --- | --- |
 | `README.md` | this page |
-| `server/src/llm.py` | the whole Moss story (ambient prepend vs tool loop) |
-| `create_index.py` + `data/knowledge.jsonl` | identical corpus as TEN |
+| `server/src/llm.py` | one turn, both modes |
+| `create_index.py` + `data/knowledge.jsonl` | same corpus as TEN |
 | `server/.env.example` | `MOSS_*`, `CUSTOM_LLM_*`, `UPSTREAM_LLM_*` |
 
-## Two entrypoints, one index
+## One turn
 
-| URL | Mode | What happens on a turn |
-| --- | --- | --- |
-| `/llm/chat/completions` | ambient (default) | extract last user text -> `query_context` -> prepend -> upstream LLM -> SSE |
-| `/llm-tools/chat/completions` | tool | advertise `search_knowledge_base` to the **upstream** LLM, run Moss in-process, stream only the final answer. Cap 2 Moss calls. Agora never sees the tool. |
+**Ambient** (`/llm/chat/completions`, default): take the last user text, `query_context`, prepend, call the upstream model, stream SSE.
 
-`MOSS_MODE=ambient|tool` selects the mode when you run `llm.py` alone.
+**Tool** (`/llm-tools/chat/completions`): give the upstream model `search_knowledge_base`. If it calls the tool, run Moss here (max 2 times). Stream only the final answer. Agora never sees the tool.
 
-## Quick start (zero LLM keys)
+`MOSS_MODE=ambient|tool` picks the mode when you run `llm.py` alone.
+
+## Run with no LLM keys
 
 ```bash
 cd apps/agora-custom-llm-moss
@@ -32,52 +31,26 @@ python -m pip install -r server/requirements.txt
 python server/src/llm.py --mock --doctor
 ```
 
-`--doctor` hits ambient + tool in-process and checks that a missing `Authorization: Bearer` is rejected when mock is off. No Moss keys, no OpenAI keys, no Agora.
-
-Mock server (Agora can call this through ngrok):
+Doctor hits both modes and checks that a missing `Authorization: Bearer` is rejected when mock is off.
 
 ```bash
-python server/src/llm.py --mock --mode ambient
-# http://127.0.0.1:8001/chat/completions
+python server/src/llm.py --mock --mode ambient   # :8001/chat/completions
+python server/src/server.py                      # /llm ambient, /llm-tools tool
 ```
 
-Both mounts on one port:
+## Run with a real index
 
 ```bash
-python server/src/server.py
-# /llm        ambient
-# /llm-tools  tool
-```
-
-## With a real index
-
-```bash
-cp server/.env.example server/.env
-# fill MOSS_PROJECT_ID / MOSS_PROJECT_KEY / MOSS_INDEX_NAME
+cp server/.env.example server/.env   # fill MOSS_* (and UPSTREAM_LLM_* if not mocking)
 python create_index.py
-# optional: UPSTREAM_LLM_API_KEY for a real model (leave MOCK unset)
 python server/src/server.py
 ngrok http 8000
 # CUSTOM_LLM_URL=https://<tunnel>/llm/chat/completions
 # tool URL:     https://<tunnel>/llm-tools/chat/completions
 ```
 
-Point Agora's custom-llm vendor at that public URL. Send `Authorization: Bearer $CUSTOM_LLM_API_KEY`.
+Send `Authorization: Bearer $CUSTOM_LLM_API_KEY`. If Moss is unset or errors, the handler returns empty context and still streams.
 
-## Fail-open
+Offline table: `python apps/ten-moss/bench/run.py --echo-grounding`
 
-If Moss is unset, fails to import, times out, or raises, the handler returns empty context and still streams an answer. The SSE loop does not die.
-
-## Offline bench
-
-The published gold-phrase table lives next to the TEN app:
-
-```bash
-python apps/ten-moss/bench/run.py --echo-grounding
-```
-
-Same queries, same FAQ corpus.
-
-## License
-
-`server/src/llm.py` keeps the Agora recipe's request/SSE contract (MIT). Moss-authored code in this directory is BSD-2-Clause, same as the rest of this repo.
+`llm.py` keeps the Agora recipe SSE contract (MIT). The rest of this directory is BSD-2-Clause.

--- a/apps/agora-custom-llm-moss/create_index.py
+++ b/apps/agora-custom-llm-moss/create_index.py
@@ -39,7 +39,8 @@ async def main() -> None:
     index_name = os.environ["MOSS_INDEX_NAME"]
     docs = load_documents()
     print(f"Creating index '{index_name}' with {len(docs)} documents...")
-    await client.create_index(name=index_name, docs=docs, model_id="moss-minilm")
+    model_id = os.getenv("MOSS_MODEL_ID", "moss-minilm")
+    await client.create_index(name=index_name, docs=docs, model_id=model_id)
     print("Done.")
 
 

--- a/apps/agora-custom-llm-moss/create_index.py
+++ b/apps/agora-custom-llm-moss/create_index.py
@@ -1,0 +1,47 @@
+"""Build the demo Moss index for the Agora custom-llm sample.
+
+Same 10 FAQs as apps/ten-moss/data/knowledge.jsonl so the bench is shared.
+
+Usage (from apps/agora-custom-llm-moss/):
+    cp server/.env.example server/.env
+    python create_index.py
+"""
+
+import asyncio
+import json
+import os
+import pathlib
+
+from dotenv import load_dotenv
+from moss import DocumentInfo, MossClient
+
+DATA = pathlib.Path(__file__).parent / "data" / "knowledge.jsonl"
+
+
+def load_documents() -> list[DocumentInfo]:
+    """Parse data/knowledge.jsonl into Moss documents."""
+    docs: list[DocumentInfo] = []
+    for line in DATA.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        row = json.loads(line)
+        docs.append(
+            DocumentInfo(id=row["id"], text=row["text"], metadata=row.get("metadata", {}))
+        )
+    return docs
+
+
+async def main() -> None:
+    load_dotenv(pathlib.Path(__file__).parent / "server" / ".env")
+    load_dotenv()
+    client = MossClient(os.environ["MOSS_PROJECT_ID"], os.environ["MOSS_PROJECT_KEY"])
+    index_name = os.environ["MOSS_INDEX_NAME"]
+    docs = load_documents()
+    print(f"Creating index '{index_name}' with {len(docs)} documents...")
+    await client.create_index(name=index_name, docs=docs, model_id="moss-minilm")
+    print("Done.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/apps/agora-custom-llm-moss/data/knowledge.jsonl
+++ b/apps/agora-custom-llm-moss/data/knowledge.jsonl
@@ -1,0 +1,10 @@
+{"id": "kb-1", "text": "Refunds are processed within 3-5 business days once the return is approved.", "metadata": {"category": "billing"}}
+{"id": "kb-2", "text": "You can track an order from the dashboard under Order History using its tracking number.", "metadata": {"category": "orders"}}
+{"id": "kb-3", "text": "Live chat support is available 24/7 from the Help menu in the app.", "metadata": {"category": "support"}}
+{"id": "kb-4", "text": "Standard shipping takes 3-5 business days; express shipping takes 1-2 business days.", "metadata": {"category": "shipping"}}
+{"id": "kb-5", "text": "Reset your password using the Forgot Password link on the login page.", "metadata": {"category": "account"}}
+{"id": "kb-6", "text": "We accept Visa, Mastercard, American Express, PayPal, and Apple Pay.", "metadata": {"category": "billing"}}
+{"id": "kb-7", "text": "Orders can be cancelled within 1 hour of placement, before they are dispatched.", "metadata": {"category": "orders"}}
+{"id": "kb-8", "text": "International shipping is available to most countries; rates and delivery times vary by destination.", "metadata": {"category": "shipping"}}
+{"id": "kb-9", "text": "Gift wrapping with a personalized message is available at checkout for a small fee.", "metadata": {"category": "services"}}
+{"id": "kb-10", "text": "We price-match identical items from authorized retailers within 14 days of purchase.", "metadata": {"category": "billing"}}

--- a/apps/agora-custom-llm-moss/pytest.ini
+++ b/apps/agora-custom-llm-moss/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/apps/agora-custom-llm-moss/pytest.ini
+++ b/apps/agora-custom-llm-moss/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
-asyncio_mode = auto
 testpaths = tests

--- a/apps/agora-custom-llm-moss/server/.env.example
+++ b/apps/agora-custom-llm-moss/server/.env.example
@@ -1,0 +1,24 @@
+# --- Moss (same index / corpus as apps/ten-moss) ---
+MOSS_PROJECT_ID=
+MOSS_PROJECT_KEY=
+MOSS_INDEX_NAME=ten-moss-demo
+MOSS_MODEL_ID=moss-minilm
+
+# ambient (default) or tool. server.py mounts both regardless:
+#   /llm        = ambient
+#   /llm-tools  = tool
+MOSS_MODE=ambient
+
+# --- This endpoint (what Agora cloud calls) ---
+CUSTOM_LLM_API_KEY=any-key-here
+CUSTOM_LLM_MODEL=moss-custom-llm
+CUSTOM_LLM_PORT=8001
+PORT=8000
+
+# --- Upstream chat model (not needed for --mock / --doctor) ---
+UPSTREAM_LLM_URL=https://api.openai.com/v1
+UPSTREAM_LLM_API_KEY=
+UPSTREAM_LLM_MODEL=gpt-4o-mini
+
+# Set MOCK=1 or pass --mock for the zero-key path.
+# MOCK=0

--- a/apps/agora-custom-llm-moss/server/.env.example
+++ b/apps/agora-custom-llm-moss/server/.env.example
@@ -10,7 +10,7 @@ MOSS_MODEL_ID=moss-minilm
 MOSS_MODE=ambient
 
 # --- This endpoint (what Agora cloud calls) ---
-CUSTOM_LLM_API_KEY=any-key-here
+CUSTOM_LLM_API_KEY=
 CUSTOM_LLM_MODEL=moss-custom-llm
 CUSTOM_LLM_PORT=8001
 PORT=8000

--- a/apps/agora-custom-llm-moss/server/.gitignore
+++ b/apps/agora-custom-llm-moss/server/.gitignore
@@ -1,0 +1,5 @@
+.env
+.env.local
+__pycache__/
+.venv/
+venv/

--- a/apps/agora-custom-llm-moss/server/requirements.txt
+++ b/apps/agora-custom-llm-moss/server/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.100.0
+uvicorn>=0.20.0
+python-dotenv>=1.0.0
+httpx>=0.27.0
+ten-moss>=0.1.0
+pydantic>=2.0.0

--- a/apps/agora-custom-llm-moss/server/src/llm.py
+++ b/apps/agora-custom-llm-moss/server/src/llm.py
@@ -1,18 +1,9 @@
-"""
-Custom LLM endpoint with Moss grounding.
+"""OpenAI-compatible /chat/completions with Moss.
 
 Forked from Agora's custom-llm recipe (MIT):
 https://github.com/AgoraIO-Conversational-AI/recipe-agent-custom-llm/blob/main/server/src/llm.py
 
-Agora cloud POSTs here. Two modes, same index:
-
-  ambient  last user text -> query_context -> prepend -> upstream LLM
-  tool     advertise search_knowledge_base to the upstream LLM;
-           run Moss here if the model calls it (cap 2);
-           stream only the final spoken answer.
-
-SSE contract: each line is `data: {json}`, end with `data: [DONE]`.
-Non-mock requests need `Authorization: Bearer`.
+SSE must end with `data: [DONE]`. Non-mock requests need Authorization: Bearer.
 """
 
 from __future__ import annotations
@@ -125,7 +116,6 @@ def as_dict(msg: Any) -> dict[str, Any]:
 
 
 async def query_moss(session, user_text: str) -> str:
-    """Fail-open: empty string if Moss is missing or errors."""
     if session is None:
         return ""
     try:
@@ -261,7 +251,7 @@ async def tool_answer(messages: list, session, mock: bool) -> str:
 
 
 async def call_upstream(messages: list, tools: list | None = None, raw: bool = False):
-    """Non-streaming upstream call. We only stream the final spoken answer to Agora."""
+    # Upstream is non-streaming; only the final answer is sent to Agora as SSE.
     import httpx
 
     payload = [as_dict(m) for m in messages]
@@ -295,8 +285,7 @@ def create_app(moss_mode: str = "ambient") -> FastAPI:
     state: dict[str, Any] = {"session": None, "ready": False}
 
     async def get_session():
-        # Open on first use so this works both standalone and mounted
-        # under server.py (FastAPI does not always run a mount's lifespan).
+        # FastAPI does not always run a mounted app's lifespan.
         if not state["ready"]:
             state["session"] = await open_moss()
             state["ready"] = True

--- a/apps/agora-custom-llm-moss/server/src/llm.py
+++ b/apps/agora-custom-llm-moss/server/src/llm.py
@@ -346,26 +346,40 @@ app = create_app(os.getenv("MOSS_MODE", "ambient"))
 def run_doctor() -> None:
     from fastapi.testclient import TestClient
 
-    os.environ["MOCK"] = "1"
-    payload = {
-        "model": "mock",
-        "stream": True,
-        "messages": [{"role": "user", "content": "How long do refunds take?"}],
-    }
-    for mode in ("ambient", "tool"):
-        with TestClient(create_app(mode)) as client:
-            ok = client.post("/chat/completions", json=payload)
-        if ok.status_code != 200 or "data: [DONE]" not in ok.text:
-            raise SystemExit(f"doctor {mode} failed: {ok.status_code} {ok.text}")
-        print(f"doctor {mode}: ok")
-    os.environ["MOCK"] = "0"
-    with TestClient(create_app("ambient")) as client:
-        denied = client.post("/chat/completions", json=payload)
-    if denied.status_code != 401:
-        raise SystemExit(f"doctor bearer: expected 401, got {denied.status_code}")
-    print("doctor bearer: rejected missing Authorization")
-    saved_key = os.environ.pop("CUSTOM_LLM_API_KEY", None)
+    # run_doctor runs in-process from the test suite, so snapshot every env var
+    # it flips and restore the originals on the way out (None means "was absent").
+    saved_mock = os.environ.get("MOCK")
+    saved_key = os.environ.get("CUSTOM_LLM_API_KEY")
+
+    def _restore(name: str, value: str | None) -> None:
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
+
     try:
+        os.environ["MOCK"] = "1"
+        payload = {
+            "model": "mock",
+            "stream": True,
+            "messages": [{"role": "user", "content": "How long do refunds take?"}],
+        }
+        for mode in ("ambient", "tool"):
+            with TestClient(create_app(mode)) as client:
+                ok = client.post("/chat/completions", json=payload)
+            if ok.status_code != 200 or "data: [DONE]" not in ok.text:
+                raise SystemExit(f"doctor {mode} failed: {ok.status_code} {ok.text}")
+            print(f"doctor {mode}: ok")
+        os.environ["MOCK"] = "0"
+        with TestClient(create_app("ambient")) as client:
+            denied = client.post("/chat/completions", json=payload)
+        if denied.status_code != 401:
+            raise SystemExit(f"doctor bearer: expected 401, got {denied.status_code}")
+        print("doctor bearer: rejected missing Authorization")
+        # Temporarily remove the key so the next request runs against an unset
+        # key; create_app reloads .env, so pop again after building the app. The
+        # outer finally owns the real restore.
+        os.environ.pop("CUSTOM_LLM_API_KEY", None)
         test_app = create_app("ambient")
         os.environ.pop("CUSTOM_LLM_API_KEY", None)
         with TestClient(test_app) as client:
@@ -378,13 +392,11 @@ def run_doctor() -> None:
             raise SystemExit(
                 f"doctor bearer: unset key should reject any token, got {any_token.status_code}"
             )
+        print("doctor bearer: rejected any token while CUSTOM_LLM_API_KEY is unset")
+        print("doctor: ok")
     finally:
-        if saved_key is None:
-            os.environ.pop("CUSTOM_LLM_API_KEY", None)
-        else:
-            os.environ["CUSTOM_LLM_API_KEY"] = saved_key
-    print("doctor bearer: rejected any token while CUSTOM_LLM_API_KEY is unset")
-    print("doctor: ok")
+        _restore("MOCK", saved_mock)
+        _restore("CUSTOM_LLM_API_KEY", saved_key)
 
 
 if __name__ == "__main__":

--- a/apps/agora-custom-llm-moss/server/src/llm.py
+++ b/apps/agora-custom-llm-moss/server/src/llm.py
@@ -366,7 +366,9 @@ def run_doctor() -> None:
     print("doctor bearer: rejected missing Authorization")
     saved_key = os.environ.pop("CUSTOM_LLM_API_KEY", None)
     try:
-        with TestClient(create_app("ambient")) as client:
+        test_app = create_app("ambient")
+        os.environ.pop("CUSTOM_LLM_API_KEY", None)
+        with TestClient(test_app) as client:
             any_token = client.post(
                 "/chat/completions",
                 json=payload,
@@ -377,7 +379,9 @@ def run_doctor() -> None:
                 f"doctor bearer: unset key should reject any token, got {any_token.status_code}"
             )
     finally:
-        if saved_key is not None:
+        if saved_key is None:
+            os.environ.pop("CUSTOM_LLM_API_KEY", None)
+        else:
             os.environ["CUSTOM_LLM_API_KEY"] = saved_key
     print("doctor bearer: rejected any token while CUSTOM_LLM_API_KEY is unset")
     print("doctor: ok")

--- a/apps/agora-custom-llm-moss/server/src/llm.py
+++ b/apps/agora-custom-llm-moss/server/src/llm.py
@@ -9,6 +9,7 @@ SSE must end with `data: [DONE]`. Non-mock requests need Authorization: Bearer.
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
 import logging
 import os
@@ -170,8 +171,20 @@ def require_bearer(authorization: Optional[str], mock: bool) -> None:
         raise HTTPException(status_code=401, detail="Authorization: Bearer required")
     token = authorization.split(" ", 1)[1].strip()
     expected = os.getenv("CUSTOM_LLM_API_KEY", "").strip()
-    if expected and token != expected:
+    if not expected:
+        raise HTTPException(status_code=401, detail="CUSTOM_LLM_API_KEY is not set")
+    if token != expected:
         raise HTTPException(status_code=401, detail="invalid bearer token")
+
+
+def search_query(raw_args, fallback: str) -> str:
+    try:
+        args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+    except json.JSONDecodeError:
+        args = {}
+    if not isinstance(args, dict):
+        args = {}
+    return str(args.get("query") or fallback or "")
 
 
 def sse_chunk(chunk_id: str, model: str, delta: dict, finish_reason=None) -> str:
@@ -231,11 +244,7 @@ async def tool_answer(messages: list, session, mock: bool) -> str:
         for call in tool_calls:
             fn = call.get("function") or {}
             raw_args = fn.get("arguments") or "{}"
-            try:
-                args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
-            except json.JSONDecodeError:
-                args = {"query": raw_args}
-            query = str((args or {}).get("query") or last_user_text(messages))
+            query = search_query(raw_args, last_user_text(messages))
             context = ""
             if fn.get("name") == SEARCH_KNOWLEDGE_BASE and moss_calls < MAX_MOSS_TOOL_CALLS:
                 context = await query_moss(session, query)
@@ -283,12 +292,15 @@ def create_app(moss_mode: str = "ambient") -> FastAPI:
     mode = moss_mode if moss_mode in {"ambient", "tool"} else "ambient"
     mock = os.getenv("MOCK", "").strip().lower() in {"1", "true", "yes", "on"}
     state: dict[str, Any] = {"session": None, "ready": False}
+    init_lock = asyncio.Lock()
 
     async def get_session():
         # FastAPI does not always run a mounted app's lifespan.
         if not state["ready"]:
-            state["session"] = await open_moss()
-            state["ready"] = True
+            async with init_lock:
+                if not state["ready"]:
+                    state["session"] = await open_moss()
+                    state["ready"] = True
         return state["session"]
 
     @asynccontextmanager
@@ -300,7 +312,7 @@ def create_app(moss_mode: str = "ambient") -> FastAPI:
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],
-        allow_credentials=True,
+        allow_credentials=False,
         allow_methods=["*"],
         allow_headers=["*"],
     )
@@ -352,6 +364,22 @@ def run_doctor() -> None:
     if denied.status_code != 401:
         raise SystemExit(f"doctor bearer: expected 401, got {denied.status_code}")
     print("doctor bearer: rejected missing Authorization")
+    saved_key = os.environ.pop("CUSTOM_LLM_API_KEY", None)
+    try:
+        with TestClient(create_app("ambient")) as client:
+            any_token = client.post(
+                "/chat/completions",
+                json=payload,
+                headers={"Authorization": "Bearer anything"},
+            )
+        if any_token.status_code != 401:
+            raise SystemExit(
+                f"doctor bearer: unset key should reject any token, got {any_token.status_code}"
+            )
+    finally:
+        if saved_key is not None:
+            os.environ["CUSTOM_LLM_API_KEY"] = saved_key
+    print("doctor bearer: rejected any token while CUSTOM_LLM_API_KEY is unset")
     print("doctor: ok")
 
 

--- a/apps/agora-custom-llm-moss/server/src/llm.py
+++ b/apps/agora-custom-llm-moss/server/src/llm.py
@@ -26,8 +26,10 @@ import os
 import time
 import uuid
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+from dotenv import load_dotenv
 from fastapi import FastAPI, Header, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
@@ -113,6 +115,13 @@ class ChatCompletionRequest(BaseModel):
 # ---------------------------------------------------------------------------
 # Small helpers
 # ---------------------------------------------------------------------------
+
+
+def load_server_env(server_dir: Path | None = None) -> None:
+    """Load server/.env then server/.env.local so a filled .env.example is enough."""
+    root = server_dir or Path(__file__).resolve().parent.parent
+    load_dotenv(root / ".env")
+    load_dotenv(root / ".env.local", override=True)
 
 
 def env_flag(name: str) -> bool:
@@ -380,6 +389,7 @@ async def call_upstream_raw(
 
 
 def create_app(moss_mode: str = "ambient") -> FastAPI:
+    load_server_env()
     mode = (moss_mode or "ambient").strip().lower()
     if mode not in {"ambient", "tool"}:
         mode = "ambient"

--- a/apps/agora-custom-llm-moss/server/src/llm.py
+++ b/apps/agora-custom-llm-moss/server/src/llm.py
@@ -4,17 +4,15 @@ Custom LLM endpoint with Moss grounding.
 Forked from Agora's custom-llm recipe (MIT):
 https://github.com/AgoraIO-Conversational-AI/recipe-agent-custom-llm/blob/main/server/src/llm.py
 
-Agora cloud POSTs here. This file is the whole Moss story:
+Agora cloud POSTs here. Two modes, same index:
 
-  ambient (default)  last user text -> query_context -> prepend -> upstream LLM
-  tool               advertise search_knowledge_base to the upstream LLM;
-                     run Moss in-process if the model calls it (cap 2);
-                     stream only the final spoken answer.
+  ambient  last user text -> query_context -> prepend -> upstream LLM
+  tool     advertise search_knowledge_base to the upstream LLM;
+           run Moss here if the model calls it (cap 2);
+           stream only the final spoken answer.
 
-Contract:
-- POST /chat/completions
-- OpenAI SSE: each line is `data: {json}`, end with `data: [DONE]`
-- Non-mock requests must send `Authorization: Bearer ...`
+SSE contract: each line is `data: {json}`, end with `data: [DONE]`.
+Non-mock requests need `Authorization: Bearer`.
 """
 
 from __future__ import annotations
@@ -40,37 +38,21 @@ logger = logging.getLogger(__name__)
 
 SEARCH_KNOWLEDGE_BASE = "search_knowledge_base"
 MAX_MOSS_TOOL_CALLS = 2
-
+MOCK_FALLBACK = (
+    "I'm a custom LLM with Moss on this server. Ask about refunds, shipping, or passwords."
+)
 SEARCH_TOOL = {
     "type": "function",
     "function": {
         "name": SEARCH_KNOWLEDGE_BASE,
-        "description": (
-            "Search the knowledge base for facts that answer the user's question. "
-            "Pass a focused natural-language query."
-        ),
+        "description": "Search the knowledge base. Pass a focused natural-language query.",
         "parameters": {
             "type": "object",
-            "properties": {
-                "query": {
-                    "type": "string",
-                    "description": "The user's question or a focused search query.",
-                }
-            },
+            "properties": {"query": {"type": "string"}},
             "required": ["query"],
         },
     },
 }
-
-MOCK_RESPONSES = [
-    "I'm a custom LLM with Moss on this server. Ask about refunds, shipping, or passwords.",
-    "This is the zero-key mock path. Replace me with UPSTREAM_LLM_* for a real model.",
-]
-
-
-# ---------------------------------------------------------------------------
-# Request models (Agora ConvoAI / OpenAI chat completions)
-# ---------------------------------------------------------------------------
 
 
 class TextContent(BaseModel):
@@ -112,29 +94,18 @@ class ChatCompletionRequest(BaseModel):
     response_format: Optional[Dict] = None
 
 
-# ---------------------------------------------------------------------------
-# Small helpers
-# ---------------------------------------------------------------------------
-
-
 def load_server_env(server_dir: Path | None = None) -> None:
-    """Load server/.env then server/.env.local so a filled .env.example is enough."""
     root = server_dir or Path(__file__).resolve().parent.parent
     load_dotenv(root / ".env")
     load_dotenv(root / ".env.local", override=True)
 
 
-def env_flag(name: str) -> bool:
-    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
-
-
 def last_user_text(messages: list) -> str:
-    """Extract the latest user utterance. Do not log it (transcripts can be PII)."""
     for msg in reversed(messages):
         role = getattr(msg, "role", None) or (msg.get("role") if isinstance(msg, dict) else None)
         if role != "user":
             continue
-        content = getattr(msg, "content", None) if not isinstance(msg, dict) else msg.get("content")
+        content = msg.get("content") if isinstance(msg, dict) else getattr(msg, "content", None)
         if isinstance(content, str):
             return content
         if isinstance(content, list) and content:
@@ -145,7 +116,7 @@ def last_user_text(messages: list) -> str:
     return ""
 
 
-def message_as_dict(msg: Any) -> dict[str, Any]:
+def as_dict(msg: Any) -> dict[str, Any]:
     if isinstance(msg, dict):
         return dict(msg)
     if hasattr(msg, "model_dump"):
@@ -153,45 +124,38 @@ def message_as_dict(msg: Any) -> dict[str, Any]:
     return {"role": getattr(msg, "role", "user"), "content": getattr(msg, "content", "")}
 
 
-class MossHandle:
-    """Thin wrapper: query_context + last_time_taken_ms. Fail-open."""
-
-    def __init__(self, session: Any | None):
-        self.session = session
-
-    async def query_context(self, user_text: str) -> str:
-        if self.session is None:
-            return ""
-        try:
-            t0 = time.perf_counter()
-            context = await self.session.query_context(user_text)
-            wall_ms = (time.perf_counter() - t0) * 1000.0
-            sdk_ms = getattr(self.session, "last_time_taken_ms", None)
-            logger.info(
-                "[retrieval-latency] backend=moss(in-process) "
-                "time_taken_ms=%s (wall_clock=%.0fms)",
-                sdk_ms,
-                wall_ms,
-            )
-            return context or ""
-        except Exception as exc:  # noqa: BLE001 - voice/SSE loop must continue
-            logger.error("Moss query failed (%s): %s", type(exc).__name__, exc)
-            return ""
+async def query_moss(session, user_text: str) -> str:
+    """Fail-open: empty string if Moss is missing or errors."""
+    if session is None:
+        return ""
+    try:
+        t0 = time.perf_counter()
+        context = await session.query_context(user_text)
+        wall_ms = (time.perf_counter() - t0) * 1000.0
+        sdk_ms = getattr(session, "last_time_taken_ms", None)
+        logger.info(
+            "[retrieval-latency] backend=moss(in-process) time_taken_ms=%s (wall_clock=%.0fms)",
+            sdk_ms,
+            wall_ms,
+        )
+        return context or ""
+    except Exception as exc:
+        logger.error("Moss query failed (%s): %s", type(exc).__name__, exc)
+        return ""
 
 
-async def open_moss() -> MossHandle:
-    """Best-effort session. Missing creds / import / open => empty handle."""
+async def open_moss():
     project_id = os.getenv("MOSS_PROJECT_ID", "").strip()
     project_key = os.getenv("MOSS_PROJECT_KEY", "").strip()
     index_name = os.getenv("MOSS_INDEX_NAME", "").strip()
     if not (project_id and project_key and index_name):
         logger.info("Moss disabled (set MOSS_PROJECT_ID / MOSS_PROJECT_KEY / MOSS_INDEX_NAME)")
-        return MossHandle(None)
+        return None
     try:
         from ten_moss import MossSessionManager
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.error("ten-moss import failed: %s", exc)
-        return MossHandle(None)
+        return None
     session = MossSessionManager(
         project_id=project_id,
         project_key=project_key,
@@ -202,11 +166,11 @@ async def open_moss() -> MossHandle:
     )
     try:
         await session.open()
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.error("Moss session failed to open: %s", exc)
-        return MossHandle(None)
+        return None
     logger.info("Moss session opened on index %s", index_name)
-    return MossHandle(session)
+    return session
 
 
 def require_bearer(authorization: Optional[str], mock: bool) -> None:
@@ -220,112 +184,62 @@ def require_bearer(authorization: Optional[str], mock: bool) -> None:
         raise HTTPException(status_code=401, detail="invalid bearer token")
 
 
-def make_chunk(chunk_id: str, model: str, content: str, finish_reason=None) -> str:
-    chunk = {
+def sse_chunk(chunk_id: str, model: str, delta: dict, finish_reason=None) -> str:
+    body = {
         "id": chunk_id,
         "object": "chat.completion.chunk",
         "created": int(time.time()),
         "model": model or "moss-custom-llm",
-        "choices": [
-            {
-                "index": 0,
-                "delta": {"content": content} if content else {},
-                "finish_reason": finish_reason,
-            }
-        ],
+        "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
     }
-    return f"data: {json.dumps(chunk)}\n\n"
-
-
-def make_role_chunk(chunk_id: str, model: str) -> str:
-    chunk = {
-        "id": chunk_id,
-        "object": "chat.completion.chunk",
-        "created": int(time.time()),
-        "model": model or "moss-custom-llm",
-        "choices": [
-            {
-                "index": 0,
-                "delta": {"role": "assistant", "content": ""},
-                "finish_reason": None,
-            }
-        ],
-    }
-    return f"data: {json.dumps(chunk)}\n\n"
+    return f"data: {json.dumps(body)}\n\n"
 
 
 async def stream_answer(text: str, model: str):
     chunk_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
-    yield make_role_chunk(chunk_id, model)
+    yield sse_chunk(chunk_id, model, {"role": "assistant", "content": ""})
     words = (text or "").split(" ")
     for i, word in enumerate(words):
         token = word if i == 0 else f" {word}"
         if token:
-            yield make_chunk(chunk_id, model, token)
-    yield make_chunk(chunk_id, model, "", finish_reason="stop")
+            yield sse_chunk(chunk_id, model, {"content": token})
+    yield sse_chunk(chunk_id, model, {}, finish_reason="stop")
     yield "data: [DONE]\n\n"
 
 
-# ---------------------------------------------------------------------------
-# Ambient: search, then answer
-# ---------------------------------------------------------------------------
-
-
-async def ambient_answer(messages: list, moss: MossHandle, mock: bool) -> str:
-    user_text = last_user_text(messages)
-    context = await moss.query_context(user_text)
+async def ambient_answer(messages: list, session, mock: bool) -> str:
+    context = await query_moss(session, last_user_text(messages))
     if mock:
-        return context or MOCK_RESPONSES[0]
+        return context or MOCK_FALLBACK
     grounded = list(messages)
     if context:
         grounded = [
             SystemMessage(role="system", content=f"Relevant knowledge from Moss:\n{context}"),
             *messages,
         ]
-    return await call_upstream(grounded, tools=None)
+    return await call_upstream(grounded)
 
 
-# ---------------------------------------------------------------------------
-# Tool: LLM decides, Agora never sees the tool
-# ---------------------------------------------------------------------------
-
-
-async def tool_answer(messages: list, moss: MossHandle, mock: bool) -> str:
+async def tool_answer(messages: list, session, mock: bool) -> str:
     if mock:
-        user_text = last_user_text(messages)
-        context = await moss.query_context(user_text)
-        logger.info("[retrieval-latency] tool_called=true (echo-grounding stub)")
-        return context or MOCK_RESPONSES[0]
+        context = await query_moss(session, last_user_text(messages))
+        logger.info("[retrieval-latency] tool_called=true (mock stub)")
+        return context or MOCK_FALLBACK
 
-    history = [message_as_dict(m) for m in messages]
+    history = [as_dict(m) for m in messages]
     moss_calls = 0
     for _ in range(MAX_MOSS_TOOL_CALLS + 1):
-        data = await call_upstream_raw(
-            history,
-            tools=[SEARCH_TOOL],
-            tool_choice="auto",
-        )
-        choice = (data.get("choices") or [{}])[0]
-        message = choice.get("message") or {}
+        data = await call_upstream(history, tools=[SEARCH_TOOL], raw=True)
+        message = ((data.get("choices") or [{}])[0].get("message")) or {}
         tool_calls = message.get("tool_calls") or []
         if not tool_calls:
             if moss_calls == 0:
                 logger.info("[retrieval-latency] tool_called=false (LLM declined to search)")
-            return (message.get("content") or "").strip() or MOCK_RESPONSES[0]
+            return (message.get("content") or "").strip() or MOCK_FALLBACK
 
         history.append(message)
         for call in tool_calls:
-            if moss_calls >= MAX_MOSS_TOOL_CALLS:
-                history.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": call.get("id") or "call_cap",
-                        "content": "",
-                    }
-                )
-                continue
             fn = call.get("function") or {}
-            name = fn.get("name") or ""
             raw_args = fn.get("arguments") or "{}"
             try:
                 args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
@@ -333,8 +247,8 @@ async def tool_answer(messages: list, moss: MossHandle, mock: bool) -> str:
                 args = {"query": raw_args}
             query = str((args or {}).get("query") or last_user_text(messages))
             context = ""
-            if name == SEARCH_KNOWLEDGE_BASE:
-                context = await moss.query_context(query)
+            if fn.get("name") == SEARCH_KNOWLEDGE_BASE and moss_calls < MAX_MOSS_TOOL_CALLS:
+                context = await query_moss(session, query)
                 moss_calls += 1
             history.append(
                 {
@@ -346,22 +260,11 @@ async def tool_answer(messages: list, moss: MossHandle, mock: bool) -> str:
     return "I looked that up but I am not sure. Please try again."
 
 
-async def call_upstream(messages: list, tools: list | None) -> str:
-    payload_messages = [message_as_dict(m) for m in messages]
-    data = await call_upstream_raw(payload_messages, tools=tools, tool_choice=None)
-    choice = (data.get("choices") or [{}])[0]
-    return ((choice.get("message") or {}).get("content") or "").strip() or MOCK_RESPONSES[0]
-
-
-async def call_upstream_raw(
-    messages: list[dict[str, Any]],
-    *,
-    tools: list | None,
-    tool_choice: str | None,
-) -> dict[str, Any]:
-    """Non-streaming upstream call. We stream only the final spoken answer."""
+async def call_upstream(messages: list, tools: list | None = None, raw: bool = False):
+    """Non-streaming upstream call. We only stream the final spoken answer to Agora."""
     import httpx
 
+    payload = [as_dict(m) for m in messages]
     base = os.getenv("UPSTREAM_LLM_URL", "https://api.openai.com/v1").rstrip("/")
     url = base if base.endswith("/chat/completions") else f"{base}/chat/completions"
     api_key = os.getenv("UPSTREAM_LLM_API_KEY") or os.getenv("OPENAI_API_KEY") or ""
@@ -369,44 +272,34 @@ async def call_upstream_raw(
         raise HTTPException(status_code=503, detail="UPSTREAM_LLM_API_KEY is not set")
     body: dict[str, Any] = {
         "model": os.getenv("UPSTREAM_LLM_MODEL", "gpt-4o-mini"),
-        "messages": messages,
+        "messages": payload,
         "stream": False,
     }
     if tools:
         body["tools"] = tools
-    if tool_choice:
-        body["tool_choice"] = tool_choice
+        body["tool_choice"] = "auto"
     headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
     async with httpx.AsyncClient(timeout=30.0) as client:
         response = await client.post(url, headers=headers, json=body)
         response.raise_for_status()
-        return response.json()
-
-
-# ---------------------------------------------------------------------------
-# App factory (ambient default; tool is the second entrypoint)
-# ---------------------------------------------------------------------------
+        data = response.json()
+    if raw:
+        return data
+    return ((data.get("choices") or [{}])[0].get("message") or {}).get("content") or MOCK_FALLBACK
 
 
 def create_app(moss_mode: str = "ambient") -> FastAPI:
     load_server_env()
-    mode = (moss_mode or "ambient").strip().lower()
-    if mode not in {"ambient", "tool"}:
-        mode = "ambient"
-    mock = env_flag("MOCK")
-    state: dict[str, MossHandle | None] = {"moss": None}
+    mode = moss_mode if moss_mode in {"ambient", "tool"} else "ambient"
+    mock = os.getenv("MOCK", "").strip().lower() in {"1", "true", "yes", "on"}
+    state: dict[str, Any] = {"session": None}
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
-        state["moss"] = await open_moss()
+        state["session"] = await open_moss()
         yield
 
-    app = FastAPI(
-        title=f"Moss custom-llm ({mode})",
-        description="OpenAI-compatible Chat Completions for Agora Conversational AI.",
-        version="1.0.0",
-        lifespan=lifespan,
-    )
+    app = FastAPI(title=f"Moss custom-llm ({mode})", version="1.0.0", lifespan=lifespan)
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],
@@ -422,15 +315,12 @@ def create_app(moss_mode: str = "ambient") -> FastAPI:
     ):
         require_bearer(authorization, mock=mock)
         if not request.stream:
-            raise HTTPException(
-                status_code=400,
-                detail="Only streaming mode is supported. Set stream=true.",
-            )
-        moss = state["moss"] or MossHandle(None)
+            raise HTTPException(status_code=400, detail="Only streaming mode is supported. Set stream=true.")
+        session = state["session"]
         if mode == "tool":
-            text = await tool_answer(request.messages, moss, mock=mock)
+            text = await tool_answer(request.messages, session, mock=mock)
         else:
-            text = await ambient_answer(request.messages, moss, mock=mock)
+            text = await ambient_answer(request.messages, session, mock=mock)
         model = request.model or os.getenv("CUSTOM_LLM_MODEL", "moss-custom-llm")
         return StreamingResponse(stream_answer(text, model), media_type="text/event-stream")
 
@@ -441,12 +331,10 @@ def create_app(moss_mode: str = "ambient") -> FastAPI:
     return app
 
 
-# Standalone default: MOSS_MODE env (ambient unless set to tool).
 app = create_app(os.getenv("MOSS_MODE", "ambient"))
 
 
 def run_doctor() -> None:
-    """Zero-key smoke: mock ambient + tool, no network, no LLM keys."""
     from fastapi.testclient import TestClient
 
     os.environ["MOCK"] = "1"
@@ -458,10 +346,8 @@ def run_doctor() -> None:
     for mode in ("ambient", "tool"):
         with TestClient(create_app(mode)) as client:
             ok = client.post("/chat/completions", json=payload)
-        if ok.status_code != 200:
-            raise SystemExit(f"doctor {mode} HTTP {ok.status_code}: {ok.text}")
-        if "data: [DONE]" not in ok.text:
-            raise SystemExit(f"doctor {mode}: SSE missing data: [DONE]")
+        if ok.status_code != 200 or "data: [DONE]" not in ok.text:
+            raise SystemExit(f"doctor {mode} failed: {ok.status_code} {ok.text}")
         print(f"doctor {mode}: ok")
     os.environ["MOCK"] = "0"
     with TestClient(create_app("ambient")) as client:
@@ -474,8 +360,8 @@ def run_doctor() -> None:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Moss custom-llm server")
-    parser.add_argument("--mock", action="store_true", help="Zero-key mock answers (no upstream LLM)")
-    parser.add_argument("--doctor", action="store_true", help="In-process smoke, then exit")
+    parser.add_argument("--mock", action="store_true")
+    parser.add_argument("--doctor", action="store_true")
     parser.add_argument("--mode", default=os.getenv("MOSS_MODE", "ambient"), choices=["ambient", "tool"])
     args = parser.parse_args()
     if args.mock:

--- a/apps/agora-custom-llm-moss/server/src/llm.py
+++ b/apps/agora-custom-llm-moss/server/src/llm.py
@@ -1,0 +1,480 @@
+"""
+Custom LLM endpoint with Moss grounding.
+
+Forked from Agora's custom-llm recipe (MIT):
+https://github.com/AgoraIO-Conversational-AI/recipe-agent-custom-llm/blob/main/server/src/llm.py
+
+Agora cloud POSTs here. This file is the whole Moss story:
+
+  ambient (default)  last user text -> query_context -> prepend -> upstream LLM
+  tool               advertise search_knowledge_base to the upstream LLM;
+                     run Moss in-process if the model calls it (cap 2);
+                     stream only the final spoken answer.
+
+Contract:
+- POST /chat/completions
+- OpenAI SSE: each line is `data: {json}`, end with `data: [DONE]`
+- Non-mock requests must send `Authorization: Bearer ...`
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import time
+import uuid
+from contextlib import asynccontextmanager
+from typing import Any, Dict, List, Optional, Union
+
+from fastapi import FastAPI, Header, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+SEARCH_KNOWLEDGE_BASE = "search_knowledge_base"
+MAX_MOSS_TOOL_CALLS = 2
+
+SEARCH_TOOL = {
+    "type": "function",
+    "function": {
+        "name": SEARCH_KNOWLEDGE_BASE,
+        "description": (
+            "Search the knowledge base for facts that answer the user's question. "
+            "Pass a focused natural-language query."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The user's question or a focused search query.",
+                }
+            },
+            "required": ["query"],
+        },
+    },
+}
+
+MOCK_RESPONSES = [
+    "I'm a custom LLM with Moss on this server. Ask about refunds, shipping, or passwords.",
+    "This is the zero-key mock path. Replace me with UPSTREAM_LLM_* for a real model.",
+]
+
+
+# ---------------------------------------------------------------------------
+# Request models (Agora ConvoAI / OpenAI chat completions)
+# ---------------------------------------------------------------------------
+
+
+class TextContent(BaseModel):
+    type: str = "text"
+    text: str
+
+
+class SystemMessage(BaseModel):
+    role: str = "system"
+    content: Union[str, List[str]]
+
+
+class UserMessage(BaseModel):
+    role: str = "user"
+    content: Union[str, List[Union[TextContent, Dict]]]
+
+
+class AssistantMessage(BaseModel):
+    role: str = "assistant"
+    content: Union[str, List[TextContent], None] = None
+    tool_calls: Optional[List[Dict]] = None
+
+
+class ToolMessage(BaseModel):
+    role: str = "tool"
+    content: Union[str, List[str]]
+    tool_call_id: str
+
+
+class ChatCompletionRequest(BaseModel):
+    model: Optional[str] = None
+    messages: List[Union[SystemMessage, UserMessage, AssistantMessage, ToolMessage]]
+    stream: bool = True
+    stream_options: Optional[Dict] = None
+    temperature: Optional[float] = None
+    max_tokens: Optional[int] = None
+    tools: Optional[List[Dict]] = None
+    tool_choice: Optional[Union[str, Dict]] = None
+    response_format: Optional[Dict] = None
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def env_flag(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def last_user_text(messages: list) -> str:
+    """Extract the latest user utterance. Do not log it (transcripts can be PII)."""
+    for msg in reversed(messages):
+        role = getattr(msg, "role", None) or (msg.get("role") if isinstance(msg, dict) else None)
+        if role != "user":
+            continue
+        content = getattr(msg, "content", None) if not isinstance(msg, dict) else msg.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list) and content:
+            first = content[0]
+            if isinstance(first, dict):
+                return str(first.get("text") or "")
+            return str(getattr(first, "text", "") or "")
+    return ""
+
+
+def message_as_dict(msg: Any) -> dict[str, Any]:
+    if isinstance(msg, dict):
+        return dict(msg)
+    if hasattr(msg, "model_dump"):
+        return msg.model_dump(exclude_none=True)
+    return {"role": getattr(msg, "role", "user"), "content": getattr(msg, "content", "")}
+
+
+class MossHandle:
+    """Thin wrapper: query_context + last_time_taken_ms. Fail-open."""
+
+    def __init__(self, session: Any | None):
+        self.session = session
+
+    async def query_context(self, user_text: str) -> str:
+        if self.session is None:
+            return ""
+        try:
+            t0 = time.perf_counter()
+            context = await self.session.query_context(user_text)
+            wall_ms = (time.perf_counter() - t0) * 1000.0
+            sdk_ms = getattr(self.session, "last_time_taken_ms", None)
+            logger.info(
+                "[retrieval-latency] backend=moss(in-process) "
+                "time_taken_ms=%s (wall_clock=%.0fms)",
+                sdk_ms,
+                wall_ms,
+            )
+            return context or ""
+        except Exception as exc:  # noqa: BLE001 - voice/SSE loop must continue
+            logger.error("Moss query failed (%s): %s", type(exc).__name__, exc)
+            return ""
+
+
+async def open_moss() -> MossHandle:
+    """Best-effort session. Missing creds / import / open => empty handle."""
+    project_id = os.getenv("MOSS_PROJECT_ID", "").strip()
+    project_key = os.getenv("MOSS_PROJECT_KEY", "").strip()
+    index_name = os.getenv("MOSS_INDEX_NAME", "").strip()
+    if not (project_id and project_key and index_name):
+        logger.info("Moss disabled (set MOSS_PROJECT_ID / MOSS_PROJECT_KEY / MOSS_INDEX_NAME)")
+        return MossHandle(None)
+    try:
+        from ten_moss import MossSessionManager
+    except Exception as exc:  # noqa: BLE001
+        logger.error("ten-moss import failed: %s", exc)
+        return MossHandle(None)
+    session = MossSessionManager(
+        project_id=project_id,
+        project_key=project_key,
+        index_name=index_name,
+        model_id=os.getenv("MOSS_MODEL_ID", "moss-minilm"),
+        top_k=int(os.getenv("MOSS_TOP_K", "3")),
+        alpha=float(os.getenv("MOSS_ALPHA", "0.8")),
+    )
+    try:
+        await session.open()
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Moss session failed to open: %s", exc)
+        return MossHandle(None)
+    logger.info("Moss session opened on index %s", index_name)
+    return MossHandle(session)
+
+
+def require_bearer(authorization: Optional[str], mock: bool) -> None:
+    if mock:
+        return
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise HTTPException(status_code=401, detail="Authorization: Bearer required")
+    token = authorization.split(" ", 1)[1].strip()
+    expected = os.getenv("CUSTOM_LLM_API_KEY", "").strip()
+    if expected and token != expected:
+        raise HTTPException(status_code=401, detail="invalid bearer token")
+
+
+def make_chunk(chunk_id: str, model: str, content: str, finish_reason=None) -> str:
+    chunk = {
+        "id": chunk_id,
+        "object": "chat.completion.chunk",
+        "created": int(time.time()),
+        "model": model or "moss-custom-llm",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"content": content} if content else {},
+                "finish_reason": finish_reason,
+            }
+        ],
+    }
+    return f"data: {json.dumps(chunk)}\n\n"
+
+
+def make_role_chunk(chunk_id: str, model: str) -> str:
+    chunk = {
+        "id": chunk_id,
+        "object": "chat.completion.chunk",
+        "created": int(time.time()),
+        "model": model or "moss-custom-llm",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"role": "assistant", "content": ""},
+                "finish_reason": None,
+            }
+        ],
+    }
+    return f"data: {json.dumps(chunk)}\n\n"
+
+
+async def stream_answer(text: str, model: str):
+    chunk_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
+    yield make_role_chunk(chunk_id, model)
+    words = (text or "").split(" ")
+    for i, word in enumerate(words):
+        token = word if i == 0 else f" {word}"
+        if token:
+            yield make_chunk(chunk_id, model, token)
+    yield make_chunk(chunk_id, model, "", finish_reason="stop")
+    yield "data: [DONE]\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Ambient: search, then answer
+# ---------------------------------------------------------------------------
+
+
+async def ambient_answer(messages: list, moss: MossHandle, mock: bool) -> str:
+    user_text = last_user_text(messages)
+    context = await moss.query_context(user_text)
+    if mock:
+        return context or MOCK_RESPONSES[0]
+    grounded = list(messages)
+    if context:
+        grounded = [
+            SystemMessage(role="system", content=f"Relevant knowledge from Moss:\n{context}"),
+            *messages,
+        ]
+    return await call_upstream(grounded, tools=None)
+
+
+# ---------------------------------------------------------------------------
+# Tool: LLM decides, Agora never sees the tool
+# ---------------------------------------------------------------------------
+
+
+async def tool_answer(messages: list, moss: MossHandle, mock: bool) -> str:
+    if mock:
+        user_text = last_user_text(messages)
+        context = await moss.query_context(user_text)
+        logger.info("[retrieval-latency] tool_called=true (echo-grounding stub)")
+        return context or MOCK_RESPONSES[0]
+
+    history = [message_as_dict(m) for m in messages]
+    moss_calls = 0
+    for _ in range(MAX_MOSS_TOOL_CALLS + 1):
+        data = await call_upstream_raw(
+            history,
+            tools=[SEARCH_TOOL],
+            tool_choice="auto",
+        )
+        choice = (data.get("choices") or [{}])[0]
+        message = choice.get("message") or {}
+        tool_calls = message.get("tool_calls") or []
+        if not tool_calls:
+            if moss_calls == 0:
+                logger.info("[retrieval-latency] tool_called=false (LLM declined to search)")
+            return (message.get("content") or "").strip() or MOCK_RESPONSES[0]
+
+        history.append(message)
+        for call in tool_calls:
+            if moss_calls >= MAX_MOSS_TOOL_CALLS:
+                history.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": call.get("id") or "call_cap",
+                        "content": "",
+                    }
+                )
+                continue
+            fn = call.get("function") or {}
+            name = fn.get("name") or ""
+            raw_args = fn.get("arguments") or "{}"
+            try:
+                args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+            except json.JSONDecodeError:
+                args = {"query": raw_args}
+            query = str((args or {}).get("query") or last_user_text(messages))
+            context = ""
+            if name == SEARCH_KNOWLEDGE_BASE:
+                context = await moss.query_context(query)
+                moss_calls += 1
+            history.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.get("id") or f"call_{moss_calls}",
+                    "content": context,
+                }
+            )
+    return "I looked that up but I am not sure. Please try again."
+
+
+async def call_upstream(messages: list, tools: list | None) -> str:
+    payload_messages = [message_as_dict(m) for m in messages]
+    data = await call_upstream_raw(payload_messages, tools=tools, tool_choice=None)
+    choice = (data.get("choices") or [{}])[0]
+    return ((choice.get("message") or {}).get("content") or "").strip() or MOCK_RESPONSES[0]
+
+
+async def call_upstream_raw(
+    messages: list[dict[str, Any]],
+    *,
+    tools: list | None,
+    tool_choice: str | None,
+) -> dict[str, Any]:
+    """Non-streaming upstream call. We stream only the final spoken answer."""
+    import httpx
+
+    base = os.getenv("UPSTREAM_LLM_URL", "https://api.openai.com/v1").rstrip("/")
+    url = base if base.endswith("/chat/completions") else f"{base}/chat/completions"
+    api_key = os.getenv("UPSTREAM_LLM_API_KEY") or os.getenv("OPENAI_API_KEY") or ""
+    if not api_key:
+        raise HTTPException(status_code=503, detail="UPSTREAM_LLM_API_KEY is not set")
+    body: dict[str, Any] = {
+        "model": os.getenv("UPSTREAM_LLM_MODEL", "gpt-4o-mini"),
+        "messages": messages,
+        "stream": False,
+    }
+    if tools:
+        body["tools"] = tools
+    if tool_choice:
+        body["tool_choice"] = tool_choice
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(url, headers=headers, json=body)
+        response.raise_for_status()
+        return response.json()
+
+
+# ---------------------------------------------------------------------------
+# App factory (ambient default; tool is the second entrypoint)
+# ---------------------------------------------------------------------------
+
+
+def create_app(moss_mode: str = "ambient") -> FastAPI:
+    mode = (moss_mode or "ambient").strip().lower()
+    if mode not in {"ambient", "tool"}:
+        mode = "ambient"
+    mock = env_flag("MOCK")
+    state: dict[str, MossHandle | None] = {"moss": None}
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        state["moss"] = await open_moss()
+        yield
+
+    app = FastAPI(
+        title=f"Moss custom-llm ({mode})",
+        description="OpenAI-compatible Chat Completions for Agora Conversational AI.",
+        version="1.0.0",
+        lifespan=lifespan,
+    )
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.post("/chat/completions")
+    async def chat_completions(
+        request: ChatCompletionRequest,
+        authorization: Optional[str] = Header(None, alias="Authorization"),
+    ):
+        require_bearer(authorization, mock=mock)
+        if not request.stream:
+            raise HTTPException(
+                status_code=400,
+                detail="Only streaming mode is supported. Set stream=true.",
+            )
+        moss = state["moss"] or MossHandle(None)
+        if mode == "tool":
+            text = await tool_answer(request.messages, moss, mock=mock)
+        else:
+            text = await ambient_answer(request.messages, moss, mock=mock)
+        model = request.model or os.getenv("CUSTOM_LLM_MODEL", "moss-custom-llm")
+        return StreamingResponse(stream_answer(text, model), media_type="text/event-stream")
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok", "service": "agora-custom-llm-moss", "moss_mode": mode, "mock": mock}
+
+    return app
+
+
+# Standalone default: MOSS_MODE env (ambient unless set to tool).
+app = create_app(os.getenv("MOSS_MODE", "ambient"))
+
+
+def run_doctor() -> None:
+    """Zero-key smoke: mock ambient + tool, no network, no LLM keys."""
+    from fastapi.testclient import TestClient
+
+    os.environ["MOCK"] = "1"
+    payload = {
+        "model": "mock",
+        "stream": True,
+        "messages": [{"role": "user", "content": "How long do refunds take?"}],
+    }
+    for mode in ("ambient", "tool"):
+        with TestClient(create_app(mode)) as client:
+            ok = client.post("/chat/completions", json=payload)
+        if ok.status_code != 200:
+            raise SystemExit(f"doctor {mode} HTTP {ok.status_code}: {ok.text}")
+        if "data: [DONE]" not in ok.text:
+            raise SystemExit(f"doctor {mode}: SSE missing data: [DONE]")
+        print(f"doctor {mode}: ok")
+    os.environ["MOCK"] = "0"
+    with TestClient(create_app("ambient")) as client:
+        denied = client.post("/chat/completions", json=payload)
+    if denied.status_code != 401:
+        raise SystemExit(f"doctor bearer: expected 401, got {denied.status_code}")
+    print("doctor bearer: rejected missing Authorization")
+    print("doctor: ok")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Moss custom-llm server")
+    parser.add_argument("--mock", action="store_true", help="Zero-key mock answers (no upstream LLM)")
+    parser.add_argument("--doctor", action="store_true", help="In-process smoke, then exit")
+    parser.add_argument("--mode", default=os.getenv("MOSS_MODE", "ambient"), choices=["ambient", "tool"])
+    args = parser.parse_args()
+    if args.mock:
+        os.environ["MOCK"] = "1"
+    if args.doctor:
+        run_doctor()
+    else:
+        import uvicorn
+
+        port = int(os.getenv("CUSTOM_LLM_PORT", "8001"))
+        logger.info("Starting Moss custom-llm mode=%s mock=%s port=%s", args.mode, args.mock, port)
+        uvicorn.run(create_app(args.mode), host="0.0.0.0", port=port)

--- a/apps/agora-custom-llm-moss/server/src/llm.py
+++ b/apps/agora-custom-llm-moss/server/src/llm.py
@@ -292,11 +292,19 @@ def create_app(moss_mode: str = "ambient") -> FastAPI:
     load_server_env()
     mode = moss_mode if moss_mode in {"ambient", "tool"} else "ambient"
     mock = os.getenv("MOCK", "").strip().lower() in {"1", "true", "yes", "on"}
-    state: dict[str, Any] = {"session": None}
+    state: dict[str, Any] = {"session": None, "ready": False}
+
+    async def get_session():
+        # Open on first use so this works both standalone and mounted
+        # under server.py (FastAPI does not always run a mount's lifespan).
+        if not state["ready"]:
+            state["session"] = await open_moss()
+            state["ready"] = True
+        return state["session"]
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
-        state["session"] = await open_moss()
+        await get_session()
         yield
 
     app = FastAPI(title=f"Moss custom-llm ({mode})", version="1.0.0", lifespan=lifespan)
@@ -316,7 +324,7 @@ def create_app(moss_mode: str = "ambient") -> FastAPI:
         require_bearer(authorization, mock=mock)
         if not request.stream:
             raise HTTPException(status_code=400, detail="Only streaming mode is supported. Set stream=true.")
-        session = state["session"]
+        session = await get_session()
         if mode == "tool":
             text = await tool_answer(request.messages, session, mock=mock)
         else:

--- a/apps/agora-custom-llm-moss/server/src/server.py
+++ b/apps/agora-custom-llm-moss/server/src/server.py
@@ -1,0 +1,33 @@
+"""Mount ambient (default) and tool custom-llm apps on one process.
+
+Agora cloud calls:
+  <public>/llm/chat/completions        ambient (MOSS_MODE default)
+  <public>/llm-tools/chat/completions  tool loop (Agora never sees the tool)
+
+Forked layout from the Agora custom-llm recipe (MIT). This file does not
+import agora_agent; tokens/startAgent stay in the public recipe if you need them.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import FastAPI
+
+from llm import create_app
+
+app = FastAPI(title="Moss custom-llm (ambient + tool)", version="1.0.0")
+app.mount("/llm", create_app("ambient"))
+app.mount("/llm-tools", create_app("tool"))
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok", "service": "agora-custom-llm-moss"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/apps/agora-custom-llm-moss/server/src/server.py
+++ b/apps/agora-custom-llm-moss/server/src/server.py
@@ -14,7 +14,9 @@ import os
 
 from fastapi import FastAPI
 
-from llm import create_app
+from llm import create_app, load_server_env
+
+load_server_env()
 
 app = FastAPI(title="Moss custom-llm (ambient + tool)", version="1.0.0")
 app.mount("/llm", create_app("ambient"))

--- a/apps/agora-custom-llm-moss/server/src/server.py
+++ b/apps/agora-custom-llm-moss/server/src/server.py
@@ -1,11 +1,7 @@
-"""Mount ambient (default) and tool custom-llm apps on one process.
+"""One process, two mounts.
 
-Agora cloud calls:
-  <public>/llm/chat/completions        ambient (MOSS_MODE default)
-  <public>/llm-tools/chat/completions  tool loop (Agora never sees the tool)
-
-Forked layout from the Agora custom-llm recipe (MIT). This file does not
-import agora_agent; tokens/startAgent stay in the public recipe if you need them.
+  /llm/chat/completions        ambient
+  /llm-tools/chat/completions  tool (Agora never sees the tool)
 """
 
 from __future__ import annotations
@@ -18,7 +14,7 @@ from llm import create_app, load_server_env
 
 load_server_env()
 
-app = FastAPI(title="Moss custom-llm (ambient + tool)", version="1.0.0")
+app = FastAPI(title="Moss custom-llm", version="1.0.0")
 app.mount("/llm", create_app("ambient"))
 app.mount("/llm-tools", create_app("tool"))
 
@@ -31,5 +27,4 @@ async def health():
 if __name__ == "__main__":
     import uvicorn
 
-    port = int(os.getenv("PORT", "8000"))
-    uvicorn.run(app, host="0.0.0.0", port=port)
+    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8000")))

--- a/apps/agora-custom-llm-moss/tests/test_llm.py
+++ b/apps/agora-custom-llm-moss/tests/test_llm.py
@@ -49,7 +49,7 @@ def mock_env(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture
 def moss_ok(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _open():
-        return llm.MossHandle(FakeSession())
+        return FakeSession()
 
     monkeypatch.setattr(llm, "open_moss", _open)
 
@@ -57,7 +57,7 @@ def moss_ok(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture
 def moss_boom(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _open():
-        return llm.MossHandle(BoomSession())
+        return BoomSession()
 
     monkeypatch.setattr(llm, "open_moss", _open)
 

--- a/apps/agora-custom-llm-moss/tests/test_llm.py
+++ b/apps/agora-custom-llm-moss/tests/test_llm.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -128,6 +129,13 @@ def test_server_mounts_share_factory(mock_env) -> None:
     assert ambient.status_code == 200 and "data: [DONE]" in ambient.text
     assert tool.status_code == 200 and "data: [DONE]" in tool.text
     assert "search_knowledge_base" not in tool.text
+
+
+def test_load_server_env_reads_dotenv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / ".env").write_text("CUSTOM_LLM_API_KEY=from-dotenv-file\n")
+    monkeypatch.delenv("CUSTOM_LLM_API_KEY", raising=False)
+    llm.load_server_env(tmp_path)
+    assert os.environ.get("CUSTOM_LLM_API_KEY") == "from-dotenv-file"
 
 
 def test_last_user_text_from_list_content() -> None:

--- a/apps/agora-custom-llm-moss/tests/test_llm.py
+++ b/apps/agora-custom-llm-moss/tests/test_llm.py
@@ -1,0 +1,142 @@
+"""Mock/doctor tests for the custom-llm middleware. No Agora, no LLM keys."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+SRC = Path(__file__).resolve().parents[1] / "server" / "src"
+sys.path.insert(0, str(SRC))
+
+import llm  # noqa: E402
+
+PAYLOAD = {
+    "model": "mock",
+    "stream": True,
+    "messages": [{"role": "user", "content": "How long do refunds take?"}],
+}
+
+GROUNDING = (
+    "Relevant knowledge from Moss:\n\n"
+    "[1] Refunds are processed within 3-5 business days once the return is approved."
+)
+
+
+class FakeSession:
+    last_time_taken_ms = 3
+
+    async def query_context(self, text: str) -> str:
+        return GROUNDING
+
+
+class BoomSession:
+    last_time_taken_ms = None
+
+    async def query_context(self, text: str) -> str:
+        raise RuntimeError("timeout")
+
+
+@pytest.fixture
+def mock_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MOCK", "1")
+    monkeypatch.delenv("CUSTOM_LLM_API_KEY", raising=False)
+
+
+@pytest.fixture
+def moss_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _open():
+        return llm.MossHandle(FakeSession())
+
+    monkeypatch.setattr(llm, "open_moss", _open)
+
+
+@pytest.fixture
+def moss_boom(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _open():
+        return llm.MossHandle(BoomSession())
+
+    monkeypatch.setattr(llm, "open_moss", _open)
+
+
+def _collect_sse(response) -> str:
+    return response.text
+
+
+def test_mock_ambient_echoes_grounding(mock_env, moss_ok) -> None:
+    with TestClient(llm.create_app("ambient")) as client:
+        response = client.post("/chat/completions", json=PAYLOAD)
+    assert response.status_code == 200
+    body = _collect_sse(response)
+    assert "data: [DONE]" in body
+    assert "3-5" in body
+    assert "tool_calls" not in body
+
+
+def test_mock_tool_echoes_grounding_and_hides_tool(mock_env, moss_ok) -> None:
+    with TestClient(llm.create_app("tool")) as client:
+        response = client.post("/chat/completions", json=PAYLOAD)
+    assert response.status_code == 200
+    body = _collect_sse(response)
+    assert "data: [DONE]" in body
+    assert "3-5" in body
+    # Agora must only see the spoken answer, never the tool schema.
+    assert "search_knowledge_base" not in body
+
+
+def test_bearer_missing_rejected_when_not_mock(monkeypatch: pytest.MonkeyPatch, moss_ok) -> None:
+    monkeypatch.setenv("MOCK", "0")
+    monkeypatch.setenv("CUSTOM_LLM_API_KEY", "secret")
+    with TestClient(llm.create_app("ambient")) as client:
+        denied = client.post("/chat/completions", json=PAYLOAD)
+        assert denied.status_code == 401
+        ok = client.post(
+            "/chat/completions",
+            json=PAYLOAD,
+            headers={"Authorization": "Bearer secret"},
+        )
+        # Without MOCK the handler tries the upstream LLM; we only assert Bearer.
+        assert ok.status_code != 401
+
+
+def test_moss_error_fail_open_still_streams(mock_env, moss_boom) -> None:
+    with TestClient(llm.create_app("ambient")) as client:
+        response = client.post("/chat/completions", json=PAYLOAD)
+    assert response.status_code == 200
+    assert "data: [DONE]" in response.text
+
+
+def test_non_stream_rejected(mock_env, moss_ok) -> None:
+    with TestClient(llm.create_app("ambient")) as client:
+        response = client.post(
+            "/chat/completions",
+            json={**PAYLOAD, "stream": False},
+        )
+    assert response.status_code == 400
+
+
+def test_server_mounts_share_factory(mock_env) -> None:
+    import server as server_mod
+
+    with TestClient(server_mod.app) as client:
+        health = client.get("/health")
+        assert health.status_code == 200
+        ambient = client.post("/llm/chat/completions", json=PAYLOAD)
+        tool = client.post("/llm-tools/chat/completions", json=PAYLOAD)
+    assert ambient.status_code == 200 and "data: [DONE]" in ambient.text
+    assert tool.status_code == 200 and "data: [DONE]" in tool.text
+    assert "search_knowledge_base" not in tool.text
+
+
+def test_last_user_text_from_list_content() -> None:
+    msg = llm.UserMessage(role="user", content=[{"type": "text", "text": "hello"}])
+    assert llm.last_user_text([msg]) == "hello"
+
+
+def test_doctor_entrypoint(monkeypatch: pytest.MonkeyPatch, moss_ok, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setenv("MOCK", "1")
+    llm.run_doctor()
+    out = capsys.readouterr().out
+    assert "doctor: ok" in out

--- a/apps/agora-custom-llm-moss/tests/test_llm.py
+++ b/apps/agora-custom-llm-moss/tests/test_llm.py
@@ -181,3 +181,16 @@ def test_doctor_entrypoint(monkeypatch: pytest.MonkeyPatch, moss_ok, capsys: pyt
     llm.run_doctor()
     out = capsys.readouterr().out
     assert "doctor: ok" in out
+
+
+def test_doctor_unset_key_survives_dotenv_reload(
+    monkeypatch: pytest.MonkeyPatch, moss_ok, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def _load(_server_dir=None) -> None:
+        os.environ["CUSTOM_LLM_API_KEY"] = "anything"
+
+    monkeypatch.setattr(llm, "load_server_env", _load)
+    llm.run_doctor()
+    out = capsys.readouterr().out
+    assert "rejected any token while CUSTOM_LLM_API_KEY is unset" in out
+    assert "doctor: ok" in out

--- a/apps/agora-custom-llm-moss/tests/test_llm.py
+++ b/apps/agora-custom-llm-moss/tests/test_llm.py
@@ -118,7 +118,7 @@ def test_non_stream_rejected(mock_env, moss_ok) -> None:
     assert response.status_code == 400
 
 
-def test_server_mounts_share_factory(mock_env) -> None:
+def test_server_mounts_open_moss_on_first_request(mock_env, moss_ok) -> None:
     import server as server_mod
 
     with TestClient(server_mod.app) as client:
@@ -126,8 +126,8 @@ def test_server_mounts_share_factory(mock_env) -> None:
         assert health.status_code == 200
         ambient = client.post("/llm/chat/completions", json=PAYLOAD)
         tool = client.post("/llm-tools/chat/completions", json=PAYLOAD)
-    assert ambient.status_code == 200 and "data: [DONE]" in ambient.text
-    assert tool.status_code == 200 and "data: [DONE]" in tool.text
+    assert ambient.status_code == 200 and "3-5" in ambient.text
+    assert tool.status_code == 200 and "3-5" in tool.text
     assert "search_knowledge_base" not in tool.text
 
 

--- a/apps/agora-custom-llm-moss/tests/test_llm.py
+++ b/apps/agora-custom-llm-moss/tests/test_llm.py
@@ -194,3 +194,23 @@ def test_doctor_unset_key_survives_dotenv_reload(
     out = capsys.readouterr().out
     assert "rejected any token while CUSTOM_LLM_API_KEY is unset" in out
     assert "doctor: ok" in out
+
+
+def test_doctor_restores_preset_env(
+    monkeypatch: pytest.MonkeyPatch, moss_ok
+) -> None:
+    monkeypatch.setenv("MOCK", "preset")
+    monkeypatch.setenv("CUSTOM_LLM_API_KEY", "preset-key")
+    llm.run_doctor()
+    assert os.environ["MOCK"] == "preset"
+    assert os.environ["CUSTOM_LLM_API_KEY"] == "preset-key"
+
+
+def test_doctor_restores_absent_env(
+    monkeypatch: pytest.MonkeyPatch, moss_ok
+) -> None:
+    monkeypatch.delenv("MOCK", raising=False)
+    monkeypatch.delenv("CUSTOM_LLM_API_KEY", raising=False)
+    llm.run_doctor()
+    assert "MOCK" not in os.environ
+    assert "CUSTOM_LLM_API_KEY" not in os.environ

--- a/apps/agora-custom-llm-moss/tests/test_llm.py
+++ b/apps/agora-custom-llm-moss/tests/test_llm.py
@@ -41,13 +41,26 @@ class BoomSession:
 
 
 @pytest.fixture
-def mock_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("MOCK", "1")
-    monkeypatch.delenv("CUSTOM_LLM_API_KEY", raising=False)
+def hermetic_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(llm, "load_server_env", lambda *_a, **_k: None)
+    for key in (
+        "MOSS_PROJECT_ID",
+        "MOSS_PROJECT_KEY",
+        "MOSS_INDEX_NAME",
+        "CUSTOM_LLM_API_KEY",
+        "UPSTREAM_LLM_API_KEY",
+        "OPENAI_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
 
 
 @pytest.fixture
-def moss_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+def mock_env(hermetic_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MOCK", "1")
+
+
+@pytest.fixture
+def moss_ok(hermetic_env, monkeypatch: pytest.MonkeyPatch) -> None:
     async def _open():
         return FakeSession()
 
@@ -55,7 +68,7 @@ def moss_ok(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
-def moss_boom(monkeypatch: pytest.MonkeyPatch) -> None:
+def moss_boom(hermetic_env, monkeypatch: pytest.MonkeyPatch) -> None:
     async def _open():
         return BoomSession()
 
@@ -100,6 +113,26 @@ def test_bearer_missing_rejected_when_not_mock(monkeypatch: pytest.MonkeyPatch, 
         )
         # Without MOCK the handler tries the upstream LLM; we only assert Bearer.
         assert ok.status_code != 401
+
+
+def test_unset_key_rejects_any_bearer(monkeypatch: pytest.MonkeyPatch, moss_ok) -> None:
+    monkeypatch.setenv("MOCK", "0")
+    with TestClient(llm.create_app("ambient")) as client:
+        denied = client.post(
+            "/chat/completions",
+            json=PAYLOAD,
+            headers={"Authorization": "Bearer anything-at-all"},
+        )
+    assert denied.status_code == 401
+
+
+def test_search_query_non_object_falls_back_to_user_text() -> None:
+    fallback = "How long do refunds take?"
+    assert llm.search_query('{"query": "refunds"}', fallback) == "refunds"
+    assert llm.search_query('["refunds"]', fallback) == fallback
+    assert llm.search_query("42", fallback) == fallback
+    assert llm.search_query("not-json", fallback) == fallback
+    assert llm.search_query('{"query": ""}', fallback) == fallback
 
 
 def test_moss_error_fail_open_still_streams(mock_env, moss_boom) -> None:

--- a/apps/ten-moss/README.md
+++ b/apps/ten-moss/README.md
@@ -37,8 +37,6 @@ flowchart LR
     class ctl,idx moss
 ```
 
-Everything on the retrieval path runs inside the agent process. There is no network hop between the transcript arriving and the grounded prompt reaching the LLM.
-
 ## What's in this directory
 
 This example ships the TEN app plus a small index builder; the run harness (playground, server, Taskfile, Dockerfile) comes from the TEN Framework, so `tenapp/` drops into any TEN checkout.
@@ -97,30 +95,9 @@ The Moss delta lives in `main_python`:
 | `extension.py` `on_cmd` | Tool: `query_context(arguments.query)` and return `{type: "llmresult", content: grounding}`. |
 | `tenapp/property.json` | `voice_assistant` (ambient, auto-start) and `voice_assistant_tools`. |
 
-Anatomy of a turn:
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant User
-    participant STT as Deepgram STT
-    participant Ctl as main_control
-    participant Moss as Moss session (in-process)
-    participant LLM as OpenAI LLM
-    participant TTS as ElevenLabs TTS
-
-    User->>STT: speech (via agora_rtc + streamid_adapter)
-    STT->>Ctl: asr_result (final)
-    Ctl->>Moss: query_context(text)
-    Moss-->>Ctl: grounding (single-digit ms)
-    Ctl->>LLM: context + [Current User Question] + text
-    LLM-->>TTS: streamed response
-    TTS-->>User: audio (via agora_rtc)
-```
-
 ## Measure the latency
 
-Every turn, the control extension logs the retrieval cost using the SDK's own `SearchResult.time_taken_ms` (surfaced by `ten-moss` as `last_time_taken_ms`), with the wall clock alongside for reference:
+Logs use the SDK `SearchResult.time_taken_ms` (`ten-moss.last_time_taken_ms`), plus wall clock:
 
 ```
 [retrieval-latency] backend=moss(in-process) time_taken_ms=2 (wall_clock=64ms)
@@ -134,7 +111,7 @@ In the playground transcript you see, per turn, what Moss retrieved plus the SDK
 <the assistant's spoken answer>
 ```
 
-The extension also emits a per-turn latency breakdown, both as a grep-able log line and as a note in the transcript, so you can see where each turn's time goes:
+Per-turn breakdown:
 
 ```
 [latency-breakdown] turn=3 moss_retrieval_ms=2 llm_ttft_ms=480 llm_total_ms=1150 turn_total_ms=1160
@@ -147,11 +124,7 @@ The extension also emits a per-turn latency breakdown, both as a grep-able log l
 | `llm_total_ms` | Full LLM generation for the turn. |
 | `turn_total_ms` | ASR-final to LLM-final (the whole control-side turn). |
 
-ASR timing appears in the Deepgram STT extension logs and TTS audio-out in the ElevenLabs TTS logs (both per turn in the worker log), so between those and the lines above you get the full component-by-component breakdown.
-
-### Benchmark against TEN's default retrieval
-
-TEN's shipped memory/RAG backends (memU, OceanBase PowerRAG, EverMemOS) are remote services that pay a network round trip every turn, whereas Moss retrieves in-process, so the same grounding is a local call of single-digit milliseconds.
+ASR timing is in the Deepgram logs; TTS audio-out is in the ElevenLabs logs.
 
 ## Configuration
 
@@ -178,7 +151,7 @@ No Agora, no Deepgram, no mic. Gold phrases are the 10 FAQs.
 python bench/run.py --echo-grounding
 ```
 
-`--echo-grounding` needs no LLM key. With `MOSS_*` set it reports `moss_retrieval_ms`. Without them it still prints the table from the local FAQ file. The tool arm always searches in that smoke (no LLM to decide). See `bench/README.md`.
+See `bench/README.md`.
 
 ## Provenance
 

--- a/apps/ten-moss/README.md
+++ b/apps/ten-moss/README.md
@@ -1,6 +1,13 @@
 # Voice Assistant with Moss (TEN Framework)
 
-A real-time voice agent built on the [TEN Framework](https://github.com/ten-framework/ten-framework) that grounds every answer in a [Moss](https://moss.dev) session. On each final ASR transcript, the control extension queries Moss for session-scoped context (single-digit milliseconds, in-process) and injects it into the LLM prompt before the model responds, so answers reflect your knowledge base with no perceptible added latency.
+A real-time voice agent built on the [TEN Framework](https://github.com/ten-framework/ten-framework) that grounds answers in a [Moss](https://moss.dev) session. Two graphs, one `tenapp/`:
+
+| Graph | Playground | What happens on ASR-final |
+| --- | --- | --- |
+| `voice_assistant` (default, `auto_start: true`) | `?graph=voice_assistant` | ambient: `query_context` then prepend |
+| `voice_assistant_tools` | `?graph=voice_assistant_tools` | tool-call: raw transcript to the LLM; `main_control` self-registers `search_knowledge_base` and handles `tool_call` in-process |
+
+Both graphs use the same index and the same 10 FAQs in `data/knowledge.jsonl`. There is no extra extension and no hop to `apps/agora-moss` MCP.
 
 The integration is powered by the [`ten-moss`](https://pypi.org/project/ten-moss/) package (`MossSessionManager`) and lives entirely in the `main_python` control extension.
 
@@ -36,8 +43,9 @@ Everything on the retrieval path runs inside the agent process. There is no netw
 
 This example ships the TEN app plus a small index builder; the run harness (playground, server, Taskfile, Dockerfile) comes from the TEN Framework, so `tenapp/` drops into any TEN checkout.
 
-- `tenapp/`: the TEN app, i.e. the graph (`property.json`) and the `main_python` control extension that carries the Moss delta.
+- `tenapp/`: the TEN app, i.e. the two graphs in `property.json` and the `main_python` control extension that carries the Moss delta.
 - `create_index.py` + `data/knowledge.jsonl`: build the demo Moss index.
+- `bench/`: offline gold-phrase table (ambient / tool / no-Moss). No mic.
 - `.env.example`: every credential the agent needs.
 
 ## Prerequisites
@@ -73,19 +81,21 @@ This example ships the TEN app plus a small index builder; the run harness (play
 
    `main_python` depends on [`ten-moss`](https://pypi.org/project/ten-moss/) (listed in `main_python/requirements.txt`), so `task install` pulls it from PyPI automatically. `task install` also pre-downloads the `moss-minilm` embedding model (when the `MOSS_*` env vars are set) so the first agent session does not have to.
 
-3. **Run with TEN's tooling** from that example directory (`task install && task run`, per the TEN docs), with the `MOSS_*` vars from step 1 plus the provider keys from Prerequisites (Agora, Deepgram, OpenAI, ElevenLabs). Open the TEN playground at http://localhost:3000, select the **`voice_assistant`** graph (a `predefined_graph` in `tenapp/property.json`, or open `?graph=voice_assistant`), and ask something covered by `data/knowledge.jsonl`, for example *"how long do refunds take?"*, to hear grounded answers.
+3. **Run with TEN's tooling** from that example directory (`task install && task run`, per the TEN docs), with the `MOSS_*` vars from step 1 plus the provider keys from Prerequisites (Agora, Deepgram, OpenAI, ElevenLabs). Open the TEN playground at http://localhost:3000. The default graph is **`voice_assistant`** (ambient). Switch with `?graph=voice_assistant` or `?graph=voice_assistant_tools`. Ask something covered by `data/knowledge.jsonl`, for example *"how long do refunds take?"*.
 
    **Apple Silicon note:** TEN's `ten_agent_build` dev image is amd64-only. On colima, start the VM with Rosetta (`colima start --vz-rosetta`); under plain qemu emulation the Go toolchain segfaults during `task install`. Docker Desktop and OrbStack enable Rosetta by default.
 
 ## Under the hood
 
-The difference from the stock TEN voice assistant is small and lives in three places in `main_python`:
+The difference from the stock TEN voice assistant is small and lives in `main_python`:
 
 | Location | Change |
 | --- | --- |
-| `config.py` | `MainControlConfig` inherits `MossSessionConfig` (the `moss_*` properties). |
-| `extension.py` (`on_init`) | Opens the Moss session via `MossSessionManager.from_config(...).open()`, best-effort. |
-| `extension.py` (`_on_asr_result`) | Calls `query_context(text)` and prepends the grounding to the user's turn. |
+| `config.py` | `MainControlConfig` inherits `MossSessionConfig` (the `moss_*` properties) plus `moss_mode`. |
+| `extension.py` (`on_init`) | Opens the Moss session via `MossSessionManager.from_config(...).open()`, best-effort. In tool mode, registers `search_knowledge_base`. |
+| `extension.py` (`_on_asr_result`) | Ambient: `query_context(text)` and prepend. Tool: send the raw transcript (no prepend). |
+| `extension.py` (`on_cmd` / `_on_tool_call`) | Tool graph only: run `query_context(arguments.query)` and return `{type: "llmresult", content: grounding}`. |
+| `tenapp/property.json` | `voice_assistant` (ambient, auto-start) and `voice_assistant_tools` (`moss_mode=tool`). |
 
 Anatomy of a turn:
 
@@ -158,6 +168,19 @@ Moss is configured on the `main_control` node in `tenapp/property.json` (env-sub
 | `moss_context_header` | `Relevant knowledge from Moss:` | Header prepended to the injected grounding. |
 | `moss_max_context_chars` | `2000` | Cap on the injected grounding block; `0` means unlimited. |
 | `enable_moss` | `true` | Set to `false` to run the plain voice assistant with no grounding. |
+| `moss_mode` | `ambient` | `ambient` prepends on ASR-final. `tool` registers `search_knowledge_base` and does not prepend. |
+
+## Offline bench
+
+No Agora, no Deepgram, no mic. Gold phrases are the 10 FAQs.
+
+```bash
+python bench/run.py --echo-grounding
+```
+
+`--echo-grounding` needs no cloud LLM key. With `MOSS_*` set it reports `moss_retrieval_ms` from the SDK; without them it still prints the table from a local corpus lookup. See `bench/README.md`.
+
+The tool arm of that smoke **always** calls the tool (there is no LLM to decide). That is documented stub behavior, not a live model.
 
 ## Provenance
 
@@ -167,4 +190,4 @@ Three small patches were applied on top of the vendored baseline: `agent/decorat
 
 ## Testing status
 
-The `ten-moss` package is covered by offline unit tests (`packages/ten-moss/tests/`). This end-to-end app is **not** run in CI; it requires the TEN toolchain plus paid Agora, Deepgram, OpenAI, and ElevenLabs credentials, so it is validated manually via the steps above.
+The `ten-moss` package is covered by offline unit tests (`packages/ten-moss/tests/`). Graph contract tests and `bench/run.py --echo-grounding` run in CI without Agora/Deepgram/LLM keys. The live voice loop is **not** in CI; it needs the TEN toolchain plus paid Agora, Deepgram, OpenAI, and ElevenLabs credentials.

--- a/apps/ten-moss/README.md
+++ b/apps/ten-moss/README.md
@@ -87,15 +87,15 @@ This example ships the TEN app plus a small index builder; the run harness (play
 
 ## Under the hood
 
-The difference from the stock TEN voice assistant is small and lives in `main_python`:
+The Moss delta lives in `main_python`:
 
-| Location | Change |
+| Location | What it does |
 | --- | --- |
-| `config.py` | `MainControlConfig` inherits `MossSessionConfig` (the `moss_*` properties) plus `moss_mode`. |
-| `extension.py` (`on_init`) | Opens the Moss session via `MossSessionManager.from_config(...).open()`, best-effort. In tool mode, registers `search_knowledge_base`. |
-| `extension.py` (`_on_asr_result`) | Ambient: `query_context(text)` and prepend. Tool: send the raw transcript (no prepend). |
-| `extension.py` (`on_cmd` / `_on_tool_call`) | Tool graph only: run `query_context(arguments.query)` and return `{type: "llmresult", content: grounding}`. |
-| `tenapp/property.json` | `voice_assistant` (ambient, auto-start) and `voice_assistant_tools` (`moss_mode=tool`). |
+| `config.py` | `moss_mode`: `ambient` (default) or `tool`. |
+| `extension.py` `on_init` | Open `MossSessionManager`. In tool mode, register `search_knowledge_base`. |
+| `extension.py` `_on_asr_result` | Ambient: `query_context` then prepend. Tool: send the raw transcript. |
+| `extension.py` `on_cmd` | Tool: `query_context(arguments.query)` and return `{type: "llmresult", content: grounding}`. |
+| `tenapp/property.json` | `voice_assistant` (ambient, auto-start) and `voice_assistant_tools`. |
 
 Anatomy of a turn:
 
@@ -178,9 +178,7 @@ No Agora, no Deepgram, no mic. Gold phrases are the 10 FAQs.
 python bench/run.py --echo-grounding
 ```
 
-`--echo-grounding` needs no cloud LLM key. With `MOSS_*` set it reports `moss_retrieval_ms` from the SDK; without them it still prints the table from a local corpus lookup. See `bench/README.md`.
-
-The tool arm of that smoke **always** calls the tool (there is no LLM to decide). That is documented stub behavior, not a live model.
+`--echo-grounding` needs no LLM key. With `MOSS_*` set it reports `moss_retrieval_ms`. Without them it still prints the table from the local FAQ file. The tool arm always searches in that smoke (no LLM to decide). See `bench/README.md`.
 
 ## Provenance
 

--- a/apps/ten-moss/bench/README.md
+++ b/apps/ten-moss/bench/README.md
@@ -1,0 +1,44 @@
+# Offline Moss bench (ambient / tool / no-Moss)
+
+Gold-phrase table over the 10 FAQs in `../data/knowledge.jsonl`. No mic, no Agora, no Deepgram.
+
+## What it measures
+
+Per query, three arms:
+
+| Arm | What the "model" sees | When Moss runs |
+| --- | --- | --- |
+| `ambient` | retrieved block (always searched) | every query |
+| `tool` | retrieved block if the tool ran | `--echo-grounding` always calls `search_knowledge_base` (no LLM to decide) |
+| `no-moss` | empty context | never |
+
+`--echo-grounding` is the zero-LLM smoke: the "answer" is the retrieved block, so `faithful` equals "gold phrase is in the block." That proves retrieval without an LLM key.
+
+| Metric | Meaning |
+| --- | --- |
+| `moss_retrieval_ms` | SDK `SearchResult.time_taken_ms` (n/a without a Moss session) |
+| `moss_wall_ms` | `perf_counter` around `query_context` |
+| `hit` | retrieved block contains a gold phrase (or doc id `kb-N`) |
+| `faithful` | answer contains a gold phrase |
+| `tool_called` | tool arm only |
+
+## Run
+
+```bash
+# From apps/ten-moss
+export MOSS_PROJECT_ID=... MOSS_PROJECT_KEY=... MOSS_INDEX_NAME=ten-moss-demo
+python create_index.py
+python bench/run.py --echo-grounding
+```
+
+The script still prints the markdown table if Moss credentials are missing: it falls back to a local substring lookup over `data/knowledge.jsonl`. SDK timings are then `n/a`. That path is for reading the table format, not for publishing latency.
+
+Optional: `python bench/run.py --echo-grounding --json /tmp/bench.json`
+
+## Gold queries
+
+Exact strings live in `queries.jsonl`. They match the 10 FAQ lines.
+
+## Tool-arm stub
+
+`--echo-grounding` has no chat model, so the tool arm **always** invokes `search_knowledge_base`. A live LLM arm (model decides) is residual polish, not this slice.

--- a/apps/ten-moss/bench/README.md
+++ b/apps/ten-moss/bench/README.md
@@ -14,10 +14,12 @@ Three arms per query:
 
 ```bash
 # from apps/ten-moss
-export MOSS_PROJECT_ID=... MOSS_PROJECT_KEY=... MOSS_INDEX_NAME=ten-moss-demo
+# run.py loads ../.env before reading MOSS_*
 python create_index.py
 python bench/run.py --echo-grounding
 ```
+
+`hit` is a gold phrase in the retrieved text, not a matching `doc_id`. Refunds and shipping use distinct gold phrases.
 
 No Moss keys? The script still prints the table by pairing each query with its FAQ. `moss_retrieval_ms` is then `n/a`.
 

--- a/apps/ten-moss/bench/README.md
+++ b/apps/ten-moss/bench/README.md
@@ -1,44 +1,24 @@
-# Offline Moss bench (ambient / tool / no-Moss)
+# Offline Moss bench
 
 Gold-phrase table over the 10 FAQs in `../data/knowledge.jsonl`. No mic, no Agora, no Deepgram.
 
-## What it measures
+Three arms per query:
 
-Per query, three arms:
-
-| Arm | What the "model" sees | When Moss runs |
-| --- | --- | --- |
-| `ambient` | retrieved block (always searched) | every query |
-| `tool` | retrieved block if the tool ran | `--echo-grounding` always calls `search_knowledge_base` (no LLM to decide) |
-| `no-moss` | empty context | never |
-
-`--echo-grounding` is the zero-LLM smoke: the "answer" is the retrieved block, so `faithful` equals "gold phrase is in the block." That proves retrieval without an LLM key.
-
-| Metric | Meaning |
+| Arm | What happens |
 | --- | --- |
-| `moss_retrieval_ms` | SDK `SearchResult.time_taken_ms` (n/a without a Moss session) |
-| `moss_wall_ms` | `perf_counter` around `query_context` |
-| `hit` | retrieved block contains a gold phrase (or doc id `kb-N`) |
-| `faithful` | answer contains a gold phrase |
-| `tool_called` | tool arm only |
+| `ambient` | always search, answer is the retrieved block |
+| `tool` | always search (`--echo-grounding` has no LLM to decide), answer is the block |
+| `no-moss` | empty answer |
 
-## Run
+`faithful` means the gold phrase is in the answer. `hit` means it is in the retrieved block.
 
 ```bash
-# From apps/ten-moss
+# from apps/ten-moss
 export MOSS_PROJECT_ID=... MOSS_PROJECT_KEY=... MOSS_INDEX_NAME=ten-moss-demo
 python create_index.py
 python bench/run.py --echo-grounding
 ```
 
-The script still prints the markdown table if Moss credentials are missing: it falls back to a local substring lookup over `data/knowledge.jsonl`. SDK timings are then `n/a`. That path is for reading the table format, not for publishing latency.
+No Moss keys? The script still prints the table by pairing each query with its FAQ. `moss_retrieval_ms` is then `n/a`.
 
-Optional: `python bench/run.py --echo-grounding --json /tmp/bench.json`
-
-## Gold queries
-
-Exact strings live in `queries.jsonl`. They match the 10 FAQ lines.
-
-## Tool-arm stub
-
-`--echo-grounding` has no chat model, so the tool arm **always** invokes `search_knowledge_base`. A live LLM arm (model decides) is residual polish, not this slice.
+Exact query strings: `queries.jsonl`.

--- a/apps/ten-moss/bench/queries.jsonl
+++ b/apps/ten-moss/bench/queries.jsonl
@@ -1,0 +1,10 @@
+{"id": "kb-1", "query": "How long do refunds take?", "gold": ["3-5"]}
+{"id": "kb-2", "query": "How do I track my order?", "gold": ["Order History"]}
+{"id": "kb-3", "query": "When is live chat available?", "gold": ["24/7"]}
+{"id": "kb-4", "query": "How long is standard shipping?", "gold": ["3-5"]}
+{"id": "kb-5", "query": "How do I reset my password?", "gold": ["Forgot Password"]}
+{"id": "kb-6", "query": "What payment methods do you take?", "gold": ["Visa", "PayPal", "Apple Pay"]}
+{"id": "kb-7", "query": "Can I cancel an order?", "gold": ["1 hour"]}
+{"id": "kb-8", "query": "Do you ship internationally?", "gold": ["International"]}
+{"id": "kb-9", "query": "Can I get gift wrap?", "gold": ["Gift wrapping"]}
+{"id": "kb-10", "query": "Do you price match?", "gold": ["14 days"]}

--- a/apps/ten-moss/bench/queries.jsonl
+++ b/apps/ten-moss/bench/queries.jsonl
@@ -1,7 +1,7 @@
-{"id": "kb-1", "query": "How long do refunds take?", "gold": ["3-5"]}
+{"id": "kb-1", "query": "How long do refunds take?", "gold": ["Refunds are processed"]}
 {"id": "kb-2", "query": "How do I track my order?", "gold": ["Order History"]}
 {"id": "kb-3", "query": "When is live chat available?", "gold": ["24/7"]}
-{"id": "kb-4", "query": "How long is standard shipping?", "gold": ["3-5"]}
+{"id": "kb-4", "query": "How long is standard shipping?", "gold": ["Standard shipping"]}
 {"id": "kb-5", "query": "How do I reset my password?", "gold": ["Forgot Password"]}
 {"id": "kb-6", "query": "What payment methods do you take?", "gold": ["Visa", "PayPal", "Apple Pay"]}
 {"id": "kb-7", "query": "Can I cancel an order?", "gold": ["1 hour"]}

--- a/apps/ten-moss/bench/run.py
+++ b/apps/ten-moss/bench/run.py
@@ -1,12 +1,13 @@
-"""Offline gold-phrase bench: ambient vs tool-call vs no-Moss.
-
-No mic, no Agora, no Deepgram. --echo-grounding needs no cloud LLM key.
+"""Offline gold-phrase bench: ambient vs tool vs no-Moss.
 
     python bench/run.py --echo-grounding
 
-With Moss credentials the ambient/tool arms query MossSessionManager.
-Without them, --echo-grounding still prints the table using a local
-substring lookup over data/knowledge.jsonl (moss_retrieval_ms is then n/a).
+No mic, no Agora, no Deepgram, no LLM key.
+With MOSS_* set, ambient and tool call MossSessionManager.query_context.
+Without them, those arms look up the matching FAQ in data/knowledge.jsonl
+so the table still prints (moss_retrieval_ms is then n/a).
+
+--echo-grounding has no chat model, so the tool arm always searches.
 """
 
 from __future__ import annotations
@@ -19,209 +20,53 @@ import statistics
 import sys
 import time
 from pathlib import Path
-from typing import Any, Callable, Awaitable
 
 HERE = Path(__file__).resolve().parent
-APP_DIR = HERE.parent
 QUERIES_PATH = HERE / "queries.jsonl"
-KNOWLEDGE_PATH = APP_DIR / "data" / "knowledge.jsonl"
-
-ARMS = ("ambient", "tool", "no-moss")
-SearchFn = Callable[[str], Awaitable[tuple[str, float | None, float | None]]]
+KNOWLEDGE_PATH = HERE.parent / "data" / "knowledge.jsonl"
 
 
-def load_queries(path: Path = QUERIES_PATH) -> list[dict[str, Any]]:
-    """Load the published 10-query gold file."""
-    rows: list[dict[str, Any]] = []
+def load_jsonl(path: Path) -> list[dict]:
+    rows = []
     for line in path.read_text().splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        rows.append(json.loads(line))
+        if line.strip():
+            rows.append(json.loads(line))
     return rows
 
 
-def load_knowledge(path: Path = KNOWLEDGE_PATH) -> list[dict[str, Any]]:
-    rows: list[dict[str, Any]] = []
-    for line in path.read_text().splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        rows.append(json.loads(line))
-    return rows
+def load_queries(path: Path = QUERIES_PATH) -> list[dict]:
+    return load_jsonl(path)
 
 
 def contains_gold(text: str, gold: list[str]) -> bool:
-    """True if any gold key-phrase is a substring of text."""
     haystack = text or ""
     return any(phrase in haystack for phrase in gold)
 
 
-def _yes(flag: bool) -> str:
-    return "yes" if flag else "no"
+def lookup_faq(query: str, queries: list[dict], docs: list[dict]) -> str:
+    """Return the FAQ that belongs to this published query. No Moss needed."""
+    by_id = {str(doc.get("id")): doc for doc in docs}
+    for row in queries:
+        if row.get("query") == query:
+            doc = by_id.get(str(row.get("id")))
+            if doc:
+                return f"Relevant knowledge from Moss:\n\n[1] {doc.get('text', '')}"
+    return ""
 
 
-def format_ms(value: float | None) -> str:
-    if value is None:
-        return "n/a"
-    return f"{value:.1f}"
+async def query_moss(session, query: str) -> tuple[str, float | None, float | None]:
+    """Fail-open: empty context on error. Returns (text, sdk_ms, wall_ms)."""
+    t0 = time.perf_counter()
+    try:
+        context = await session.query_context(query)
+    except Exception:
+        return "", None, (time.perf_counter() - t0) * 1000.0
+    wall_ms = (time.perf_counter() - t0) * 1000.0
+    sdk_ms = getattr(session, "last_time_taken_ms", None)
+    return context or "", float(sdk_ms) if sdk_ms is not None else None, wall_ms
 
 
-def percentile(values: list[float], p: float) -> float | None:
-    if not values:
-        return None
-    if len(values) == 1:
-        return values[0]
-    ordered = sorted(values)
-    k = (len(ordered) - 1) * p
-    lo = int(k)
-    hi = min(lo + 1, len(ordered) - 1)
-    frac = k - lo
-    return ordered[lo] * (1.0 - frac) + ordered[hi] * frac
-
-
-class LocalCorpusSearch:
-    """Pair each published query with its FAQ so --echo-grounding works without Moss keys."""
-
-    def __init__(self, docs: list[dict[str, Any]], queries: list[dict[str, Any]]):
-        self.docs = {str(d.get("id")): d for d in docs}
-        self.query_to_id = {str(q.get("query")): str(q.get("id")) for q in queries}
-
-    async def search(self, query: str) -> tuple[str, float | None, float | None]:
-        doc_id = self.query_to_id.get(query)
-        doc = self.docs.get(doc_id) if doc_id else None
-        if doc is None:
-            return "", None, None
-        block = (
-            "Relevant knowledge from Moss:\n\n"
-            f"[1] {doc.get('text', '')}"
-        )
-        return block, None, None
-
-
-class MossSearch:
-    def __init__(self, session: Any):
-        self.session = session
-
-    async def search(self, query: str) -> tuple[str, float | None, float | None]:
-        t0 = time.perf_counter()
-        try:
-            context = await self.session.query_context(query)
-        except Exception:  # noqa: BLE001 - fail open
-            return "", None, (time.perf_counter() - t0) * 1000.0
-        wall_ms = (time.perf_counter() - t0) * 1000.0
-        sdk_ms = getattr(self.session, "last_time_taken_ms", None)
-        if sdk_ms is not None:
-            sdk_ms = float(sdk_ms)
-        return context or "", sdk_ms, wall_ms
-
-
-async def echo_answer(
-    *,
-    arm: str,
-    query: str,
-    search: SearchFn | None,
-    always_call_tool: bool,
-) -> dict[str, Any]:
-    """Zero-LLM arm: ambient/tool echo the retrieved block; no-Moss answers empty."""
-    tool_called = False
-    context = ""
-    sdk_ms: float | None = None
-    wall_ms: float | None = None
-    if arm == "no-moss":
-        answer = ""
-    elif arm == "tool":
-        # Stub: --echo-grounding has no model, so the tool arm always searches.
-        tool_called = always_call_tool
-        if tool_called and search is not None:
-            context, sdk_ms, wall_ms = await search(query)
-        answer = context
-    else:
-        if search is not None:
-            context, sdk_ms, wall_ms = await search(query)
-        answer = context
-    return {
-        "context": context,
-        "answer": answer,
-        "moss_retrieval_ms": sdk_ms,
-        "moss_wall_ms": wall_ms,
-        "tool_called": tool_called,
-    }
-
-
-def score_row(query_row: dict[str, Any], result: dict[str, Any], arm: str) -> dict[str, Any]:
-    gold = list(query_row["gold"])
-    context = result.get("context") or ""
-    answer = result.get("answer") or ""
-    doc_id = str(query_row.get("id") or "")
-    hit = contains_gold(context, gold) or (doc_id and doc_id in context)
-    faithful = contains_gold(answer, gold)
-    return {
-        "id": query_row["id"],
-        "query": query_row["query"],
-        "arm": arm,
-        "moss_retrieval_ms": result.get("moss_retrieval_ms"),
-        "moss_wall_ms": result.get("moss_wall_ms"),
-        "hit": bool(hit),
-        "faithful": bool(faithful),
-        "tool_called": bool(result.get("tool_called")),
-        "answer": answer,
-    }
-
-
-def render_table(rows: list[dict[str, Any]]) -> str:
-    header = (
-        "| query | arm | moss_retrieval_ms | moss_wall_ms | hit | faithful | tool_called |"
-    )
-    sep = "| --- | --- | ---: | ---: | --- | --- | --- |"
-    lines = [header, sep]
-    for row in rows:
-        lines.append(
-            "| {query} | {arm} | {retr} | {wall} | {hit} | {faithful} | {tool} |".format(
-                query=row["query"],
-                arm=row["arm"],
-                retr=format_ms(row["moss_retrieval_ms"]),
-                wall=format_ms(row["moss_wall_ms"]),
-                hit=_yes(row["hit"]),
-                faithful=_yes(row["faithful"]),
-                tool=_yes(row["tool_called"]) if row["arm"] == "tool" else "-",
-            )
-        )
-    return "\n".join(lines)
-
-
-def render_summary(rows: list[dict[str, Any]]) -> str:
-    lines = ["", "### Summary"]
-    for arm in ARMS:
-        arm_rows = [r for r in rows if r["arm"] == arm]
-        searched = [
-            r["moss_retrieval_ms"]
-            for r in arm_rows
-            if r["moss_retrieval_ms"] is not None
-        ]
-        n = len(arm_rows)
-        faithful = sum(1 for r in arm_rows if r["faithful"])
-        hits = sum(1 for r in arm_rows if r["hit"])
-        tool_called = sum(1 for r in arm_rows if r["tool_called"])
-        lines.append(f"**{arm}** ({n} queries)")
-        lines.append(f"- hit: {hits}/{n}")
-        lines.append(f"- faithful: {faithful}/{n}")
-        if arm == "tool":
-            lines.append(f"- tool_called: {tool_called}/{n}")
-        if searched:
-            mean = statistics.fmean(searched)
-            p50 = percentile(searched, 0.50)
-            p95 = percentile(searched, 0.95)
-            lines.append(
-                f"- moss_retrieval_ms mean/p50/p95: "
-                f"{format_ms(mean)} / {format_ms(p50)} / {format_ms(p95)}"
-            )
-        else:
-            lines.append("- moss_retrieval_ms mean/p50/p95: n/a (no SDK timings)")
-    return "\n".join(lines)
-
-
-async def open_moss_search() -> MossSearch | None:
+async def open_moss():
     project_id = os.environ.get("MOSS_PROJECT_ID", "").strip()
     project_key = os.environ.get("MOSS_PROJECT_KEY", "").strip()
     index_name = os.environ.get("MOSS_INDEX_NAME", "").strip()
@@ -241,73 +86,153 @@ async def open_moss_search() -> MossSearch | None:
     )
     try:
         await session.open()
-    except Exception as exc:  # noqa: BLE001
-        print(f"warning: Moss session failed to open ({exc}); using local corpus", file=sys.stderr)
+    except Exception as exc:
+        print(f"warning: Moss session failed to open ({exc}); using local FAQ lookup", file=sys.stderr)
         return None
-    return MossSearch(session)
+    return session
 
 
-async def run_bench(*, echo_grounding: bool, json_out: Path | None) -> list[dict[str, Any]]:
-    if not echo_grounding:
-        raise SystemExit("This slice ships --echo-grounding only. A live LLM arm is follow-up.")
-    queries = load_queries()
-    moss = await open_moss_search()
-    if moss is not None:
-        search: SearchFn = moss.search
-        backend = "moss"
+def format_ms(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.1f}"
+
+
+def percentile(values: list[float], p: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    k = (len(ordered) - 1) * p
+    lo = int(k)
+    hi = min(lo + 1, len(ordered) - 1)
+    return ordered[lo] * (1.0 - (k - lo)) + ordered[hi] * (k - lo)
+
+
+def render_table(rows: list[dict]) -> str:
+    lines = [
+        "| query | arm | moss_retrieval_ms | moss_wall_ms | hit | faithful | tool_called |",
+        "| --- | --- | ---: | ---: | --- | --- | --- |",
+    ]
+    for row in rows:
+        tool = "yes" if row["tool_called"] else "no" if row["arm"] == "tool" else "-"
+        lines.append(
+            f"| {row['query']} | {row['arm']} | {format_ms(row['moss_retrieval_ms'])} | "
+            f"{format_ms(row['moss_wall_ms'])} | "
+            f"{'yes' if row['hit'] else 'no'} | "
+            f"{'yes' if row['faithful'] else 'no'} | {tool} |"
+        )
+    return "\n".join(lines)
+
+
+def render_summary(rows: list[dict]) -> str:
+    lines = ["", "### Summary"]
+    for arm in ("ambient", "tool", "no-moss"):
+        arm_rows = [r for r in rows if r["arm"] == arm]
+        n = len(arm_rows)
+        searched = [r["moss_retrieval_ms"] for r in arm_rows if r["moss_retrieval_ms"] is not None]
+        lines.append(f"**{arm}** ({n} queries)")
+        lines.append(f"- hit: {sum(1 for r in arm_rows if r['hit'])}/{n}")
+        lines.append(f"- faithful: {sum(1 for r in arm_rows if r['faithful'])}/{n}")
+        if arm == "tool":
+            lines.append(f"- tool_called: {sum(1 for r in arm_rows if r['tool_called'])}/{n}")
+        if searched:
+            lines.append(
+                "- moss_retrieval_ms mean/p50/p95: "
+                f"{format_ms(statistics.fmean(searched))} / "
+                f"{format_ms(percentile(searched, 0.50))} / "
+                f"{format_ms(percentile(searched, 0.95))}"
+            )
+        else:
+            lines.append("- moss_retrieval_ms mean/p50/p95: n/a (no SDK timings)")
+    return "\n".join(lines)
+
+
+async def run_one(
+    arm: str,
+    query: str,
+    gold: list[str],
+    doc_id: str,
+    session,
+    queries: list[dict],
+    docs: list[dict],
+) -> dict:
+    context = ""
+    sdk_ms = None
+    wall_ms = None
+    tool_called = False
+
+    if arm == "no-moss":
+        answer = ""
     else:
-        search = LocalCorpusSearch(load_knowledge(), queries).search
-        backend = "local-corpus"
+        if arm == "tool":
+            tool_called = True
+        if session is not None:
+            context, sdk_ms, wall_ms = await query_moss(session, query)
+        else:
+            context = lookup_faq(query, queries, docs)
+        answer = context
+
+    hit = contains_gold(context, gold) or (doc_id and doc_id in context)
+    faithful = contains_gold(answer, gold)
+    return {
+        "id": doc_id,
+        "query": query,
+        "arm": arm,
+        "moss_retrieval_ms": sdk_ms,
+        "moss_wall_ms": wall_ms,
+        "hit": bool(hit),
+        "faithful": bool(faithful),
+        "tool_called": tool_called,
+        "answer": answer,
+    }
+
+
+async def run_bench(json_out: Path | None = None) -> list[dict]:
+    queries = load_queries()
+    docs = load_jsonl(KNOWLEDGE_PATH)
+    session = await open_moss()
+    if session is None:
         print(
             "note: no Moss session (set MOSS_PROJECT_ID / MOSS_PROJECT_KEY / "
-            "MOSS_INDEX_NAME to measure moss_retrieval_ms). Using local corpus.",
+            "MOSS_INDEX_NAME to measure moss_retrieval_ms). Using local FAQ lookup.",
             file=sys.stderr,
         )
 
-    rows: list[dict[str, Any]] = []
-    for query_row in queries:
-        for arm in ARMS:
-            result = await echo_answer(
-                arm=arm,
-                query=query_row["query"],
-                search=search,
-                always_call_tool=True,
+    rows = []
+    for row in queries:
+        for arm in ("ambient", "tool", "no-moss"):
+            rows.append(
+                await run_one(
+                    arm,
+                    row["query"],
+                    list(row["gold"]),
+                    str(row["id"]),
+                    session,
+                    queries,
+                    docs,
+                )
             )
-            scored = score_row(query_row, result, arm)
-            scored["backend"] = backend
-            rows.append(scored)
 
-    table = render_table(rows)
-    summary = render_summary(rows)
-    print(table)
-    print(summary)
+    print(render_table(rows))
+    print(render_summary(rows))
     if json_out is not None:
         json_out.write_text(json.dumps(rows, indent=2) + "\n")
         print(f"\nwrote {json_out}")
     return rows
 
 
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--echo-grounding",
         action="store_true",
         help="Zero-LLM smoke: ambient/tool answers are the retrieved block.",
     )
-    parser.add_argument(
-        "--json",
-        type=Path,
-        default=None,
-        help="Optional path to write the per-row JSON.",
-    )
-    return parser.parse_args(argv)
-
-
-def main(argv: list[str] | None = None) -> None:
-    args = parse_args(argv)
+    parser.add_argument("--json", type=Path, default=None)
+    args = parser.parse_args(argv)
     if not args.echo_grounding:
-        raise SystemExit("pass --echo-grounding (zero-LLM smoke is the required gate)")
-    asyncio.run(run_bench(echo_grounding=True, json_out=args.json))
+        raise SystemExit("pass --echo-grounding")
+    asyncio.run(run_bench(json_out=args.json))
 
 
 if __name__ == "__main__":

--- a/apps/ten-moss/bench/run.py
+++ b/apps/ten-moss/bench/run.py
@@ -15,6 +15,13 @@ import sys
 import time
 from pathlib import Path
 
+try:
+    from dotenv import load_dotenv
+except ImportError:
+
+    def load_dotenv(*_args, **_kwargs):
+        return False
+
 HERE = Path(__file__).resolve().parent
 QUERIES_PATH = HERE / "queries.jsonl"
 KNOWLEDGE_PATH = HERE.parent / "data" / "knowledge.jsonl"
@@ -59,6 +66,8 @@ async def query_moss(session, query: str) -> tuple[str, float | None, float | No
 
 
 async def open_moss():
+    load_dotenv(HERE.parent / ".env")
+    load_dotenv(HERE.parent / ".env.local", override=True)
     project_id = os.environ.get("MOSS_PROJECT_ID", "").strip()
     project_key = os.environ.get("MOSS_PROJECT_KEY", "").strip()
     index_name = os.environ.get("MOSS_INDEX_NAME", "").strip()
@@ -164,7 +173,7 @@ async def run_one(
             context = lookup_faq(query, queries, docs)
         answer = context
 
-    hit = contains_gold(context, gold) or (doc_id and doc_id in context)
+    hit = contains_gold(context, gold)
     faithful = contains_gold(answer, gold)
     return {
         "id": doc_id,

--- a/apps/ten-moss/bench/run.py
+++ b/apps/ten-moss/bench/run.py
@@ -1,13 +1,7 @@
-"""Offline gold-phrase bench: ambient vs tool vs no-Moss.
+"""Gold-phrase bench. python bench/run.py --echo-grounding
 
-    python bench/run.py --echo-grounding
-
-No mic, no Agora, no Deepgram, no LLM key.
-With MOSS_* set, ambient and tool call MossSessionManager.query_context.
-Without them, those arms look up the matching FAQ in data/knowledge.jsonl
-so the table still prints (moss_retrieval_ms is then n/a).
-
---echo-grounding has no chat model, so the tool arm always searches.
+No LLM key. Tool arm always searches (no model). Without MOSS_* the
+FAQ file is used and moss_retrieval_ms is n/a.
 """
 
 from __future__ import annotations
@@ -44,7 +38,6 @@ def contains_gold(text: str, gold: list[str]) -> bool:
 
 
 def lookup_faq(query: str, queries: list[dict], docs: list[dict]) -> str:
-    """Return the FAQ that belongs to this published query. No Moss needed."""
     by_id = {str(doc.get("id")): doc for doc in docs}
     for row in queries:
         if row.get("query") == query:
@@ -55,7 +48,6 @@ def lookup_faq(query: str, queries: list[dict], docs: list[dict]) -> str:
 
 
 async def query_moss(session, query: str) -> tuple[str, float | None, float | None]:
-    """Fail-open: empty context on error. Returns (text, sdk_ms, wall_ms)."""
     t0 = time.perf_counter()
     try:
         context = await session.query_context(query)

--- a/apps/ten-moss/bench/run.py
+++ b/apps/ten-moss/bench/run.py
@@ -1,0 +1,314 @@
+"""Offline gold-phrase bench: ambient vs tool-call vs no-Moss.
+
+No mic, no Agora, no Deepgram. --echo-grounding needs no cloud LLM key.
+
+    python bench/run.py --echo-grounding
+
+With Moss credentials the ambient/tool arms query MossSessionManager.
+Without them, --echo-grounding still prints the table using a local
+substring lookup over data/knowledge.jsonl (moss_retrieval_ms is then n/a).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable, Awaitable
+
+HERE = Path(__file__).resolve().parent
+APP_DIR = HERE.parent
+QUERIES_PATH = HERE / "queries.jsonl"
+KNOWLEDGE_PATH = APP_DIR / "data" / "knowledge.jsonl"
+
+ARMS = ("ambient", "tool", "no-moss")
+SearchFn = Callable[[str], Awaitable[tuple[str, float | None, float | None]]]
+
+
+def load_queries(path: Path = QUERIES_PATH) -> list[dict[str, Any]]:
+    """Load the published 10-query gold file."""
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        rows.append(json.loads(line))
+    return rows
+
+
+def load_knowledge(path: Path = KNOWLEDGE_PATH) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        rows.append(json.loads(line))
+    return rows
+
+
+def contains_gold(text: str, gold: list[str]) -> bool:
+    """True if any gold key-phrase is a substring of text."""
+    haystack = text or ""
+    return any(phrase in haystack for phrase in gold)
+
+
+def _yes(flag: bool) -> str:
+    return "yes" if flag else "no"
+
+
+def format_ms(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.1f}"
+
+
+def percentile(values: list[float], p: float) -> float | None:
+    if not values:
+        return None
+    if len(values) == 1:
+        return values[0]
+    ordered = sorted(values)
+    k = (len(ordered) - 1) * p
+    lo = int(k)
+    hi = min(lo + 1, len(ordered) - 1)
+    frac = k - lo
+    return ordered[lo] * (1.0 - frac) + ordered[hi] * frac
+
+
+class LocalCorpusSearch:
+    """Pair each published query with its FAQ so --echo-grounding works without Moss keys."""
+
+    def __init__(self, docs: list[dict[str, Any]], queries: list[dict[str, Any]]):
+        self.docs = {str(d.get("id")): d for d in docs}
+        self.query_to_id = {str(q.get("query")): str(q.get("id")) for q in queries}
+
+    async def search(self, query: str) -> tuple[str, float | None, float | None]:
+        doc_id = self.query_to_id.get(query)
+        doc = self.docs.get(doc_id) if doc_id else None
+        if doc is None:
+            return "", None, None
+        block = (
+            "Relevant knowledge from Moss:\n\n"
+            f"[1] {doc.get('text', '')}"
+        )
+        return block, None, None
+
+
+class MossSearch:
+    def __init__(self, session: Any):
+        self.session = session
+
+    async def search(self, query: str) -> tuple[str, float | None, float | None]:
+        t0 = time.perf_counter()
+        try:
+            context = await self.session.query_context(query)
+        except Exception:  # noqa: BLE001 - fail open
+            return "", None, (time.perf_counter() - t0) * 1000.0
+        wall_ms = (time.perf_counter() - t0) * 1000.0
+        sdk_ms = getattr(self.session, "last_time_taken_ms", None)
+        if sdk_ms is not None:
+            sdk_ms = float(sdk_ms)
+        return context or "", sdk_ms, wall_ms
+
+
+async def echo_answer(
+    *,
+    arm: str,
+    query: str,
+    search: SearchFn | None,
+    always_call_tool: bool,
+) -> dict[str, Any]:
+    """Zero-LLM arm: ambient/tool echo the retrieved block; no-Moss answers empty."""
+    tool_called = False
+    context = ""
+    sdk_ms: float | None = None
+    wall_ms: float | None = None
+    if arm == "no-moss":
+        answer = ""
+    elif arm == "tool":
+        # Stub: --echo-grounding has no model, so the tool arm always searches.
+        tool_called = always_call_tool
+        if tool_called and search is not None:
+            context, sdk_ms, wall_ms = await search(query)
+        answer = context
+    else:
+        if search is not None:
+            context, sdk_ms, wall_ms = await search(query)
+        answer = context
+    return {
+        "context": context,
+        "answer": answer,
+        "moss_retrieval_ms": sdk_ms,
+        "moss_wall_ms": wall_ms,
+        "tool_called": tool_called,
+    }
+
+
+def score_row(query_row: dict[str, Any], result: dict[str, Any], arm: str) -> dict[str, Any]:
+    gold = list(query_row["gold"])
+    context = result.get("context") or ""
+    answer = result.get("answer") or ""
+    doc_id = str(query_row.get("id") or "")
+    hit = contains_gold(context, gold) or (doc_id and doc_id in context)
+    faithful = contains_gold(answer, gold)
+    return {
+        "id": query_row["id"],
+        "query": query_row["query"],
+        "arm": arm,
+        "moss_retrieval_ms": result.get("moss_retrieval_ms"),
+        "moss_wall_ms": result.get("moss_wall_ms"),
+        "hit": bool(hit),
+        "faithful": bool(faithful),
+        "tool_called": bool(result.get("tool_called")),
+        "answer": answer,
+    }
+
+
+def render_table(rows: list[dict[str, Any]]) -> str:
+    header = (
+        "| query | arm | moss_retrieval_ms | moss_wall_ms | hit | faithful | tool_called |"
+    )
+    sep = "| --- | --- | ---: | ---: | --- | --- | --- |"
+    lines = [header, sep]
+    for row in rows:
+        lines.append(
+            "| {query} | {arm} | {retr} | {wall} | {hit} | {faithful} | {tool} |".format(
+                query=row["query"],
+                arm=row["arm"],
+                retr=format_ms(row["moss_retrieval_ms"]),
+                wall=format_ms(row["moss_wall_ms"]),
+                hit=_yes(row["hit"]),
+                faithful=_yes(row["faithful"]),
+                tool=_yes(row["tool_called"]) if row["arm"] == "tool" else "-",
+            )
+        )
+    return "\n".join(lines)
+
+
+def render_summary(rows: list[dict[str, Any]]) -> str:
+    lines = ["", "### Summary"]
+    for arm in ARMS:
+        arm_rows = [r for r in rows if r["arm"] == arm]
+        searched = [
+            r["moss_retrieval_ms"]
+            for r in arm_rows
+            if r["moss_retrieval_ms"] is not None
+        ]
+        n = len(arm_rows)
+        faithful = sum(1 for r in arm_rows if r["faithful"])
+        hits = sum(1 for r in arm_rows if r["hit"])
+        tool_called = sum(1 for r in arm_rows if r["tool_called"])
+        lines.append(f"**{arm}** ({n} queries)")
+        lines.append(f"- hit: {hits}/{n}")
+        lines.append(f"- faithful: {faithful}/{n}")
+        if arm == "tool":
+            lines.append(f"- tool_called: {tool_called}/{n}")
+        if searched:
+            mean = statistics.fmean(searched)
+            p50 = percentile(searched, 0.50)
+            p95 = percentile(searched, 0.95)
+            lines.append(
+                f"- moss_retrieval_ms mean/p50/p95: "
+                f"{format_ms(mean)} / {format_ms(p50)} / {format_ms(p95)}"
+            )
+        else:
+            lines.append("- moss_retrieval_ms mean/p50/p95: n/a (no SDK timings)")
+    return "\n".join(lines)
+
+
+async def open_moss_search() -> MossSearch | None:
+    project_id = os.environ.get("MOSS_PROJECT_ID", "").strip()
+    project_key = os.environ.get("MOSS_PROJECT_KEY", "").strip()
+    index_name = os.environ.get("MOSS_INDEX_NAME", "").strip()
+    if not (project_id and project_key and index_name):
+        return None
+    try:
+        from ten_moss import MossSessionManager
+    except ImportError:
+        return None
+    session = MossSessionManager(
+        project_id=project_id,
+        project_key=project_key,
+        index_name=index_name,
+        model_id=os.environ.get("MOSS_MODEL_ID", "moss-minilm"),
+        top_k=3,
+        alpha=0.8,
+    )
+    try:
+        await session.open()
+    except Exception as exc:  # noqa: BLE001
+        print(f"warning: Moss session failed to open ({exc}); using local corpus", file=sys.stderr)
+        return None
+    return MossSearch(session)
+
+
+async def run_bench(*, echo_grounding: bool, json_out: Path | None) -> list[dict[str, Any]]:
+    if not echo_grounding:
+        raise SystemExit("This slice ships --echo-grounding only. A live LLM arm is follow-up.")
+    queries = load_queries()
+    moss = await open_moss_search()
+    if moss is not None:
+        search: SearchFn = moss.search
+        backend = "moss"
+    else:
+        search = LocalCorpusSearch(load_knowledge(), queries).search
+        backend = "local-corpus"
+        print(
+            "note: no Moss session (set MOSS_PROJECT_ID / MOSS_PROJECT_KEY / "
+            "MOSS_INDEX_NAME to measure moss_retrieval_ms). Using local corpus.",
+            file=sys.stderr,
+        )
+
+    rows: list[dict[str, Any]] = []
+    for query_row in queries:
+        for arm in ARMS:
+            result = await echo_answer(
+                arm=arm,
+                query=query_row["query"],
+                search=search,
+                always_call_tool=True,
+            )
+            scored = score_row(query_row, result, arm)
+            scored["backend"] = backend
+            rows.append(scored)
+
+    table = render_table(rows)
+    summary = render_summary(rows)
+    print(table)
+    print(summary)
+    if json_out is not None:
+        json_out.write_text(json.dumps(rows, indent=2) + "\n")
+        print(f"\nwrote {json_out}")
+    return rows
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--echo-grounding",
+        action="store_true",
+        help="Zero-LLM smoke: ambient/tool answers are the retrieved block.",
+    )
+    parser.add_argument(
+        "--json",
+        type=Path,
+        default=None,
+        help="Optional path to write the per-row JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    if not args.echo_grounding:
+        raise SystemExit("pass --echo-grounding (zero-LLM smoke is the required gate)")
+    asyncio.run(run_bench(echo_grounding=True, json_out=args.json))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/ten-moss/bench/test_run.py
+++ b/apps/ten-moss/bench/test_run.py
@@ -1,0 +1,164 @@
+"""Unit tests for the offline bench. No Moss creds, no LLM keys."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from run import (
+    LocalCorpusSearch,
+    contains_gold,
+    echo_answer,
+    load_queries,
+    render_table,
+    run_bench,
+    score_row,
+)
+
+
+def test_queries_cover_ten_faqs() -> None:
+    rows = load_queries()
+    assert len(rows) == 10
+    ids = [r["id"] for r in rows]
+    assert ids == [f"kb-{i}" for i in range(1, 11)]
+    assert rows[0]["query"] == "How long do refunds take?"
+    assert "3-5" in rows[0]["gold"]
+    assert "Visa" in rows[5]["gold"]
+
+
+def test_contains_gold_any_phrase() -> None:
+    assert contains_gold("We accept Visa and cash", ["Visa", "PayPal", "Apple Pay"])
+    assert not contains_gold("we take cash only", ["Visa", "PayPal", "Apple Pay"])
+
+
+@pytest.mark.asyncio
+async def test_echo_grounding_scores_three_arms() -> None:
+    grounding = "Relevant knowledge from Moss:\n\n[1] Refunds are processed within 3-5 business days."
+
+    async def search(query: str):
+        return grounding, 2.0, 8.0
+
+    query = {
+        "id": "kb-1",
+        "query": "How long do refunds take?",
+        "gold": ["3-5"],
+    }
+    ambient = score_row(
+        query,
+        await echo_answer(arm="ambient", query=query["query"], search=search, always_call_tool=True),
+        "ambient",
+    )
+    tool = score_row(
+        query,
+        await echo_answer(arm="tool", query=query["query"], search=search, always_call_tool=True),
+        "tool",
+    )
+    none = score_row(
+        query,
+        await echo_answer(arm="no-moss", query=query["query"], search=search, always_call_tool=True),
+        "no-moss",
+    )
+    assert ambient["hit"] and ambient["faithful"]
+    assert tool["hit"] and tool["faithful"] and tool["tool_called"]
+    assert not none["hit"] and not none["faithful"]
+    assert none["moss_retrieval_ms"] is None
+
+
+@pytest.mark.asyncio
+async def test_moss_error_fail_open() -> None:
+    async def boom(query: str):
+        raise RuntimeError("timeout")
+
+    # echo_answer itself should not raise; MossSearch catches. Simulate empty.
+    result = await echo_answer(
+        arm="ambient",
+        query="How long do refunds take?",
+        search=AsyncMock(return_value=("", None, None)),
+        always_call_tool=True,
+    )
+    scored = score_row(
+        {"id": "kb-1", "query": "q", "gold": ["3-5"]},
+        result,
+        "ambient",
+    )
+    assert scored["hit"] is False
+    assert scored["faithful"] is False
+    _ = boom  # kept so a later mutation can swap search=boom and expect no raise
+
+
+@pytest.mark.asyncio
+async def test_echo_answer_swallows_search_error_via_wrapper() -> None:
+    from run import MossSearch
+
+    class Broken:
+        last_time_taken_ms = None
+
+        async def query_context(self, text: str) -> str:
+            raise TimeoutError("nope")
+
+    result = await MossSearch(Broken()).search("How long do refunds take?")
+    assert result[0] == ""
+
+
+@pytest.mark.asyncio
+async def test_run_echo_grounding_prints_table(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    rows = await run_bench(echo_grounding=True, json_out=tmp_path / "out.json")
+    assert len(rows) == 30  # 10 queries x 3 arms
+    out = capsys.readouterr().out
+    assert "| query | arm |" in out
+    assert "How long do refunds take?" in out
+    assert "### Summary" in out
+    saved = json.loads((tmp_path / "out.json").read_text())
+    assert len(saved) == 30
+
+
+@pytest.mark.asyncio
+async def test_local_corpus_hits_refunds() -> None:
+    from run import load_knowledge
+
+    block, sdk, wall = await LocalCorpusSearch(load_knowledge(), load_queries()).search(
+        "How long do refunds take?"
+    )
+    assert "3-5" in block
+    assert sdk is None and wall is None
+
+
+def test_render_table_includes_all_arms() -> None:
+    table = render_table(
+        [
+            {
+                "query": "q",
+                "arm": "ambient",
+                "moss_retrieval_ms": 2,
+                "moss_wall_ms": 9,
+                "hit": True,
+                "faithful": True,
+                "tool_called": False,
+            },
+            {
+                "query": "q",
+                "arm": "tool",
+                "moss_retrieval_ms": 2,
+                "moss_wall_ms": 9,
+                "hit": True,
+                "faithful": True,
+                "tool_called": True,
+            },
+            {
+                "query": "q",
+                "arm": "no-moss",
+                "moss_retrieval_ms": None,
+                "moss_wall_ms": None,
+                "hit": False,
+                "faithful": False,
+                "tool_called": False,
+            },
+        ]
+    )
+    assert "ambient" in table and "tool" in table and "no-moss" in table

--- a/apps/ten-moss/bench/test_run.py
+++ b/apps/ten-moss/bench/test_run.py
@@ -5,28 +5,26 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from unittest.mock import AsyncMock
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from run import (
-    LocalCorpusSearch,
     contains_gold,
-    echo_answer,
     load_queries,
+    lookup_faq,
+    query_moss,
     render_table,
     run_bench,
-    score_row,
+    run_one,
 )
 
 
 def test_queries_cover_ten_faqs() -> None:
     rows = load_queries()
     assert len(rows) == 10
-    ids = [r["id"] for r in rows]
-    assert ids == [f"kb-{i}" for i in range(1, 11)]
+    assert [r["id"] for r in rows] == [f"kb-{i}" for i in range(1, 11)]
     assert rows[0]["query"] == "How long do refunds take?"
     assert "3-5" in rows[0]["gold"]
     assert "Visa" in rows[5]["gold"]
@@ -38,95 +36,55 @@ def test_contains_gold_any_phrase() -> None:
 
 
 @pytest.mark.asyncio
-async def test_echo_grounding_scores_three_arms() -> None:
-    grounding = "Relevant knowledge from Moss:\n\n[1] Refunds are processed within 3-5 business days."
-
-    async def search(query: str):
-        return grounding, 2.0, 8.0
-
-    query = {
-        "id": "kb-1",
-        "query": "How long do refunds take?",
-        "gold": ["3-5"],
-    }
-    ambient = score_row(
-        query,
-        await echo_answer(arm="ambient", query=query["query"], search=search, always_call_tool=True),
-        "ambient",
-    )
-    tool = score_row(
-        query,
-        await echo_answer(arm="tool", query=query["query"], search=search, always_call_tool=True),
-        "tool",
-    )
-    none = score_row(
-        query,
-        await echo_answer(arm="no-moss", query=query["query"], search=search, always_call_tool=True),
-        "no-moss",
-    )
+async def test_three_arms_with_echo() -> None:
+    queries = load_queries()
+    docs = [{"id": "kb-1", "text": "Refunds are processed within 3-5 business days."}]
+    query = "How long do refunds take?"
+    gold = ["3-5"]
+    ambient = await run_one("ambient", query, gold, "kb-1", None, queries, docs)
+    tool = await run_one("tool", query, gold, "kb-1", None, queries, docs)
+    none = await run_one("no-moss", query, gold, "kb-1", None, queries, docs)
     assert ambient["hit"] and ambient["faithful"]
     assert tool["hit"] and tool["faithful"] and tool["tool_called"]
     assert not none["hit"] and not none["faithful"]
-    assert none["moss_retrieval_ms"] is None
 
 
 @pytest.mark.asyncio
-async def test_moss_error_fail_open() -> None:
-    async def boom(query: str):
-        raise RuntimeError("timeout")
-
-    # echo_answer itself should not raise; MossSearch catches. Simulate empty.
-    result = await echo_answer(
-        arm="ambient",
-        query="How long do refunds take?",
-        search=AsyncMock(return_value=("", None, None)),
-        always_call_tool=True,
-    )
-    scored = score_row(
-        {"id": "kb-1", "query": "q", "gold": ["3-5"]},
-        result,
-        "ambient",
-    )
-    assert scored["hit"] is False
-    assert scored["faithful"] is False
-    _ = boom  # kept so a later mutation can swap search=boom and expect no raise
-
-
-@pytest.mark.asyncio
-async def test_echo_answer_swallows_search_error_via_wrapper() -> None:
-    from run import MossSearch
-
+async def test_query_moss_fail_open() -> None:
     class Broken:
         last_time_taken_ms = None
 
         async def query_context(self, text: str) -> str:
             raise TimeoutError("nope")
 
-    result = await MossSearch(Broken()).search("How long do refunds take?")
-    assert result[0] == ""
+    context, sdk_ms, _wall = await query_moss(Broken(), "How long do refunds take?")
+    assert context == ""
+    assert sdk_ms is None
 
 
 @pytest.mark.asyncio
-async def test_run_echo_grounding_prints_table(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
-    rows = await run_bench(echo_grounding=True, json_out=tmp_path / "out.json")
-    assert len(rows) == 30  # 10 queries x 3 arms
+async def test_run_echo_grounding_prints_table(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    rows = await run_bench(json_out=tmp_path / "out.json")
+    assert len(rows) == 30
     out = capsys.readouterr().out
     assert "| query | arm |" in out
     assert "How long do refunds take?" in out
     assert "### Summary" in out
-    saved = json.loads((tmp_path / "out.json").read_text())
-    assert len(saved) == 30
+    assert len(json.loads((tmp_path / "out.json").read_text())) == 30
 
 
-@pytest.mark.asyncio
-async def test_local_corpus_hits_refunds() -> None:
-    from run import load_knowledge
-
-    block, sdk, wall = await LocalCorpusSearch(load_knowledge(), load_queries()).search(
-        "How long do refunds take?"
-    )
+def test_lookup_faq_hits_refunds() -> None:
+    queries = load_queries()
+    docs = [
+        {
+            "id": "kb-1",
+            "text": "Refunds are processed within 3-5 business days once the return is approved.",
+        }
+    ]
+    block = lookup_faq("How long do refunds take?", queries, docs)
     assert "3-5" in block
-    assert sdk is None and wall is None
 
 
 def test_render_table_includes_all_arms() -> None:

--- a/apps/ten-moss/bench/test_run.py
+++ b/apps/ten-moss/bench/test_run.py
@@ -26,7 +26,9 @@ def test_queries_cover_ten_faqs() -> None:
     assert len(rows) == 10
     assert [r["id"] for r in rows] == [f"kb-{i}" for i in range(1, 11)]
     assert rows[0]["query"] == "How long do refunds take?"
-    assert "3-5" in rows[0]["gold"]
+    assert "Refunds are processed" in rows[0]["gold"]
+    assert "Standard shipping" in rows[3]["gold"]
+    assert rows[0]["gold"] != rows[3]["gold"]
     assert "Visa" in rows[5]["gold"]
 
 
@@ -40,7 +42,7 @@ async def test_three_arms_with_echo() -> None:
     queries = load_queries()
     docs = [{"id": "kb-1", "text": "Refunds are processed within 3-5 business days."}]
     query = "How long do refunds take?"
-    gold = ["3-5"]
+    gold = ["Refunds are processed"]
     ambient = await run_one("ambient", query, gold, "kb-1", None, queries, docs)
     tool = await run_one("tool", query, gold, "kb-1", None, queries, docs)
     none = await run_one("no-moss", query, gold, "kb-1", None, queries, docs)
@@ -63,8 +65,36 @@ async def test_query_moss_fail_open() -> None:
 
 
 @pytest.mark.asyncio
+async def test_hit_requires_gold_phrase_not_doc_id() -> None:
+    class IdOnly:
+        last_time_taken_ms = 1
+
+        async def query_context(self, text: str) -> str:
+            return "kb-1"
+
+    row = await run_one(
+        "ambient",
+        "How long do refunds take?",
+        ["Refunds are processed"],
+        "kb-1",
+        IdOnly(),
+        [],
+        [],
+    )
+    assert row["hit"] is False
+    assert row["faithful"] is False
+
+
+@pytest.fixture
+def offline_moss(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("run.load_dotenv", lambda *_a, **_k: False)
+    for key in ("MOSS_PROJECT_ID", "MOSS_PROJECT_KEY", "MOSS_INDEX_NAME", "MOSS_MODEL_ID"):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.mark.asyncio
 async def test_run_echo_grounding_prints_table(
-    capsys: pytest.CaptureFixture[str], tmp_path: Path
+    capsys: pytest.CaptureFixture[str], tmp_path: Path, offline_moss
 ) -> None:
     rows = await run_bench(json_out=tmp_path / "out.json")
     assert len(rows) == 30

--- a/apps/ten-moss/create_index.py
+++ b/apps/ten-moss/create_index.py
@@ -40,7 +40,8 @@ async def main() -> None:
     index_name = os.environ["MOSS_INDEX_NAME"]
     docs = load_documents()
     print(f"Creating index '{index_name}' with {len(docs)} documents...")
-    await client.create_index(name=index_name, docs=docs, model_id="moss-minilm")
+    model_id = os.getenv("MOSS_MODEL_ID", "moss-minilm")
+    await client.create_index(name=index_name, docs=docs, model_id=model_id)
     print("Done.")
 
 

--- a/apps/ten-moss/pytest.ini
+++ b/apps/ten-moss/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests bench

--- a/apps/ten-moss/setup.sh
+++ b/apps/ten-moss/setup.sh
@@ -53,5 +53,6 @@ Next, from that directory (inside TEN's dev container, or with TEN tooling
 installed locally):
   task install && task run
 
-Then open http://localhost:3000 and select the voice_assistant graph.
+Then open http://localhost:3000. Default graph is voice_assistant (ambient).
+Tool-call graph: http://localhost:3000?graph=voice_assistant_tools
 EOF

--- a/apps/ten-moss/tenapp/property.json
+++ b/apps/ten-moss/tenapp/property.json
@@ -178,6 +178,185 @@
             }
           ]
         }
+      },
+      {
+        "name": "voice_assistant_tools",
+        "auto_start": false,
+        "graph": {
+          "nodes": [
+            {
+              "type": "extension",
+              "name": "agora_rtc",
+              "addon": "agora_rtc",
+              "extension_group": "default",
+              "property": {
+                "app_id": "${env:AGORA_APP_ID}",
+                "app_certificate": "${env:AGORA_APP_CERTIFICATE|}",
+                "channel": "ten_agent_test",
+                "stream_id": 1234,
+                "remote_stream_id": 123,
+                "subscribe_audio": true,
+                "publish_audio": true,
+                "publish_data": true,
+                "enable_agora_asr": false,
+                "agora_asr_vendor_name": "microsoft",
+                "agora_asr_language": "en-US",
+                "agora_asr_vendor_key": "${env:AZURE_STT_KEY|}",
+                "agora_asr_vendor_region": "${env:AZURE_STT_REGION|}",
+                "agora_asr_session_control_file_path": "session_control.conf"
+              }
+            },
+            {
+              "type": "extension",
+              "name": "stt",
+              "addon": "deepgram_asr_python",
+              "extension_group": "stt",
+              "property": {
+                "params": {
+                  "api_key": "${env:DEEPGRAM_API_KEY}",
+                  "language": "en-US",
+                  "model": "nova-3"
+                }
+              }
+            },
+            {
+              "type": "extension",
+              "name": "llm",
+              "addon": "openai_llm2_python",
+              "extension_group": "chatgpt",
+              "property": {
+                "base_url": "https://api.openai.com/v1",
+                "api_key": "${env:OPENAI_API_KEY}",
+                "frequency_penalty": 0.9,
+                "model": "${env:OPENAI_MODEL}",
+                "max_tokens": 512,
+                "prompt": "You are a helpful customer-support voice assistant. Use the search_knowledge_base tool to look up product facts before you answer. Keep every reply short and conversational - one or two sentences, the way you would say it out loud. Do not use lists, numbered steps, bullet points, markdown, or headings; give the direct answer, not a how-to guide. If the tool does not cover the question, briefly say you are not sure.",
+                "proxy_url": "${env:OPENAI_PROXY_URL|}",
+                "greeting": "TEN Agent connected. How can I help you today?",
+                "max_memory_length": 10
+              }
+            },
+            {
+              "type": "extension",
+              "name": "tts",
+              "addon": "elevenlabs_tts2_python",
+              "extension_group": "tts",
+              "property": {
+                "dump": false,
+                "dump_path": "./",
+                "params": {
+                  "key": "${env:ELEVENLABS_TTS_KEY}",
+                  "model_id": "eleven_multilingual_v2",
+                  "voice_id": "pNInz6obpgDQGcFmaJgB",
+                  "output_format": "pcm_16000"
+                }
+              }
+            },
+            {
+              "type": "extension",
+              "name": "main_control",
+              "addon": "main_python",
+              "extension_group": "control",
+              "property": {
+                "greeting": "Hello, I am your Moss-powered AI assistant.",
+                "moss_project_id": "${env:MOSS_PROJECT_ID}",
+                "moss_project_key": "${env:MOSS_PROJECT_KEY}",
+                "moss_index_name": "${env:MOSS_INDEX_NAME}",
+                "moss_model_id": "moss-minilm",
+                "moss_top_k": 3,
+                "moss_alpha": 0.8,
+                "moss_context_header": "Relevant knowledge from Moss:",
+                "enable_moss": true,
+                "moss_mode": "tool"
+              }
+            },
+            {
+              "type": "extension",
+              "name": "message_collector",
+              "addon": "message_collector2",
+              "extension_group": "transcriber",
+              "property": {}
+            },
+            {
+              "type": "extension",
+              "name": "streamid_adapter",
+              "addon": "streamid_adapter",
+              "property": {}
+            }
+          ],
+          "connections": [
+            {
+              "extension": "main_control",
+              "cmd": [
+                {
+                  "names": [
+                    "on_user_joined",
+                    "on_user_left"
+                  ],
+                  "source": [
+                    {
+                      "extension": "agora_rtc"
+                    }
+                  ]
+                }
+              ],
+              "data": [
+                {
+                  "name": "asr_result",
+                  "source": [
+                    {
+                      "extension": "stt"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "extension": "agora_rtc",
+              "audio_frame": [
+                {
+                  "name": "pcm_frame",
+                  "dest": [
+                    {
+                      "extension": "streamid_adapter"
+                    }
+                  ]
+                },
+                {
+                  "name": "pcm_frame",
+                  "source": [
+                    {
+                      "extension": "tts"
+                    }
+                  ]
+                }
+              ],
+              "data": [
+                {
+                  "name": "data",
+                  "source": [
+                    {
+                      "extension": "message_collector"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "extension": "streamid_adapter",
+              "audio_frame": [
+                {
+                  "name": "pcm_frame",
+                  "dest": [
+                    {
+                      "extension": "stt"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
       }
     ],
     "log": {

--- a/apps/ten-moss/tenapp/ten_packages/extension/main_python/config.py
+++ b/apps/ten-moss/tenapp/ten_packages/extension/main_python/config.py
@@ -4,7 +4,5 @@ from ten_moss import MossSessionConfig
 
 
 class MainControlConfig(MossSessionConfig):
-    """Moss session fields (moss_*) plus greeting and moss_mode."""
-
     greeting: str = "Hello, I am your AI assistant."
     moss_mode: Literal["ambient", "tool"] = "ambient"

--- a/apps/ten-moss/tenapp/ten_packages/extension/main_python/config.py
+++ b/apps/ten-moss/tenapp/ten_packages/extension/main_python/config.py
@@ -2,19 +2,9 @@ from typing import Literal
 
 from ten_moss import MossSessionConfig
 
-MOSS_MODE_AMBIENT = "ambient"
-MOSS_MODE_TOOL = "tool"
-
-
-def moss_mode_prepends_on_asr(moss_mode: str) -> bool:
-    """Ambient prepends Moss grounding on ASR-final. Tool mode does not."""
-    return moss_mode != MOSS_MODE_TOOL
-
 
 class MainControlConfig(MossSessionConfig):
-    """Main control config: Moss session fields (moss_*) plus the agent greeting."""
+    """Moss session fields (moss_*) plus greeting and moss_mode."""
 
     greeting: str = "Hello, I am your AI assistant."
-    # ambient (default): search on every ASR-final and prepend.
-    # tool: register search_knowledge_base; the LLM decides when to search.
-    moss_mode: Literal["ambient", "tool"] = MOSS_MODE_AMBIENT
+    moss_mode: Literal["ambient", "tool"] = "ambient"

--- a/apps/ten-moss/tenapp/ten_packages/extension/main_python/config.py
+++ b/apps/ten-moss/tenapp/ten_packages/extension/main_python/config.py
@@ -1,7 +1,20 @@
+from typing import Literal
+
 from ten_moss import MossSessionConfig
+
+MOSS_MODE_AMBIENT = "ambient"
+MOSS_MODE_TOOL = "tool"
+
+
+def moss_mode_prepends_on_asr(moss_mode: str) -> bool:
+    """Ambient prepends Moss grounding on ASR-final. Tool mode does not."""
+    return moss_mode != MOSS_MODE_TOOL
 
 
 class MainControlConfig(MossSessionConfig):
     """Main control config: Moss session fields (moss_*) plus the agent greeting."""
 
     greeting: str = "Hello, I am your AI assistant."
+    # ambient (default): search on every ASR-final and prepend.
+    # tool: register search_knowledge_base; the LLM decides when to search.
+    moss_mode: Literal["ambient", "tool"] = MOSS_MODE_AMBIENT

--- a/apps/ten-moss/tenapp/ten_packages/extension/main_python/extension.py
+++ b/apps/ten-moss/tenapp/ten_packages/extension/main_python/extension.py
@@ -94,7 +94,7 @@ class MainControlExtension(AsyncExtension):
             if event_type:
                 self.agent.on(event_type, fn)
 
-        if self.config.moss_mode == "tool" and self.moss is not None:
+        if self.config.moss_mode == "tool":
             await self._register_search_knowledge_base()
 
     # === Register handlers with decorators ===

--- a/apps/ten-moss/tenapp/ten_packages/extension/main_python/extension.py
+++ b/apps/ten-moss/tenapp/ten_packages/extension/main_python/extension.py
@@ -7,7 +7,9 @@ from ten_runtime import (
     AsyncExtension,
     AsyncTenEnv,
     Cmd,
+    CmdResult,
     Data,
+    StatusCode,
 )
 
 from .agent.agent import Agent
@@ -19,11 +21,19 @@ from .agent.events import (
     UserLeftEvent,
 )
 from .helper import _send_cmd, _send_data, parse_sentences
-from .config import MainControlConfig  # assume extracted from your base model
+from .config import (
+    MOSS_MODE_TOOL,
+    MainControlConfig,
+    moss_mode_prepends_on_asr,
+)
 
 from ten_moss import MossSessionManager
+from ten_ai_base.const import CMD_PROPERTY_RESULT
+from ten_ai_base.types import LLMToolMetadata, LLMToolMetadataParameter
 
 import uuid
+
+SEARCH_KNOWLEDGE_BASE = "search_knowledge_base"
 
 
 class MainControlExtension(AsyncExtension):
@@ -88,6 +98,11 @@ class MainControlExtension(AsyncExtension):
             if event_type:
                 self.agent.on(event_type, fn)
 
+        # Tool graph only: advertise search_knowledge_base to the LLM and
+        # handle tool_call on this extension (no new TEN extension, no MCP hop).
+        if self.config.moss_mode == MOSS_MODE_TOOL and self.moss is not None:
+            await self._register_search_knowledge_base()
+
     # === Register handlers with decorators ===
     @agent_event_handler(UserJoinedEvent)
     async def _on_user_joined(self, event: UserJoinedEvent):
@@ -126,31 +141,10 @@ class MainControlExtension(AsyncExtension):
             self._last_grounding = ""
             self._last_sdk_ms = None
             llm_input = event.text
-            if self.moss is not None:
-                # query_context is designed not to raise, but guard anyway so a
-                # grounding failure can never drop the user's turn.
-                try:
-                    t0 = time.perf_counter()
-                    context = await self.moss.query_context(event.text)
-                    took_ms = (time.perf_counter() - t0) * 1000.0
-                    # The SDK reports the engine retrieval time on the result
-                    # object (SearchResult.time_taken_ms), surfaced by ten-moss as
-                    # `last_time_taken_ms`. Prefer it; fall back to wall-clock.
-                    sdk_ms = getattr(self.moss, "last_time_taken_ms", None)
-                    self._retrieval_ms = float(sdk_ms) if sdk_ms is not None else took_ms
-                    self._last_grounding = context
-                    self._last_sdk_ms = sdk_ms
-                    backend = "moss(in-process)"
-                    # Shared tag so this lines up 1:1 with the instrumented memU
-                    # example — grep '[retrieval-latency]' in both agents' logs.
-                    self.ten_env.log_info(
-                        f"[retrieval-latency] backend={backend} time_taken_ms={sdk_ms} (wall_clock={took_ms:.0f}ms)"
-                    )
-                except Exception as exc:  # noqa: BLE001
-                    context = ""
-                    self.ten_env.log_error(
-                        f"[MainControlExtension] Moss grounding failed: {exc}"
-                    )
+            if self.moss is not None and moss_mode_prepends_on_asr(
+                self.config.moss_mode
+            ):
+                context = await self._query_moss(event.text)
                 if context:
                     llm_input = f"{context}\n\n[Current User Question]\n{event.text}"
             # Mark the LLM dispatch time so we can measure time-to-first-token.
@@ -158,7 +152,11 @@ class MainControlExtension(AsyncExtension):
             self._llm_first_at = None
             await self.agent.queue_llm_input(llm_input)
         await self._send_transcript("user", event.text, event.final, stream_id)
-        if event.final and self.moss is not None:
+        if (
+            event.final
+            and self.moss is not None
+            and moss_mode_prepends_on_asr(self.config.moss_mode)
+        ):
             # After the user's turn is shown, surface what Moss retrieved + the SDK time.
             await self._send_retrieval_note(self._last_grounding, self._last_sdk_ms)
 
@@ -202,12 +200,98 @@ class MainControlExtension(AsyncExtension):
         await self.agent.stop()
 
     async def on_cmd(self, ten_env: AsyncTenEnv, cmd: Cmd):
+        if cmd.get_name() == "tool_call":
+            await self._on_tool_call(cmd)
+            return
         await self.agent.on_cmd(cmd)
 
     async def on_data(self, ten_env: AsyncTenEnv, data: Data):
         await self.agent.on_data(data)
 
     # === helpers ===
+    async def _register_search_knowledge_base(self) -> None:
+        tool = LLMToolMetadata(
+            name=SEARCH_KNOWLEDGE_BASE,
+            description=(
+                "Search the knowledge base for facts that answer the user's "
+                "question. Pass a focused natural-language query."
+            ),
+            parameters=[
+                LLMToolMetadataParameter(
+                    name="query",
+                    type="string",
+                    description="The user's question or a focused search query.",
+                    required=True,
+                ),
+            ],
+        )
+        # Source is this graph node so llm_exec routes tool_call back here.
+        await self.agent.register_llm_tool(tool, "main_control")
+        self.ten_env.log_info(
+            "[MainControlExtension] registered tool search_knowledge_base"
+        )
+
+    async def _on_tool_call(self, cmd: Cmd) -> None:
+        """Run search_knowledge_base in-process. Fail open: empty content."""
+        try:
+            raw, _ = cmd.get_property_to_json(None)
+            payload = json.loads(raw) if raw else {}
+        except Exception as exc:  # noqa: BLE001
+            self.ten_env.log_error(
+                f"[MainControlExtension] tool_call payload unreadable: {exc}"
+            )
+            payload = {}
+        name = payload.get("name") or ""
+        arguments = payload.get("arguments") or payload.get("args") or {}
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                arguments = {"query": arguments}
+        query = ""
+        if isinstance(arguments, dict):
+            query = str(arguments.get("query") or "")
+
+        grounding = ""
+        if name == SEARCH_KNOWLEDGE_BASE:
+            grounding = await self._query_moss(query)
+            await self._send_retrieval_note(self._last_grounding, self._last_sdk_ms)
+        else:
+            self.ten_env.log_error(
+                f"[MainControlExtension] unknown tool_call name={name!r}"
+            )
+
+        result = CmdResult.create(StatusCode.OK, cmd)
+        result.set_property_from_json(
+            CMD_PROPERTY_RESULT,
+            json.dumps({"type": "llmresult", "content": grounding or ""}),
+        )
+        await self.ten_env.return_result(result)
+
+    async def _query_moss(self, user_text: str) -> str:
+        """query_context wrapper: log retrieval-latency, never raise."""
+        if self.moss is None:
+            return ""
+        try:
+            t0 = time.perf_counter()
+            context = await self.moss.query_context(user_text)
+            took_ms = (time.perf_counter() - t0) * 1000.0
+            # SearchResult.time_taken_ms, surfaced by ten-moss as last_time_taken_ms.
+            sdk_ms = getattr(self.moss, "last_time_taken_ms", None)
+            self._retrieval_ms = float(sdk_ms) if sdk_ms is not None else took_ms
+            self._last_grounding = context
+            self._last_sdk_ms = sdk_ms
+            self.ten_env.log_info(
+                f"[retrieval-latency] backend=moss(in-process) "
+                f"time_taken_ms={sdk_ms} (wall_clock={took_ms:.0f}ms)"
+            )
+            return context
+        except Exception as exc:  # noqa: BLE001
+            self.ten_env.log_error(
+                f"[MainControlExtension] Moss grounding failed: {exc}"
+            )
+            return ""
+
     async def _log_latency_breakdown(self):
         """Per-turn latency breakdown for onboarding/debugging.
 

--- a/apps/ten-moss/tenapp/ten_packages/extension/main_python/extension.py
+++ b/apps/ten-moss/tenapp/ten_packages/extension/main_python/extension.py
@@ -33,10 +33,6 @@ SEARCH_KNOWLEDGE_BASE = "search_knowledge_base"
 
 
 class MainControlExtension(AsyncExtension):
-    """
-    The entry point of the agent module.
-    Consumes semantic AgentEvents from the Agent class and drives the runtime behavior.
-    """
 
     def __init__(self, name: str):
         super().__init__(name)
@@ -51,9 +47,6 @@ class MainControlExtension(AsyncExtension):
         self.turn_id: int = 0
         self.session_id: str = "0"
 
-        # Per-turn latency breakdown (see _log_latency_breakdown). main_control
-        # orchestrates retrieval -> LLM -> TTS, so it can time those stages; ASR
-        # timing lives in the STT extension logs and TTS audio-out in the TTS logs.
         self._turn_t0: float | None = None
         self._retrieval_ms: float | None = None
         self._llm_sent_at: float | None = None
@@ -67,12 +60,9 @@ class MainControlExtension(AsyncExtension):
     async def on_init(self, ten_env: AsyncTenEnv):
         self.ten_env = ten_env
 
-        # Load config from runtime properties
         config_json, _ = await ten_env.get_property_to_json(None)
         self.config = MainControlConfig.model_validate_json(config_json)
 
-        # Open a Moss session for ambient, session-scoped grounding (best-effort:
-        # if the session can't open, the agent still runs, just without grounding).
         self.moss = None
         if self.config.enable_moss and self.config.moss_index_name:
             try:
@@ -87,7 +77,6 @@ class MainControlExtension(AsyncExtension):
 
         self.agent = Agent(ten_env)
 
-        # Now auto-register decorated methods
         for attr_name in dir(self):
             fn = getattr(self, attr_name)
             event_type = getattr(fn, "_agent_event_type", None)
@@ -97,7 +86,6 @@ class MainControlExtension(AsyncExtension):
         if self.config.moss_mode == "tool":
             await self._register_search_knowledge_base()
 
-    # === Register handlers with decorators ===
     @agent_event_handler(UserJoinedEvent)
     async def _on_user_joined(self, event: UserJoinedEvent):
         self._rtc_user_count += 1
@@ -118,8 +106,6 @@ class MainControlExtension(AsyncExtension):
     @agent_event_handler(ASRResultEvent)
     async def _on_asr_result(self, event: ASRResultEvent):
         self.session_id = event.metadata.get("session_id", "100")
-        # session_id is a string in the event schema; parse defensively so a
-        # non-numeric value can't crash the ASR handler and break the voice loop.
         try:
             stream_id = int(self.session_id)
         except (TypeError, ValueError):
@@ -130,13 +116,11 @@ class MainControlExtension(AsyncExtension):
             await self._interrupt()
         if event.final:
             self.turn_id += 1
-            self._turn_t0 = time.perf_counter()  # turn clock starts at ASR-final
+            self._turn_t0 = time.perf_counter()
             self._retrieval_ms = None
             self._last_grounding = ""
             self._last_sdk_ms = None
             llm_input = event.text
-            # Ambient searches here and prepends. Tool mode sends the raw
-            # transcript; the LLM calls search_knowledge_base if it needs facts.
             if self.moss is not None and self.config.moss_mode != "tool":
                 context = await self._query_moss(event.text)
                 if context:
@@ -150,7 +134,6 @@ class MainControlExtension(AsyncExtension):
 
     @agent_event_handler(LLMResponseEvent)
     async def _on_llm_response(self, event: LLMResponseEvent):
-        # First streamed token of this turn -> time-to-first-token.
         if (
             event.type == "message"
             and self._llm_first_at is None
@@ -196,7 +179,6 @@ class MainControlExtension(AsyncExtension):
     async def on_data(self, ten_env: AsyncTenEnv, data: Data):
         await self.agent.on_data(data)
 
-    # === helpers ===
     async def _register_search_knowledge_base(self) -> None:
         tool = LLMToolMetadata(
             name=SEARCH_KNOWLEDGE_BASE,
@@ -219,7 +201,6 @@ class MainControlExtension(AsyncExtension):
         )
 
     async def _on_tool_call(self, cmd: Cmd) -> None:
-        """search_knowledge_base: query_context, return empty on error."""
         try:
             raw, _ = cmd.get_property_to_json(None)
             payload = json.loads(raw) if raw else {}
@@ -256,7 +237,6 @@ class MainControlExtension(AsyncExtension):
         await self.ten_env.return_result(result)
 
     async def _query_moss(self, user_text: str) -> str:
-        """query_context + latency log. Never raise into the voice loop."""
         if self.moss is None:
             return ""
         try:
@@ -279,13 +259,6 @@ class MainControlExtension(AsyncExtension):
             return ""
 
     async def _log_latency_breakdown(self):
-        """Per-turn latency breakdown for onboarding/debugging.
-
-        Emits a grep-able log line ('[latency-breakdown]') and a reasoning note
-        in the transcript so users can see where each turn's time goes:
-        Moss retrieval, LLM time-to-first-token, and full LLM generation. (ASR
-        timing is in the STT extension logs; TTS audio-out in the TTS logs.)
-        """
         now = time.perf_counter()
 
         def _ms(v: float | None) -> str:
@@ -309,23 +282,18 @@ class MainControlExtension(AsyncExtension):
             f"⏱ turn {self.turn_id} · Moss {_ms(retrieval)} ms (time_taken_ms) · "
             f"LLM first token {_ms(ttft)} ms · LLM total {_ms(llm_total)} ms"
         )
-        # Own stream id (distinct from the answer's 100 and the retrieval note's).
         await self._send_transcript(
             "assistant", note, True, 710_000_000 + self.turn_id, data_type="reasoning"
         )
 
     async def _send_retrieval_note(self, grounding: str, time_taken_ms):
-        """Show what Moss retrieved this turn + the SDK's time_taken_ms, so users
-        see the retrieval *results* alongside the timing (the LLM answer follows
-        as its own transcript message)."""
         ms_txt = f"{time_taken_ms}" if time_taken_ms is not None else "n/a"
         body = (
             f"🔎 Moss · retrieved in {ms_txt} ms (SDK time_taken_ms)\n\n{grounding}"
             if grounding
             else f"🔎 Moss · retrieved in {ms_txt} ms (SDK time_taken_ms) — no match"
         )
-        # Own stream id so this note is a separate transcript item, not merged
-        # into (and replacing) the assistant answer bubble at stream_id 100.
+        # Distinct stream_id so this note is not merged into the answer bubble.
         await self._send_transcript(
             "assistant", body, True, 700_000_000 + self.turn_id, data_type="reasoning"
         )
@@ -338,9 +306,6 @@ class MainControlExtension(AsyncExtension):
         stream_id: int,
         data_type: Literal["text", "reasoning"] = "text",
     ):
-        """
-        Sends the transcript (ASR or LLM output) to the message collector.
-        """
         if data_type == "text":
             await _send_data(
                 self.ten_env,
@@ -381,9 +346,6 @@ class MainControlExtension(AsyncExtension):
         )
 
     async def _send_to_tts(self, text: str, is_final: bool):
-        """
-        Sends a sentence to the TTS system.
-        """
         request_id = f"tts-request-{self.turn_id}"
         await _send_data(
             self.ten_env,
@@ -401,9 +363,6 @@ class MainControlExtension(AsyncExtension):
         )
 
     async def _interrupt(self):
-        """
-        Interrupts ongoing LLM and TTS generation. Typically called when user speech is detected.
-        """
         self.sentence_fragment = ""
         await self.agent.flush_llm()
         await _send_data(

--- a/apps/ten-moss/tenapp/ten_packages/extension/main_python/extension.py
+++ b/apps/ten-moss/tenapp/ten_packages/extension/main_python/extension.py
@@ -21,11 +21,7 @@ from .agent.events import (
     UserLeftEvent,
 )
 from .helper import _send_cmd, _send_data, parse_sentences
-from .config import (
-    MOSS_MODE_TOOL,
-    MainControlConfig,
-    moss_mode_prepends_on_asr,
-)
+from .config import MainControlConfig
 
 from ten_moss import MossSessionManager
 from ten_ai_base.const import CMD_PROPERTY_RESULT
@@ -98,9 +94,7 @@ class MainControlExtension(AsyncExtension):
             if event_type:
                 self.agent.on(event_type, fn)
 
-        # Tool graph only: advertise search_knowledge_base to the LLM and
-        # handle tool_call on this extension (no new TEN extension, no MCP hop).
-        if self.config.moss_mode == MOSS_MODE_TOOL and self.moss is not None:
+        if self.config.moss_mode == "tool" and self.moss is not None:
             await self._register_search_knowledge_base()
 
     # === Register handlers with decorators ===
@@ -141,23 +135,17 @@ class MainControlExtension(AsyncExtension):
             self._last_grounding = ""
             self._last_sdk_ms = None
             llm_input = event.text
-            if self.moss is not None and moss_mode_prepends_on_asr(
-                self.config.moss_mode
-            ):
+            # Ambient searches here and prepends. Tool mode sends the raw
+            # transcript; the LLM calls search_knowledge_base if it needs facts.
+            if self.moss is not None and self.config.moss_mode != "tool":
                 context = await self._query_moss(event.text)
                 if context:
                     llm_input = f"{context}\n\n[Current User Question]\n{event.text}"
-            # Mark the LLM dispatch time so we can measure time-to-first-token.
             self._llm_sent_at = time.perf_counter()
             self._llm_first_at = None
             await self.agent.queue_llm_input(llm_input)
         await self._send_transcript("user", event.text, event.final, stream_id)
-        if (
-            event.final
-            and self.moss is not None
-            and moss_mode_prepends_on_asr(self.config.moss_mode)
-        ):
-            # After the user's turn is shown, surface what Moss retrieved + the SDK time.
+        if event.final and self.moss is not None and self.config.moss_mode != "tool":
             await self._send_retrieval_note(self._last_grounding, self._last_sdk_ms)
 
     @agent_event_handler(LLMResponseEvent)
@@ -225,14 +213,13 @@ class MainControlExtension(AsyncExtension):
                 ),
             ],
         )
-        # Source is this graph node so llm_exec routes tool_call back here.
         await self.agent.register_llm_tool(tool, "main_control")
         self.ten_env.log_info(
             "[MainControlExtension] registered tool search_knowledge_base"
         )
 
     async def _on_tool_call(self, cmd: Cmd) -> None:
-        """Run search_knowledge_base in-process. Fail open: empty content."""
+        """search_knowledge_base: query_context, return empty on error."""
         try:
             raw, _ = cmd.get_property_to_json(None)
             payload = json.loads(raw) if raw else {}
@@ -269,14 +256,13 @@ class MainControlExtension(AsyncExtension):
         await self.ten_env.return_result(result)
 
     async def _query_moss(self, user_text: str) -> str:
-        """query_context wrapper: log retrieval-latency, never raise."""
+        """query_context + latency log. Never raise into the voice loop."""
         if self.moss is None:
             return ""
         try:
             t0 = time.perf_counter()
             context = await self.moss.query_context(user_text)
             took_ms = (time.perf_counter() - t0) * 1000.0
-            # SearchResult.time_taken_ms, surfaced by ten-moss as last_time_taken_ms.
             sdk_ms = getattr(self.moss, "last_time_taken_ms", None)
             self._retrieval_ms = float(sdk_ms) if sdk_ms is not None else took_ms
             self._last_grounding = context

--- a/apps/ten-moss/tenapp/ten_packages/extension/main_python/extension.py
+++ b/apps/ten-moss/tenapp/ten_packages/extension/main_python/extension.py
@@ -247,7 +247,7 @@ class MainControlExtension(AsyncExtension):
             else:
                 self._moss_tool_calls += 1
                 grounding = await self._query_moss(query)
-                await self._send_retrieval_note(self._last_grounding, self._last_sdk_ms)
+                await self._send_retrieval_note(grounding, self._last_sdk_ms)
         else:
             self.ten_env.log_error(
                 f"[MainControlExtension] unknown tool_call name={name!r}"
@@ -261,6 +261,10 @@ class MainControlExtension(AsyncExtension):
         await self.ten_env.return_result(result)
 
     async def _query_moss(self, user_text: str) -> str:
+        # Reset per-query state up front so a failed search never replays the
+        # previous hit's grounding/latency in the retrieval note.
+        self._last_grounding = ""
+        self._last_sdk_ms = None
         if self.moss is None:
             return ""
         try:

--- a/apps/ten-moss/tenapp/ten_packages/extension/main_python/extension.py
+++ b/apps/ten-moss/tenapp/ten_packages/extension/main_python/extension.py
@@ -30,6 +30,7 @@ from ten_ai_base.types import LLMToolMetadata, LLMToolMetadataParameter
 import uuid
 
 SEARCH_KNOWLEDGE_BASE = "search_knowledge_base"
+MAX_MOSS_TOOL_CALLS = 2
 
 
 class MainControlExtension(AsyncExtension):
@@ -53,6 +54,8 @@ class MainControlExtension(AsyncExtension):
         self._llm_first_at: float | None = None
         self._last_grounding: str = ""
         self._last_sdk_ms = None
+        self._last_user_text: str = ""
+        self._moss_tool_calls: int = 0
 
     def _current_metadata(self) -> dict:
         return {"session_id": self.session_id, "turn_id": self.turn_id}
@@ -61,7 +64,16 @@ class MainControlExtension(AsyncExtension):
         self.ten_env = ten_env
 
         config_json, _ = await ten_env.get_property_to_json(None)
-        self.config = MainControlConfig.model_validate_json(config_json)
+        try:
+            payload = json.loads(config_json) if config_json else {}
+        except json.JSONDecodeError:
+            payload = {}
+        if payload.get("moss_mode") not in (None, "", "ambient", "tool"):
+            ten_env.log_error(
+                f"[MainControlExtension] unknown moss_mode={payload.get('moss_mode')!r}; using ambient"
+            )
+            payload["moss_mode"] = "ambient"
+        self.config = MainControlConfig.model_validate(payload)
 
         self.moss = None
         if self.config.enable_moss and self.config.moss_index_name:
@@ -120,6 +132,8 @@ class MainControlExtension(AsyncExtension):
             self._retrieval_ms = None
             self._last_grounding = ""
             self._last_sdk_ms = None
+            self._last_user_text = event.text
+            self._moss_tool_calls = 0
             llm_input = event.text
             if self.moss is not None and self.config.moss_mode != "tool":
                 context = await self._query_moss(event.text)
@@ -215,14 +229,23 @@ class MainControlExtension(AsyncExtension):
             try:
                 arguments = json.loads(arguments)
             except json.JSONDecodeError:
-                arguments = {"query": arguments}
+                arguments = {}
         query = ""
         if isinstance(arguments, dict):
             query = str(arguments.get("query") or "")
+        if not query:
+            query = self._last_user_text
 
         grounding = ""
         if name == SEARCH_KNOWLEDGE_BASE:
-            grounding = await self._query_moss(query)
+            if self._moss_tool_calls >= MAX_MOSS_TOOL_CALLS:
+                self.ten_env.log_info(
+                    f"[MainControlExtension] search_knowledge_base cap "
+                    f"({MAX_MOSS_TOOL_CALLS}) reached this turn"
+                )
+            else:
+                self._moss_tool_calls += 1
+                grounding = await self._query_moss(query)
             await self._send_retrieval_note(self._last_grounding, self._last_sdk_ms)
         else:
             self.ten_env.log_error(

--- a/apps/ten-moss/tenapp/ten_packages/extension/main_python/extension.py
+++ b/apps/ten-moss/tenapp/ten_packages/extension/main_python/extension.py
@@ -247,7 +247,7 @@ class MainControlExtension(AsyncExtension):
             else:
                 self._moss_tool_calls += 1
                 grounding = await self._query_moss(query)
-            await self._send_retrieval_note(self._last_grounding, self._last_sdk_ms)
+                await self._send_retrieval_note(self._last_grounding, self._last_sdk_ms)
         else:
             self.ten_env.log_error(
                 f"[MainControlExtension] unknown tool_call name={name!r}"

--- a/apps/ten-moss/tenapp/ten_packages/extension/main_python/extension.py
+++ b/apps/ten-moss/tenapp/ten_packages/extension/main_python/extension.py
@@ -68,10 +68,11 @@ class MainControlExtension(AsyncExtension):
             payload = json.loads(config_json) if config_json else {}
         except json.JSONDecodeError:
             payload = {}
-        if payload.get("moss_mode") not in (None, "", "ambient", "tool"):
-            ten_env.log_error(
-                f"[MainControlExtension] unknown moss_mode={payload.get('moss_mode')!r}; using ambient"
-            )
+        if payload.get("moss_mode") not in ("ambient", "tool"):
+            if payload.get("moss_mode") not in (None, ""):
+                ten_env.log_error(
+                    f"[MainControlExtension] unknown moss_mode={payload.get('moss_mode')!r}; using ambient"
+                )
             payload["moss_mode"] = "ambient"
         self.config = MainControlConfig.model_validate(payload)
 

--- a/apps/ten-moss/tenapp/ten_packages/extension/main_python/manifest.json
+++ b/apps/ten-moss/tenapp/ten_packages/extension/main_python/manifest.json
@@ -53,6 +53,9 @@
         },
         "enable_moss": {
           "type": "bool"
+        },
+        "moss_mode": {
+          "type": "string"
         }
       }
     }

--- a/apps/ten-moss/tests/test_graphs.py
+++ b/apps/ten-moss/tests/test_graphs.py
@@ -53,6 +53,9 @@ def test_ambient_prepend_and_tool_handler_are_visible() -> None:
     assert 'if self.config.moss_mode == "tool":' in src
     assert "search_knowledge_base" in src
     assert 'cmd.get_name() == "tool_call"' in src
+    assert "MAX_MOSS_TOOL_CALLS = 2" in src
+    assert 'unknown moss_mode=' in src
+    assert 'payload["moss_mode"] = "ambient"' in src
     assert 'moss_mode: Literal["ambient", "tool"] = "ambient"' in (
         EXTENSION / "config.py"
     ).read_text()

--- a/apps/ten-moss/tests/test_graphs.py
+++ b/apps/ten-moss/tests/test_graphs.py
@@ -1,0 +1,63 @@
+"""Contract tests for the two TEN graphs. No TEN runtime, no Moss creds."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+TENAPP = Path(__file__).resolve().parents[1] / "tenapp"
+EXTENSION = TENAPP / "ten_packages" / "extension" / "main_python"
+PROPERTY = TENAPP / "property.json"
+
+
+@pytest.fixture(scope="module")
+def graphs() -> list[dict]:
+    payload = json.loads(PROPERTY.read_text())
+    return payload["ten"]["predefined_graphs"]
+
+
+def _main_control(graph: dict) -> dict:
+    nodes = graph["graph"]["nodes"]
+    matches = [n for n in nodes if n.get("name") == "main_control"]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def test_default_graph_is_ambient_voice_assistant(graphs: list[dict]) -> None:
+    names = [g["name"] for g in graphs]
+    assert names[0] == "voice_assistant"
+    ambient = graphs[0]
+    assert ambient["auto_start"] is True
+    props = _main_control(ambient)["property"]
+    assert props["enable_moss"] is True
+    assert props.get("moss_mode", "ambient") == "ambient"
+
+
+def test_tool_graph_is_selectable_and_not_default(graphs: list[dict]) -> None:
+    by_name = {g["name"]: g for g in graphs}
+    assert "voice_assistant_tools" in by_name
+    tool = by_name["voice_assistant_tools"]
+    assert tool["auto_start"] is False
+    props = _main_control(tool)["property"]
+    assert props["moss_mode"] == "tool"
+    assert props["enable_moss"] is True
+
+
+def test_ambient_prepend_and_tool_handler_are_visible() -> None:
+    src = (EXTENSION / "extension.py").read_text()
+    assert "query_context" in src
+    assert "[Current User Question]" in src
+    assert "moss_mode_prepends_on_asr" in src
+    assert "search_knowledge_base" in src
+    assert 'cmd.get_name() == "tool_call"' in src
+    # Ambient prepend must stay gated on moss_mode, not deleted.
+    assert "moss_mode_prepends_on_asr" in (EXTENSION / "config.py").read_text()
+
+
+def test_config_helper_skips_prepend_in_tool_mode() -> None:
+    src = (EXTENSION / "config.py").read_text()
+    assert "def moss_mode_prepends_on_asr" in src
+    assert "return moss_mode != MOSS_MODE_TOOL" in src
+    assert 'moss_mode: Literal["ambient", "tool"] = MOSS_MODE_AMBIENT' in src

--- a/apps/ten-moss/tests/test_graphs.py
+++ b/apps/ten-moss/tests/test_graphs.py
@@ -49,15 +49,9 @@ def test_ambient_prepend_and_tool_handler_are_visible() -> None:
     src = (EXTENSION / "extension.py").read_text()
     assert "query_context" in src
     assert "[Current User Question]" in src
-    assert "moss_mode_prepends_on_asr" in src
+    assert 'self.config.moss_mode != "tool"' in src
     assert "search_knowledge_base" in src
     assert 'cmd.get_name() == "tool_call"' in src
-    # Ambient prepend must stay gated on moss_mode, not deleted.
-    assert "moss_mode_prepends_on_asr" in (EXTENSION / "config.py").read_text()
-
-
-def test_config_helper_skips_prepend_in_tool_mode() -> None:
-    src = (EXTENSION / "config.py").read_text()
-    assert "def moss_mode_prepends_on_asr" in src
-    assert "return moss_mode != MOSS_MODE_TOOL" in src
-    assert 'moss_mode: Literal["ambient", "tool"] = MOSS_MODE_AMBIENT' in src
+    assert 'moss_mode: Literal["ambient", "tool"] = "ambient"' in (
+        EXTENSION / "config.py"
+    ).read_text()

--- a/apps/ten-moss/tests/test_graphs.py
+++ b/apps/ten-moss/tests/test_graphs.py
@@ -54,7 +54,7 @@ def test_ambient_prepend_and_tool_handler_are_visible() -> None:
     assert "search_knowledge_base" in src
     assert 'cmd.get_name() == "tool_call"' in src
     assert "MAX_MOSS_TOOL_CALLS = 2" in src
-    assert 'unknown moss_mode=' in src
+    assert 'if payload.get("moss_mode") not in ("ambient", "tool")' in src
     assert 'payload["moss_mode"] = "ambient"' in src
     assert 'moss_mode: Literal["ambient", "tool"] = "ambient"' in (
         EXTENSION / "config.py"

--- a/apps/ten-moss/tests/test_graphs.py
+++ b/apps/ten-moss/tests/test_graphs.py
@@ -50,6 +50,7 @@ def test_ambient_prepend_and_tool_handler_are_visible() -> None:
     assert "query_context" in src
     assert "[Current User Question]" in src
     assert 'self.config.moss_mode != "tool"' in src
+    assert 'if self.config.moss_mode == "tool":' in src
     assert "search_knowledge_base" in src
     assert 'cmd.get_name() == "tool_call"' in src
     assert 'moss_mode: Literal["ambient", "tool"] = "ambient"' in (

--- a/apps/ten-moss/tests/test_retrieval_note.py
+++ b/apps/ten-moss/tests/test_retrieval_note.py
@@ -1,0 +1,168 @@
+"""Regression for the retrieval note after a failed second search in a turn.
+
+extension.py imports the TEN runtime, which is not installed offline, so we load
+just that one file against light stubs and drive its Moss methods directly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+EXTENSION = (
+    Path(__file__).resolve().parents[1]
+    / "tenapp"
+    / "ten_packages"
+    / "extension"
+    / "main_python"
+    / "extension.py"
+)
+
+
+def _load_extension_module():
+    pkg = "main_python"
+
+    def stub(name: str) -> types.ModuleType:
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+        return mod
+
+    runtime = stub("ten_runtime")
+    for symbol in ("AsyncTenEnv", "Cmd", "Data"):
+        setattr(runtime, symbol, type(symbol, (), {}))
+    runtime.AsyncExtension = type(
+        "AsyncExtension", (), {"__init__": lambda self, name: None}
+    )
+    runtime.StatusCode = type("StatusCode", (), {"OK": "ok"})
+
+    class _CmdResult:
+        def __init__(self):
+            self.content = None
+
+        @classmethod
+        def create(cls, _status, _cmd):
+            return cls()
+
+        def set_property_from_json(self, _key, value):
+            self.content = value
+
+    runtime.CmdResult = _CmdResult
+
+    ten_moss = stub("ten_moss")
+    ten_moss.MossSessionManager = type("MossSessionManager", (), {})
+
+    const = stub("ten_ai_base.const")
+    const.CMD_PROPERTY_RESULT = "result"
+    ai_types = stub("ten_ai_base.types")
+    ai_types.LLMToolMetadata = type("LLMToolMetadata", (), {})
+    ai_types.LLMToolMetadataParameter = type("LLMToolMetadataParameter", (), {})
+    ai_base = stub("ten_ai_base")
+    ai_base.const = const
+    ai_base.types = ai_types
+
+    parent = stub(pkg)
+    parent.__path__ = []
+    agent_pkg = stub(f"{pkg}.agent")
+    agent_pkg.__path__ = []
+    decorators = stub(f"{pkg}.agent.decorators")
+    decorators.agent_event_handler = lambda *a, **k: (lambda fn: fn)
+    agent_mod = stub(f"{pkg}.agent.agent")
+    agent_mod.Agent = type("Agent", (), {})
+    events = stub(f"{pkg}.agent.events")
+    for evt in (
+        "ASRResultEvent",
+        "LLMResponseEvent",
+        "ToolRegisterEvent",
+        "UserJoinedEvent",
+        "UserLeftEvent",
+    ):
+        setattr(events, evt, type(evt, (), {}))
+    helper = stub(f"{pkg}.helper")
+    helper._send_cmd = helper._send_data = lambda *a, **k: None
+    helper.parse_sentences = lambda frag, delta: ([], "")
+    config = stub(f"{pkg}.config")
+    config.MainControlConfig = type("MainControlConfig", (), {})
+
+    spec = importlib.util.spec_from_file_location(f"{pkg}.extension", EXTENSION)
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = pkg
+    spec.loader.exec_module(module)
+    return module
+
+
+extension = _load_extension_module()
+
+
+class _RecordingEnv:
+    def __init__(self):
+        self.results = []
+
+    def log_info(self, *_a):
+        pass
+
+    def log_error(self, *_a):
+        pass
+
+    async def return_result(self, result):
+        self.results.append(result)
+
+
+class _FlakyMoss:
+    """Succeeds once, then raises - a second search failing mid-turn."""
+
+    last_time_taken_ms = 12
+
+    def __init__(self):
+        self.calls = 0
+
+    async def query_context(self, _text: str) -> str:
+        self.calls += 1
+        if self.calls == 1:
+            return "Refunds land in 3-5 business days."
+        raise RuntimeError("moss backend unavailable")
+
+
+class _ToolCallCmd:
+    """A tool_call Cmd carrying a search_knowledge_base payload."""
+
+    def __init__(self, query: str):
+        self._raw = json.dumps(
+            {"name": "search_knowledge_base", "arguments": {"query": query}}
+        )
+
+    def get_property_to_json(self, _key):
+        return self._raw, None
+
+
+@pytest.mark.asyncio
+async def test_failed_second_search_does_not_replay_first_hit() -> None:
+    ext = extension.MainControlExtension("main_control")
+    ext.ten_env = _RecordingEnv()
+    ext.moss = _FlakyMoss()
+
+    notes: list[str] = []
+
+    async def capture(role, text, final, stream_id, data_type="text"):
+        notes.append(text)
+
+    ext._send_transcript = capture
+
+    # Drive the real tool-call handler so the note reflects production flow.
+    await ext._on_tool_call(_ToolCallCmd("How long do refunds take?"))
+    assert "3-5 business days" in notes[0]
+    assert "3-5 business days" in ext.ten_env.results[0].content
+
+    await ext._on_tool_call(_ToolCallCmd("What about exchanges?"))
+
+    # Second search failed: the note must not replay the first hit, and the
+    # tool result is empty - the two must agree.
+    assert "3-5 business days" not in notes[1]
+    assert "no match" in notes[1]
+    assert '"content": ""' in ext.ten_env.results[1].content
+    assert ext._last_grounding == ""
+    assert ext._last_sdk_ms is None


### PR DESCRIPTION
## Intent

PR #507 adds Agora/TEN Moss integration samples: (1) TEN tool-call graph voice_assistant_tools alongside the ambient voice_assistant default, where main_control self-registers search_knowledge_base and handles tool_call in-process via MossSessionManager; (2) an offline bench under apps/ten-moss/bench (ambient/tool-call/no-Moss arms, --echo-grounding zero-LLM smoke); (3) a custom-llm middleware app apps/agora-custom-llm-moss forked from Agora's recipe with ambient and tool modes over the same 10-FAQ corpus, Bearer auth, and a zero-key doctor path. Samples are meant to be stranger-copyable.

This run validates the fix commit on top of that PR, which closes three post-review threads:
- TEN stale retrieval note: _query_moss() returned '' on exception but left _last_grounding/_last_sdk_ms from a prior successful search, so a failed second search in the same turn replayed the earlier hit in the retrieval note while the tool result was empty. Fix: reset _last_grounding/_last_sdk_ms at the top of _query_moss before touching the backend, and have _on_tool_call send the note the grounding it just received. Regression in apps/ten-moss/tests/test_retrieval_note.py drives _on_tool_call through a success then a failure and asserts the second note reads 'no match'.
- Custom-llm doctor env leak: run_doctor() is called in-process by tests; it flipped MOCK to '1' then '0' and never restored it (and did not fully own CUSTOM_LLM_API_KEY restoration). Fix: snapshot MOCK and CUSTOM_LLM_API_KEY before the first create_app() and restore both in an outer finally, including the 'was absent' case; the temporary key removal for the unset-key request stays separate. Regressions assert both preset and originally-absent vars are restored.

Scope is intentionally limited to these three threads; no behavior changes beyond them. Do not merge.

## What Changed

- Added a TEN tool-call graph (`voice_assistant_tools`) beside the ambient `voice_assistant` default, where `main_control` self-registers `search_knowledge_base` and handles `tool_call` in-process via `MossSessionManager`; opened Moss on the first custom-llm request, treated blank `moss_mode` as ambient, and reset `_last_grounding`/`_last_sdk_ms` at the top of `_query_moss` so a failed second search no longer replays a prior hit in the retrieval note.
- Added an offline bench under `apps/ten-moss/bench` (ambient / tool-call / no-Moss arms with an `--echo-grounding` zero-LLM smoke path) plus graph and retrieval-note regression tests.
- Added the `apps/agora-custom-llm-moss` middleware app forked from Agora's custom-llm recipe with ambient and tool modes over the shared 10-FAQ corpus, Bearer auth, `.env` loading, and a zero-key doctor path that snapshots and restores `MOCK`/`CUSTOM_LLM_API_KEY`; wired CI and refreshed the README/AGENTS docs.

## Risk Assessment

✅ Low: The fix commit is tightly scoped to the three declared post-review threads, each fix is correct and backed by a targeted regression test, and no defects, regressions, or intent contradictions were found across the changed source.

## Testing

`Ran the two regression suites on the target commit (all 12 ten-moss and 14 custom-llm tests pass) after building a fresh venv with fastapi/httpx/pydantic/pytest-asyncio. To prove the regressions actually guard the fixed bugs, I reverted each source fix to its pre-fix version (da1e5ba) and confirmed the tests fail with the exact described symptoms (retrieval note replaying the prior "3-5 business days" hit; doctor leaking MOCK='0'), then restored. I also captured two product-level CLI transcripts as reviewer evidence: the TEN retrieval-note transcript shows turn 1 (Moss hit) vs turn 2 (failed second search -> "no match" note with empty tool result, no replay), and the doctor transcript shows both modes + bearer checks running and MOCK/CUSTOM_LLM_API_KEY restored to their preset values afterward. These are CLI/API surfaces with no rendered UI, so text transcripts are the appropriate end-user artifact. Worktree cleaned of pytest/__pycache__ artifacts; evidence left in the dedicated directory.`

<details>
<summary>Evidence: TEN retrieval-note fix: turn 1 hit vs turn 2 failed search (no stale replay)</summary>

<code>=== TURN 1 (Moss hit) ===&#10;retrieval note : &#39;🔎 Moss · retrieved in 12 ms (SDK time_taken_ms)\n\nRefunds land in 3-5 business days.&#39;&#10;tool result : {&#34;type&#34;: &#34;llmresult&#34;, &#34;content&#34;: &#34;Refunds land in 3-5 business days.&#34;}&#10;&#10;=== TURN 2 (second search FAILS mid-turn) ===&#10;retrieval note : &#39;🔎 Moss · retrieved in n/a ms (SDK time_taken_ms) — no match&#39;&#10;tool result : {&#34;type&#34;: &#34;llmresult&#34;, &#34;content&#34;: &#34;&#34;}&#10;&#10;replays first hit in note? False (must be False)&#10;note says no match? True (must be True)&#10;note &amp; tool result agree? True (empty result, must be True)</code>

```text
=== TURN 1 (Moss hit) ===
retrieval note : '🔎 Moss · retrieved in 12 ms (SDK time_taken_ms)\n\nRefunds land in 3-5 business days.'
tool result    : {"type": "llmresult", "content": "Refunds land in 3-5 business days."}

=== TURN 2 (second search FAILS mid-turn) ===
retrieval note : '🔎 Moss · retrieved in n/a ms (SDK time_taken_ms) — no match'
tool result    : {"type": "llmresult", "content": ""}

replays first hit in note?  False (must be False)
note says no match?         True (must be True)
note & tool result agree?   True (empty result, must be True)
```
</details>
<details>
<summary>Evidence: custom-llm --doctor: both modes + bearer checks pass, preset env restored (no leak)</summary>

<code>BEFORE MOCK=&#39;preset&#39; CUSTOM_LLM_API_KEY=&#39;preset-key&#39;&#10;doctor ambient: ok&#10;doctor tool: ok&#10;doctor bearer: rejected missing Authorization&#10;doctor bearer: rejected any token while CUSTOM_LLM_API_KEY is unset&#10;doctor: ok&#10;AFTER MOCK=&#39;preset&#39; CUSTOM_LLM_API_KEY=&#39;preset-key&#39;&#10;ENV RESTORED: no leak</code>

```text
/tmp/nm-venv-3b0/lib/python3.12/site-packages/fastapi/testclient.py:1: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
  from starlette.testclient import TestClient as TestClient  # noqa
INFO:llm:Moss disabled (set MOSS_PROJECT_ID / MOSS_PROJECT_KEY / MOSS_INDEX_NAME)
INFO:httpx:HTTP Request: POST http://testserver/chat/completions "HTTP/1.1 200 OK"
INFO:llm:Moss disabled (set MOSS_PROJECT_ID / MOSS_PROJECT_KEY / MOSS_INDEX_NAME)
INFO:llm:[retrieval-latency] tool_called=true (mock stub)
INFO:httpx:HTTP Request: POST http://testserver/chat/completions "HTTP/1.1 200 OK"
INFO:llm:Moss disabled (set MOSS_PROJECT_ID / MOSS_PROJECT_KEY / MOSS_INDEX_NAME)
INFO:httpx:HTTP Request: POST http://testserver/chat/completions "HTTP/1.1 401 Unauthorized"
INFO:llm:Moss disabled (set MOSS_PROJECT_ID / MOSS_PROJECT_KEY / MOSS_INDEX_NAME)
INFO:httpx:HTTP Request: POST http://testserver/chat/completions "HTTP/1.1 401 Unauthorized"
BEFORE  MOCK='preset'  CUSTOM_LLM_API_KEY='preset-key'
doctor ambient: ok
doctor tool: ok
doctor bearer: rejected missing Authorization
doctor bearer: rejected any token while CUSTOM_LLM_API_KEY is unset
doctor: ok
AFTER   MOCK='preset'  CUSTOM_LLM_API_KEY='preset-key'
ENV RESTORED: no leak
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pytest apps/ten-moss/tests/test_retrieval_note.py` (pass on target)</code>
- <code>`pytest apps/ten-moss` full suite - 12 passed (tests + bench)</code>
- <code>`pytest apps/agora-custom-llm-moss/tests/test_llm.py` - 14 passed incl. test_doctor_restores_preset_env / test_doctor_restores_absent_env</code>
- <code>Bug-guard proof: `git checkout da1e5ba -- extension.py` then ran retrieval-note test -&gt; FAILED replaying first hit; restored</code>
- <code>Bug-guard proof: `git checkout da1e5ba -- llm.py` then ran env-restore tests -&gt; 2 FAILED (MOCK left as &#39;0&#39;); restored</code>
- <code>Manual E2E: drove `MainControlExtension._on_tool_call` through success-then-failure, captured both retrieval notes and tool results</code>
- <code>Manual E2E: ran `run_doctor()` under preset MOCK=preset/CUSTOM_LLM_API_KEY=preset-key and asserted both restored afterward</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
