### PR TITLE
fix(cli): restore shell completion script generation

### DIFF
--- a/packages/moss-cli/src/moss_cli/commands/completions.py
+++ b/packages/moss-cli/src/moss_cli/commands/completions.py
@@ -9,6 +9,7 @@ import typer
 from .. import output
 
 PROG_NAME = "moss"
+_UNAVAILABLE = "Shell completion is unavailable in this Typer installation."
 
 
 class Shell(str, Enum):
@@ -43,18 +44,15 @@ def completions_command(
         from typer.main import get_completion_script  # type: ignore[attr-defined]
     except Exception:  # pragma: no cover
         try:
-            from typer._completion_shared import get_completion_script  # type: ignore
-        except Exception:  # pragma: no cover - depends on Typer installation
-            output.print_error(
-                "Shell completion is unavailable in this Typer installation.",
-                json_mode,
-            )
-            raise typer.Exit(1)
-        output.print_error(
-            "Shell completion is unavailable in this Typer installation.",
-            json_mode,
-        )
-        raise typer.Exit(1)
+            from typer.completion import get_completion_script  # type: ignore
+        except Exception:  # pragma: no cover
+            try:
+                from typer._completion_shared import (  # type: ignore
+                    get_completion_script,
+                )
+            except Exception:  # pragma: no cover
+                output.print_error(_UNAVAILABLE, json_mode)
+                raise typer.Exit(1)
 
     complete_var = "_{}_COMPLETE".format(PROG_NAME.replace("-", "_").upper())
     script = get_completion_script(


### PR DESCRIPTION
## Problem

`moss completions bash` and `moss completions zsh` always fail on a healthy install:

```console
$ moss completions bash
Shell completion is unavailable in this Typer installation.
$ echo $?
1
```

The two existing tests in `tests/test_completions.py` fail on `main` for this reason (`28 passed, 2 failed`).

## Root cause

Two separate defects in `packages/moss-cli/src/moss_cli/commands/completions.py`:

**1. The working import path was never tried.** The fallback chain attempts `typer.main.get_completion_script`, then `typer._completion_shared.get_completion_script`. Neither resolves on current Typer — but `typer.completion.get_completion_script` does, with an identical signature:

```python
>>> from typer.completion import get_completion_script
>>> inspect.signature(get_completion_script)
(*, prog_name: str, complete_var: str, shell: str) -> str
```

**2. The fallback could not succeed even if the import worked.** After the inner `except`, control fell through to an unconditional `print_error(...)` / `raise typer.Exit(1)`, so a successful `typer._completion_shared` import would still have errored out.

## Fix

- Add `typer.completion` to the import chain.
- Nest the handlers so the failure message is raised only once every path is exhausted.
- Lift the message to a module constant instead of duplicating the string.

## Verification

| | before | after |
|---|---|---|
| `pytest tests/` | 28 passed, 2 failed | **30 passed** |
| `black --check` | — | clean |
| `isort --check-only` | — | clean |
| `mypy` | — | clean |
| flake8 `E501` in this file | 2 | 1 |

`moss completions bash` now emits a valid script:

```console
$ moss completions bash
_moss_completion() {
    local IFS=$'\n'
    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
                   COMP_CWORD=$COMP_CWORD \
                   _MOSS_COMPLETE=complete_bash $1 ) )
```

## Relationship to #404

#404 includes a shell-completion fix among other changes. This PR is a targeted alternative to just that portion — one file, +10/−12, no lockfile churn — since #404 currently reports conflicts. Happy to close this if #404 lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJrKvKssS5wMSUEU5ePWuw


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/usemoss/moss/pull/515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shell completion setup across supported CLI environments.
  - Increased compatibility with different completion support configurations.
  - Added a clear error message when completion generation is unavailable.
  - The CLI now exits with a failure status when completion scripts cannot be generated, making setup issues easier to identify.
  - Existing completion behavior remains available across environments using different supported completion mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->