### PR TITLE
fix(python-sdk): align cloud query fallback default top_k with local queries

### DIFF
--- a/sdks/python/sdk/CHANGELOG.md
+++ b/sdks/python/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Cloud query fallback now uses the same default `top_k=5` as local queries (and the TypeScript SDK). Previously `query()` without `load_index()` silently requested 10 results, so local vs cloud result counts diverged.
+
 ## [1.0.0] - 2026-03-29
 
 First stable release of the `moss` Python SDK (previously published as `inferedge-moss`).

--- a/sdks/python/sdk/src/moss/client/moss_client.py
+++ b/sdks/python/sdk/src/moss/client/moss_client.py
@@ -9,14 +9,14 @@ from typing import Any, Dict, List, Optional
 import httpx
 from moss_core import (
     CLOUD_API_MANAGE_URL,
-    ManageClient,
     DocumentInfo,
     GetDocumentsOptions,
     IndexInfo,
     IndexManager,
+    JobStatusResponse,
+    ManageClient,
     MutationOptions,
     MutationResult,
-    JobStatusResponse,
     QueryOptions,
     QueryResultDocumentInfo,
     SearchResult,
@@ -61,6 +61,8 @@ class MossClient:
     """
 
     DEFAULT_MODEL_ID = "moss-minilm"
+    DEFAULT_TOP_K = 5
+    DEFAULT_ALPHA = 0.8
 
     def __init__(self, project_id: str, project_key: str) -> None:
         self._project_id = project_id
@@ -188,6 +190,9 @@ class MossClient:
         If the index is loaded locally (via load_index), queries run in-memory.
         Otherwise, falls back to the cloud query API.
 
+        Default ``top_k`` is 5 on both the local and cloud paths so result
+        cardinality stays consistent whether or not ``load_index()`` was called.
+
         Args:
             options: Query options (top_k, alpha, embedding, filter). Example filter:
                 QueryOptions(filter={"$and": [
@@ -218,10 +223,10 @@ class MossClient:
     ) -> SearchResult:
         top_k = getattr(options, "top_k", None)
         if top_k is None:
-            top_k = 5
+            top_k = self.DEFAULT_TOP_K
         alpha = getattr(options, "alpha", None)
         if alpha is None:
-            alpha = 0.8
+            alpha = self.DEFAULT_ALPHA
         query_embedding = getattr(options, "embedding", None)
         filter = getattr(options, "filter", None)
 
@@ -260,7 +265,9 @@ class MossClient:
         options: Optional[QueryOptions],
     ) -> SearchResult:
         """Fallback: query via the cloud API when the index is not loaded locally."""
-        top_k = getattr(options, "top_k", None) or 10
+        top_k = getattr(options, "top_k", None)
+        if top_k is None:
+            top_k = self.DEFAULT_TOP_K
         query_embedding = getattr(options, "embedding", None)
 
         request_body: Dict[str, Any] = {

--- a/sdks/python/sdk/tests/test_client.py
+++ b/sdks/python/sdk/tests/test_client.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from moss import MossClient
+from moss import MossClient, QueryOptions
 
 
 @pytest.fixture
@@ -549,6 +549,68 @@ class TestQueryCloudFallback:
             url = call_args[0][0]
             assert "/query" in url
             assert "/manage" not in url
+
+    @pytest.mark.asyncio
+    async def test_cloud_fallback_defaults_top_k_to_five(self, unloaded_client):
+        """Cloud fallback must use the same default top_k as local queries."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {"docs": [], "query": "q"}
+
+        with patch("moss.client.moss_client.httpx.AsyncClient") as mock_httpx:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.post = AsyncMock(return_value=mock_response)
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client_instance
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await unloaded_client.query("idx", "q")
+
+            body = mock_client_instance.post.call_args.kwargs["json"]
+            assert body["topK"] == MossClient.DEFAULT_TOP_K
+            assert body["topK"] == 5
+
+    @pytest.mark.asyncio
+    async def test_cloud_fallback_defaults_top_k_when_options_top_k_is_none(
+        self, unloaded_client
+    ):
+        """QueryOptions() leaves top_k unset; must not fall through to the old `or 10` default."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {"docs": [], "query": "q"}
+
+        with patch("moss.client.moss_client.httpx.AsyncClient") as mock_httpx:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.post = AsyncMock(return_value=mock_response)
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client_instance
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await unloaded_client.query("idx", "q", QueryOptions())
+
+            body = mock_client_instance.post.call_args.kwargs["json"]
+            assert body["topK"] == MossClient.DEFAULT_TOP_K
+
+    @pytest.mark.asyncio
+    async def test_cloud_fallback_respects_explicit_top_k(self, unloaded_client):
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {"docs": [], "query": "q"}
+
+        with patch("moss.client.moss_client.httpx.AsyncClient") as mock_httpx:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.post = AsyncMock(return_value=mock_response)
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client_instance
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await unloaded_client.query("idx", "q", QueryOptions(top_k=10))
+
+            body = mock_client_instance.post.call_args.kwargs["json"]
+            assert body["topK"] == 10
 
     @pytest.mark.asyncio
     async def test_uses_local_when_index_loaded(self, client):


### PR DESCRIPTION
## Summary
- Python `query()` without `load_index()` was requesting `topK=10` from the cloud API, while local in-memory queries (and the TypeScript SDK) default to `top_k=5`.
- Root cause: `_query_cloud()` used `getattr(options, "top_k", None) or 10`. That both picked the wrong default and treated an explicit `None` as falsy, so `QueryOptions()` also sent 10.
- Both paths now share `MossClient.DEFAULT_TOP_K = 5` via an `is None` check, so result cardinality stays consistent whether or not the index is loaded.

## Test plan
- [x] `pytest tests/test_client.py tests/test_client_extended.py tests/test_types.py` — 89 passed
- [x] `pytest tests/` — 89 passed, 44 skipped (cloud/E2E, no credentials)
- [x] New unit tests assert the cloud request body:
  - omitted options → `topK=5`
  - `QueryOptions()` (`top_k=None`) → `topK=5` (guards the old `or 10` path)
  - `QueryOptions(top_k=10)` → `topK=10`

## Reproduction (before)
```python
# index not loaded
await client.query("my-index", "refunds")
# cloud request body had topK=10

await client.load_index("my-index")
await client.query("my-index", "refunds")
# local query used top_k=5
```

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/usemoss/moss/pull/514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cloud queries now return 5 results by default, matching local query behavior.
  - Explicit result limits continue to be respected.
  - Query behavior is now consistent when no local index is loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->